### PR TITLE
プランの画面のページタイトルを変える

### DIFF
--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -25,6 +25,8 @@ import { PlanPlaceList } from "src/view/plan/PlanPlaceList";
 import { PlanSchedule } from "src/view/plan/PlanSchedule";
 import { PlanPageSection } from "src/view/plan/section/PlanPageSection";
 import { PlanPageSectionSummary } from "src/view/plan/section/PlanPageSectionSummary";
+import Head from "next/head";
+import { Plan } from "src/domain/models/Plan";
 
 export default function PlanPage() {
     const { id } = useRouter().query;
@@ -73,6 +75,9 @@ export default function PlanPage() {
 
     return (
         <Center flexDirection="column" pb={`${FooterHeight}px`}>
+            <Head>
+                <title>{plan.title} | poroto</title>
+            </Head>
             <NavBar />
             <VStack
                 maxWidth="990px"

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Center, Icon, useToast, VStack } from "@chakra-ui/react";
+import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { RiShareForwardLine } from "react-icons/ri";
@@ -25,8 +26,6 @@ import { PlanPlaceList } from "src/view/plan/PlanPlaceList";
 import { PlanSchedule } from "src/view/plan/PlanSchedule";
 import { PlanPageSection } from "src/view/plan/section/PlanPageSection";
 import { PlanPageSectionSummary } from "src/view/plan/section/PlanPageSectionSummary";
-import Head from "next/head";
-import { Plan } from "src/domain/models/Plan";
 
 export default function PlanPage() {
     const { id } = useRouter().query;


### PR DESCRIPTION
### 修正の概要


|before| after |
|---|-------|
|<img width="226" alt="image" src="https://github.com/poroto-app/poroto/assets/90236945/b247ad36-fe65-40bc-b0c8-150287762f14">|<img width="220" alt="image" src="https://github.com/poroto-app/poroto/assets/90236945/33aaa643-78e1-4f07-bbfc-0f4e145f701b">|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
ページタイトルでもプランのタイトル、内容を理解しやすくするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] プランのタイトルとページタイトルが一致していることを確認

```shell
# poroto
export BRANCH_POROTO=feature/plan_page_title
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````