### PR TITLE
プランに含まれる場所を削除できるようにする

### DIFF
--- a/src/pages/plans/select/[sessionId]/[planId]/edit.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/edit.tsx
@@ -1,8 +1,8 @@
 import { Link } from "@chakra-ui/next-js";
-import { Button, Center, Icon, VStack } from "@chakra-ui/react";
+import { Button, Center, HStack, Icon, VStack } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
-import { MdAdd } from "react-icons/md";
+import { MdAdd, MdDeleteOutline } from "react-icons/md";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import {
     fetchCachedCreatedPlans,
@@ -18,12 +18,14 @@ import { Colors } from "src/view/constants/color";
 import { Routes } from "src/view/constants/router";
 import { useLocation } from "src/view/hooks/useLocation";
 import { usePlanPlaceAdd } from "src/view/hooks/usePlanPlaceAdd";
+import { usePlanPlaceDelete } from "src/view/hooks/usePlanPlaceDelete";
 import { usePlanPlaceReplace } from "src/view/hooks/usePlanPlaceReplace";
 import { SearchRouteByGoogleMapButton } from "src/view/plan/button/SearchRouteByGoogleMapButton";
 import { PlaceMap } from "src/view/plan/PlaceMap";
 import { FooterHeight, PlanFooter } from "src/view/plan/PlanFooter";
 import { PlanPageSection } from "src/view/plan/section/PlanPageSection";
 import { DialogAddPlace } from "src/view/plancandidate/DialogAddPlace";
+import { DialogDeletePlace } from "src/view/plancandidate/DialogDeletePlace";
 import { DialogReplacePlace } from "src/view/plancandidate/DialogReplacePlace";
 import { EditPlanCandidatePlaceListItem } from "src/view/plancandidate/EditPlanCandidatePlaceListItem";
 
@@ -55,6 +57,18 @@ const PlanEdit = () => {
         placesToAdd,
         isAddingPlace,
     } = usePlanPlaceAdd({
+        planCandidateId: sessionId as string,
+        planId: planId as string,
+    });
+
+    const {
+        deletePlaceFromPlan,
+        showDialogToDelete,
+        closeDialogToDelete,
+        isDialogToDeletePlaceVisible,
+        isDeletingPlace,
+        placeToDelete,
+    } = usePlanPlaceDelete({
         planCandidateId: sessionId as string,
         planId: planId as string,
     });
@@ -118,12 +132,31 @@ const PlanEdit = () => {
                         <VStack spacing="16px">
                             {plan.places.map((place, i) => (
                                 <VStack key={place.id} w="100%" spacing="16px">
-                                    <EditPlanCandidatePlaceListItem
-                                        place={place}
-                                        onClickShowRelatedPlaces={
-                                            showRelatedPlaces
+                                    <HStack w="100%">
+                                        <EditPlanCandidatePlaceListItem
+                                            place={place}
+                                            onClickShowRelatedPlaces={
+                                                showRelatedPlaces
+                                            }
+                                        />
+                                        {
+                                            // プランには最低1つの場所が必要
+                                            plan.places.length > 1 && (
+                                                <Icon
+                                                    as={MdDeleteOutline}
+                                                    w="24px"
+                                                    h="24px"
+                                                    color="rgba(0,0,0,.6)"
+                                                    onClick={() =>
+                                                        showDialogToDelete({
+                                                            placeIdToDelete:
+                                                                place.id,
+                                                        })
+                                                    }
+                                                />
+                                            )
                                         }
-                                    />
+                                    </HStack>
                                     <AddPlaceButton
                                         onClick={() =>
                                             showPlacesToAdd({
@@ -176,6 +209,13 @@ const PlanEdit = () => {
                     })
                 }
                 onCloseDialog={onCloseDialogToAddPlace}
+            />
+            <DialogDeletePlace
+                placeToDelete={placeToDelete}
+                isDialogVisible={isDialogToDeletePlaceVisible}
+                isDeleting={isDeletingPlace}
+                onDelete={deletePlaceFromPlan}
+                onClose={closeDialogToDelete}
             />
             {/*Footer*/}
             <PlanFooter>

--- a/src/redux/editPlanCandidate.ts
+++ b/src/redux/editPlanCandidate.ts
@@ -20,6 +20,7 @@ export type EditPlanCandidateState = {
     placesToAdd: Place[] | null;
     requestStatusFetchPlacesToAdd: RequestStatus | null;
     requestStatusAddPlaceToPlanCandidate: RequestStatus | null;
+    requestStatusDeletePlaceFromPlanOfPlanCandidate: RequestStatus | null;
 };
 
 const initialState: EditPlanCandidateState = {
@@ -30,6 +31,7 @@ const initialState: EditPlanCandidateState = {
     placesToAdd: null,
     requestStatusFetchPlacesToAdd: null,
     requestStatusAddPlaceToPlanCandidate: null,
+    requestStatusDeletePlaceFromPlanOfPlanCandidate: null,
 };
 
 type FetchPlacesToReplaceProps = {
@@ -150,6 +152,40 @@ export const addPlaceToPlanOfPlanCandidate = createAsyncThunk(
     }
 );
 
+type DeletePlaceFromPlanOfPlanCandidateProps = {
+    planCandidateId: string;
+    planId: string;
+    placeId: string;
+};
+export const deletePlaceFromPlanOfPlanCandidate = createAsyncThunk(
+    "editPlanCandidate/deletePlaceFromPlanOfPlanCandidate",
+    async (
+        {
+            planCandidateId,
+            planId,
+            placeId,
+        }: DeletePlaceFromPlanOfPlanCandidateProps,
+        { dispatch }
+    ) => {
+        const plannerApi: PlannerApi = new PlannerGraphQlApi();
+        const { plan } = await plannerApi.deletePlaceFromPlanOfPlanCandidate({
+            planCandidateId,
+            planId,
+            placeId,
+        });
+
+        dispatch(
+            updatePlanOfPlanCandidate({
+                plan: createPlanFromPlanEntity(plan, null),
+            })
+        );
+
+        return {
+            plan: createPlanFromPlanEntity(plan, null),
+        };
+    }
+);
+
 export const slice = createSlice({
     name: "editPlanCandidate",
     initialState,
@@ -237,6 +273,19 @@ export const slice = createSlice({
                 state.requestStatusAddPlaceToPlanCandidate =
                     RequestStatuses.REJECTED;
                 state.placesToAdd = null;
+            })
+            // Delete Place From Plan Of Plan Candidate
+            .addCase(deletePlaceFromPlanOfPlanCandidate.pending, (state) => {
+                state.requestStatusDeletePlaceFromPlanOfPlanCandidate =
+                    RequestStatuses.PENDING;
+            })
+            .addCase(deletePlaceFromPlanOfPlanCandidate.fulfilled, (state) => {
+                state.requestStatusDeletePlaceFromPlanOfPlanCandidate =
+                    RequestStatuses.FULFILLED;
+            })
+            .addCase(deletePlaceFromPlanOfPlanCandidate.rejected, (state) => {
+                state.requestStatusDeletePlaceFromPlanOfPlanCandidate =
+                    RequestStatuses.REJECTED;
             });
     },
 });

--- a/src/stories/mock/place.ts
+++ b/src/stories/mock/place.ts
@@ -1,155 +1,161 @@
 import { Place } from "src/domain/models/Place";
 import { PlaceCategoryTypes } from "src/domain/models/PlaceCategory";
 
-export const mockPlaces: { [key: string]: Place } = {
-    bookStore: {
-        id: "bookStore",
-        googlePlaceId: "poroto_book_store",
-        name: "poroto書店",
-        images: [
-            {
-                default: "https://picsum.photos/300/400",
-                small: "https://picsum.photos/300/400",
-                large: "https://picsum.photos/300/400",
-            },
-            {
-                default: "https://picsum.photos/1280/720",
-                small: "https://picsum.photos/1280/720",
-                large: "https://picsum.photos/1280/720",
-            },
-            {
-                default: "https://picsum.photos/400/600",
-                small: "https://picsum.photos/400/600",
-                large: "https://picsum.photos/400/600",
-            },
-            {
-                default: "https://picsum.photos/400/600",
-                small: "https://picsum.photos/400/600",
-                large: "https://picsum.photos/400/600",
-            },
-            {
-                default: "https://picsum.photos/300/400",
-                small: "https://picsum.photos/300/400",
-                large: "https://picsum.photos/300/400",
-            },
-            {
-                default: "https://picsum.photos/1280/720",
-                small: "https://picsum.photos/1280/720",
-                large: "https://picsum.photos/1280/720",
-            },
-            {
-                default: "https://picsum.photos/400/600",
-                small: "https://picsum.photos/400/600",
-                large: "https://picsum.photos/400/600",
-            },
-        ],
-        estimatedStayDuration: 60,
-        location: {
-            latitude: 35.681616,
-            longitude: 139.764954,
+const bookStore: Place = {
+    id: "bookStore",
+    googlePlaceId: "poroto_book_store",
+    name: "poroto書店",
+    images: [
+        {
+            default: "https://picsum.photos/300/400",
+            small: "https://picsum.photos/300/400",
+            large: "https://picsum.photos/300/400",
         },
-        googlePlaceReviews: [
-            {
-                rating: 4.5,
-                text: "とてもきれいな書店です。",
-                authorName: "山田太郎",
-                authorUrl: "https://example.com",
-                authorPhotoUrl: "https://picsum.photos/200/300",
-                timeInMilliSec: 1600000000000,
-            },
-            {
-                rating: 3.5,
-                text: "混雑しています。",
-                authorName: "鈴木二郎",
-                authorUrl: "https://example.com",
-                authorPhotoUrl: "https://picsum.photos/200/300",
-                timeInMilliSec: 1600000000000,
-            },
-        ],
-        categories: [{ id: PlaceCategoryTypes.BookStores }],
-    },
-    tokyo: {
-        id: "tokyo",
-        googlePlaceId: "tokyo_station",
-        name: "東京駅",
-        images: [
-            {
-                default: "https://picsum.photos/300/400",
-                small: "https://picsum.photos/300/400",
-                large: "https://picsum.photos/300/400",
-            },
-            {
-                default: "https://picsum.photos/1280/720",
-                small: "https://picsum.photos/1280/720",
-                large: "https://picsum.photos/1280/720",
-            },
-            {
-                default: "https://picsum.photos/400/600",
-                small: "https://picsum.photos/400/600",
-                large: "https://picsum.photos/400/600",
-            },
-            {
-                default: "https://picsum.photos/400/650",
-                small: "https://picsum.photos/400/650",
-                large: "https://picsum.photos/400/650",
-            },
-        ],
-        location: {
-            latitude: 35.6809591,
-            longitude: 139.7673068,
+        {
+            default: "https://picsum.photos/1280/720",
+            small: "https://picsum.photos/1280/720",
+            large: "https://picsum.photos/1280/720",
         },
-        estimatedStayDuration: 60,
-        googlePlaceReviews: [
-            {
-                rating: 4.5,
-                text: "とてもきれいな駅です。",
-                authorName: "山田太郎",
-                authorUrl: "https://example.com",
-                authorPhotoUrl: "https://picsum.photos/200/300",
-                timeInMilliSec: 1600000000000,
-            },
-            {
-                rating: 3.5,
-                text: "混雑しています。",
-                authorName: "鈴木二郎",
-                authorUrl: "https://example.com",
-                authorPhotoUrl: "https://picsum.photos/200/300",
-                timeInMilliSec: 1600000000000,
-            },
-        ],
-        categories: [],
-    },
-    marunouchi: {
-        id: "marunouchi",
-        googlePlaceId: "marunouchi_station",
-        name: "東京駅丸の内駅前広場",
-        images: [
-            {
-                default: "https://picsum.photos/400/400",
-                small: "https://picsum.photos/400/400",
-                large: "https://picsum.photos/400/400",
-            },
-            {
-                default: "https://picsum.photos/1280/700",
-                small: "https://picsum.photos/1280/700",
-                large: "https://picsum.photos/1280/700",
-            },
-            {
-                default: "https://picsum.photos/400/500",
-                small: "https://picsum.photos/400/500",
-                large: "https://picsum.photos/400/500",
-            },
-            {
-                default: "https://picsum.photos/450/600",
-                small: "https://picsum.photos/450/600",
-                large: "https://picsum.photos/450/600",
-            },
-        ],
-        location: {
-            latitude: 35.681616,
-            longitude: 139.764954,
+        {
+            default: "https://picsum.photos/400/600",
+            small: "https://picsum.photos/400/600",
+            large: "https://picsum.photos/400/600",
         },
-        estimatedStayDuration: 60,
-        categories: [{ id: PlaceCategoryTypes.Park }],
+        {
+            default: "https://picsum.photos/400/600",
+            small: "https://picsum.photos/400/600",
+            large: "https://picsum.photos/400/600",
+        },
+        {
+            default: "https://picsum.photos/300/400",
+            small: "https://picsum.photos/300/400",
+            large: "https://picsum.photos/300/400",
+        },
+        {
+            default: "https://picsum.photos/1280/720",
+            small: "https://picsum.photos/1280/720",
+            large: "https://picsum.photos/1280/720",
+        },
+        {
+            default: "https://picsum.photos/400/600",
+            small: "https://picsum.photos/400/600",
+            large: "https://picsum.photos/400/600",
+        },
+    ],
+    estimatedStayDuration: 60,
+    location: {
+        latitude: 35.681616,
+        longitude: 139.764954,
     },
+    googlePlaceReviews: [
+        {
+            rating: 4.5,
+            text: "とてもきれいな書店です。",
+            authorName: "山田太郎",
+            authorUrl: "https://example.com",
+            authorPhotoUrl: "https://picsum.photos/200/300",
+            timeInMilliSec: 1600000000000,
+        },
+        {
+            rating: 3.5,
+            text: "混雑しています。",
+            authorName: "鈴木二郎",
+            authorUrl: "https://example.com",
+            authorPhotoUrl: "https://picsum.photos/200/300",
+            timeInMilliSec: 1600000000000,
+        },
+    ],
+    categories: [{ id: PlaceCategoryTypes.BookStores }],
+};
+
+const tokyo: Place = {
+    id: "tokyo",
+    googlePlaceId: "tokyo_station",
+    name: "東京駅",
+    images: [
+        {
+            default: "https://picsum.photos/300/400",
+            small: "https://picsum.photos/300/400",
+            large: "https://picsum.photos/300/400",
+        },
+        {
+            default: "https://picsum.photos/1280/720",
+            small: "https://picsum.photos/1280/720",
+            large: "https://picsum.photos/1280/720",
+        },
+        {
+            default: "https://picsum.photos/400/600",
+            small: "https://picsum.photos/400/600",
+            large: "https://picsum.photos/400/600",
+        },
+        {
+            default: "https://picsum.photos/400/650",
+            small: "https://picsum.photos/400/650",
+            large: "https://picsum.photos/400/650",
+        },
+    ],
+    location: {
+        latitude: 35.6809591,
+        longitude: 139.7673068,
+    },
+    estimatedStayDuration: 60,
+    googlePlaceReviews: [
+        {
+            rating: 4.5,
+            text: "とてもきれいな駅です。",
+            authorName: "山田太郎",
+            authorUrl: "https://example.com",
+            authorPhotoUrl: "https://picsum.photos/200/300",
+            timeInMilliSec: 1600000000000,
+        },
+        {
+            rating: 3.5,
+            text: "混雑しています。",
+            authorName: "鈴木二郎",
+            authorUrl: "https://example.com",
+            authorPhotoUrl: "https://picsum.photos/200/300",
+            timeInMilliSec: 1600000000000,
+        },
+    ],
+    categories: [],
+};
+
+const marunouchi: Place = {
+    id: "marunouchi",
+    googlePlaceId: "marunouchi_station",
+    name: "東京駅丸の内駅前広場",
+    images: [
+        {
+            default: "https://picsum.photos/400/400",
+            small: "https://picsum.photos/400/400",
+            large: "https://picsum.photos/400/400",
+        },
+        {
+            default: "https://picsum.photos/1280/700",
+            small: "https://picsum.photos/1280/700",
+            large: "https://picsum.photos/1280/700",
+        },
+        {
+            default: "https://picsum.photos/400/500",
+            small: "https://picsum.photos/400/500",
+            large: "https://picsum.photos/400/500",
+        },
+        {
+            default: "https://picsum.photos/450/600",
+            small: "https://picsum.photos/450/600",
+            large: "https://picsum.photos/450/600",
+        },
+    ],
+    location: {
+        latitude: 35.681616,
+        longitude: 139.764954,
+    },
+    estimatedStayDuration: 60,
+    categories: [{ id: PlaceCategoryTypes.Park }],
+};
+
+export const mockPlaces = {
+    bookStore,
+    tokyo,
+    marunouchi,
 };

--- a/src/stories/plancandidate/DialogDeletePlace.stories.tsx
+++ b/src/stories/plancandidate/DialogDeletePlace.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { mockPlaces } from "src/stories/mock/place";
+import { DialogDeletePlace } from "src/view/plancandidate/DialogDeletePlace";
+
+export default {
+    title: "plan_candidate/DialogDeletePlace",
+    component: DialogDeletePlace,
+    tags: ["autodocs"],
+    parameters: {},
+} as Meta<typeof DialogDeletePlace>;
+
+type Story = StoryObj<typeof DialogDeletePlace>;
+
+export const Primary: Story = {
+    args: {
+        placeToDelete: mockPlaces.bookStore,
+        isDialogVisible: true,
+        isDeleting: false,
+    },
+};
+
+export const Deleting: Story = {
+    args: {
+        isDeleting: true,
+    },
+};

--- a/src/view/hooks/usePlanPlaceDelete.ts
+++ b/src/view/hooks/usePlanPlaceDelete.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { RequestStatuses } from "src/domain/models/RequestStatus";
+import {
+    deletePlaceFromPlanOfPlanCandidate,
+    reduxEditPlanCandidateSelector,
+} from "src/redux/editPlanCandidate";
+import { reduxPlanCandidateSelector } from "src/redux/planCandidate";
+import { useAppDispatch } from "src/redux/redux";
+
+export const usePlanPlaceDelete = ({
+    planCandidateId,
+    planId,
+}: {
+    planCandidateId: string;
+    planId: string;
+}) => {
+    const dispatch = useAppDispatch();
+    const [placeIdToDelete, setPlaceIdToDelete] = useState<string>(null);
+    const [isDialogVisible, setIsDialogVisible] = useState(false);
+    const { preview: plan } = reduxPlanCandidateSelector();
+    const { requestStatusDeletePlaceFromPlanOfPlanCandidate } =
+        reduxEditPlanCandidateSelector();
+
+    const showDialog = ({ placeIdToDelete }: { placeIdToDelete: string }) => {
+        setPlaceIdToDelete(placeIdToDelete);
+        setIsDialogVisible(true);
+    };
+
+    const closeDialog = () => {
+        setIsDialogVisible(false);
+    };
+
+    const deletePlaceFromPlan = ({
+        placeIdToDelete,
+    }: {
+        placeIdToDelete: string;
+    }) => {
+        dispatch(
+            deletePlaceFromPlanOfPlanCandidate({
+                planCandidateId,
+                planId,
+                placeId: placeIdToDelete,
+            })
+        );
+    };
+
+    useEffect(() => {
+        if (
+            requestStatusDeletePlaceFromPlanOfPlanCandidate ===
+            RequestStatuses.REJECTED
+        ) {
+            // TODO: show error message
+            setIsDialogVisible(false);
+            return;
+        }
+
+        if (
+            requestStatusDeletePlaceFromPlanOfPlanCandidate ===
+            RequestStatuses.FULFILLED
+        ) {
+            setIsDialogVisible(false);
+            return;
+        }
+
+        if (
+            requestStatusDeletePlaceFromPlanOfPlanCandidate ===
+            RequestStatuses.PENDING
+        ) {
+            setIsDialogVisible(true);
+            return;
+        }
+    }, [requestStatusDeletePlaceFromPlanOfPlanCandidate]);
+
+    useEffect(() => {
+        if (!isDialogVisible) setPlaceIdToDelete(null);
+    }, [isDialogVisible]);
+
+    return {
+        deletePlaceFromPlan,
+        showDialogToDelete: showDialog,
+        closeDialogToDelete: closeDialog,
+        isDialogToDeletePlaceVisible: isDialogVisible,
+        isDeletingPlace:
+            requestStatusDeletePlaceFromPlanOfPlanCandidate ===
+            RequestStatuses.PENDING,
+        placeToDelete:
+            placeIdToDelete &&
+            plan.places.find((place) => place.id === placeIdToDelete),
+    };
+};

--- a/src/view/plancandidate/DialogDeletePlace.tsx
+++ b/src/view/plancandidate/DialogDeletePlace.tsx
@@ -37,7 +37,10 @@ export function DialogDeletePlace({
             position="bottom"
             width="100%"
             visible={isDialogVisible}
-            onClickOutside={onClose}
+            onClickOutside={() => {
+                // 削除中は閉じないようにする
+                if (!isDeleting) onClose();
+            }}
         >
             <Center
                 backgroundColor="white"

--- a/src/view/plancandidate/DialogDeletePlace.tsx
+++ b/src/view/plancandidate/DialogDeletePlace.tsx
@@ -64,6 +64,8 @@ export function DialogDeletePlace({
                     <VStack
                         flex={1}
                         w="100%"
+                        px="16px"
+                        py="16px"
                         alignItems="center"
                         spacing="32px"
                     >

--- a/src/view/plancandidate/DialogDeletePlace.tsx
+++ b/src/view/plancandidate/DialogDeletePlace.tsx
@@ -1,0 +1,113 @@
+import {
+    Box,
+    Button,
+    Center,
+    HStack,
+    Image,
+    Spinner,
+    Text,
+    VStack,
+} from "@chakra-ui/react";
+import { getImageSizeOf, ImageSizes } from "src/domain/models/Image";
+import { Place } from "src/domain/models/Place";
+import { FullscreenDialog } from "src/view/common/FullscreenDialog";
+
+type Props = {
+    placeToDelete: Place | null;
+    isDialogVisible: boolean;
+    isDeleting: boolean;
+    onDelete: (props: { placeIdToDelete: string }) => void;
+    onClose: () => void;
+};
+
+export function DialogDeletePlace({
+    placeToDelete,
+    isDeleting,
+    isDialogVisible,
+    onDelete,
+    onClose,
+}: Props) {
+    const image =
+        placeToDelete && placeToDelete.images.length > 0
+            ? placeToDelete.images[0]
+            : null;
+
+    return (
+        <FullscreenDialog
+            position="bottom"
+            width="100%"
+            visible={isDialogVisible}
+            onClickOutside={onClose}
+        >
+            <Center
+                backgroundColor="white"
+                w="100%"
+                h="900px"
+                maxH="80vh"
+                borderTopRadius="20px"
+                overflowY="scroll"
+                sx={{
+                    "::-webkit-scrollbar": {
+                        display: "none",
+                    },
+                }}
+            >
+                {isDeleting || !placeToDelete ? (
+                    <Spinner
+                        thickness="4px"
+                        speed="0.65s"
+                        emptyColor="gray.200"
+                        color="#84A6FF"
+                        size="xl"
+                    />
+                ) : (
+                    <VStack
+                        flex={1}
+                        w="100%"
+                        alignItems="center"
+                        spacing="32px"
+                    >
+                        <VStack spacing="16px">
+                            <Box
+                                w="200px"
+                                h="200px"
+                                borderRadius="20px"
+                                overflow="hidden"
+                            >
+                                {image && (
+                                    <Image
+                                        w="100%"
+                                        h="100%"
+                                        objectFit="cover"
+                                        src={getImageSizeOf(
+                                            ImageSizes.Small,
+                                            image
+                                        )}
+                                    />
+                                )}
+                            </Box>
+                            <Text fontSize="18px">
+                                <b>「{placeToDelete.name}」</b>を削除しますか？
+                            </Text>
+                        </VStack>
+                        <HStack mt="auto" pb="48px">
+                            <Button onClick={onClose} variant="text">
+                                キャンセル
+                            </Button>
+                            <Button
+                                onClick={() =>
+                                    onDelete({
+                                        placeIdToDelete: placeToDelete.id,
+                                    })
+                                }
+                                colorScheme="red"
+                            >
+                                削除
+                            </Button>
+                        </HStack>
+                    </VStack>
+                )}
+            </Center>
+        </FullscreenDialog>
+    );
+}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

- プラン編集ページから指定した場所を削除できるようにした

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/6c1e0ca6-250a-47e4-9ffc-6d19996cfef7)|![image](https://github.com/poroto-app/poroto/assets/55840281/2120cac1-7977-4217-8489-c82af7825384)|
||![image](https://github.com/poroto-app/poroto/assets/55840281/37de3510-5426-4465-b27f-e80b0495174c)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #374 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- プランをユーザーの好きなように編集できるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 削除アイコンをクリックすると、削除確認ダイアログが開く
- [x] 削除確認ダイアログに場所の名前と写真が表示されている
- [x] キャンセルやダイアログの外側をタップすると、ダイアログが閉じ、削除されない
- [x] 削除ボタンを押すと削除される
- [x] 削除中は外をクリックしても閉じない 
- [x] プランに１つの場所しかない場合は削除アイコンが表示されない

```shell
# poroto
export BRANCH_POROTO=feature/delete_place_from_plan_candidate
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````