### PR TITLE
詳細画面から場所の削除・関連した場所の表示の操作ができるようにする

### DIFF
--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -22,6 +22,7 @@ import { NotFound } from "src/view/common/NotFound";
 import { Colors } from "src/view/constants/color";
 import { Routes } from "src/view/constants/router";
 import { useLocation } from "src/view/hooks/useLocation";
+import { usePlanPlaceDelete } from "src/view/hooks/usePlanPlaceDelete";
 import { usePlanPlaceReplace } from "src/view/hooks/usePlanPlaceReplace";
 import { SearchRouteByGoogleMapButton } from "src/view/plan/button/SearchRouteByGoogleMapButton";
 import { PlaceMap } from "src/view/plan/PlaceMap";
@@ -30,6 +31,7 @@ import { PlanPageThumbnail } from "src/view/plan/PlanPageThumbnail";
 import { PlanSchedule } from "src/view/plan/PlanSchedule";
 import { PlanPageSection } from "src/view/plan/section/PlanPageSection";
 import { PlanPageSectionSummary } from "src/view/plan/section/PlanPageSectionSummary";
+import { DialogDeletePlace } from "src/view/plancandidate/DialogDeletePlace";
 import { DialogReplacePlace } from "src/view/plancandidate/DialogReplacePlace";
 import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
 
@@ -52,6 +54,17 @@ const PlanDetail = () => {
         planId: planId as string,
     });
 
+    const {
+        deletePlaceFromPlan,
+        showDialogToDelete,
+        closeDialogToDelete,
+        isDialogToDeletePlaceVisible,
+        isDeletingPlace,
+        placeToDelete,
+    } = usePlanPlaceDelete({
+        planCandidateId: sessionId as string,
+        planId: planId as string,
+    });
     const {
         preview: plan,
         createdBasedOnCurrentLocation,
@@ -146,6 +159,9 @@ const PlanDetail = () => {
                             onClickShowRelatedPlaces={(placeId) =>
                                 showRelatedPlaces(placeId)
                             }
+                            onClickDeletePlace={(placeId) =>
+                                showDialogToDelete({ placeIdToDelete: placeId })
+                            }
                         />
                     </Box>
                     <AdInArticle
@@ -207,6 +223,7 @@ const PlanDetail = () => {
                     しおりとして保存
                 </Button>
             </PlanFooter>
+            {/*Dialog*/}
             <DialogReplacePlace
                 placesInPlan={plan.places}
                 placesToReplace={placesToReplace}
@@ -220,6 +237,13 @@ const PlanDetail = () => {
                     })
                 }
                 onCloseDialog={onCloseDialogRelatedPlaces}
+            />
+            <DialogDeletePlace
+                placeToDelete={placeToDelete}
+                isDialogVisible={isDialogToDeletePlaceVisible}
+                isDeleting={isDeletingPlace}
+                onDelete={deletePlaceFromPlan}
+                onClose={closeDialogToDelete}
             />
         </>
     );

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -13,6 +13,8 @@ import {
     VStack,
 } from "@chakra-ui/react";
 import { useState } from "react";
+import { IconType } from "react-icons";
+import { MdOutlineLocationOn } from "react-icons/md";
 import { GooglePlaceReview } from "src/domain/models/GooglePlaceReview";
 import {
     getImageSizeOf,
@@ -108,19 +110,15 @@ export const PlacePreview = ({
                     googlePlaceReviews={googlePlaceReviews}
                     priceRange={priceRange}
                 />
-                <VStack w="100%" mt="auto">
+                <HStack w="100%" mt="auto">
                     {onClickShowRelatedPlaces && (
-                        <Box
-                            color="#AB7129"
-                            as="button"
-                            fontWeight="bold"
-                            fontSize="16px"
+                        <ChipAction
+                            label="関連した場所を表示"
+                            icon={MdOutlineLocationOn}
                             onClick={onClickShowRelatedPlaces}
-                        >
-                            関連した場所を表示
-                        </Box>
+                        />
                     )}
-                </VStack>
+                </HStack>
             </VStack>
             {/* 画像を拡大表示するためのモーダル */}
             <Modal isOpen={!!selectedImage} onClose={closeModal} size="xl">
@@ -175,3 +173,28 @@ const ImagePreviewContainer = styled.div<{ hasImage: boolean }>`
         padding: 16px;
     }
 `;
+
+const ChipAction = ({
+    label,
+    icon,
+    onClick,
+}: {
+    label: string;
+    icon: IconType;
+    onClick: () => void;
+}) => {
+    return (
+        <HStack
+            backgroundColor="#F8E7D3"
+            color="#483216"
+            onClick={onClick}
+            as="button"
+            px="8px"
+            py="4px"
+            borderRadius="20px"
+        >
+            <Icon w="16px" h="16px" as={icon} />
+            <Text fontSize="0.8rem">{label}</Text>
+        </HStack>
+    );
+};

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -14,7 +14,7 @@ import {
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { IconType } from "react-icons";
-import { MdOutlineLocationOn } from "react-icons/md";
+import { MdOutlineDeleteOutline, MdOutlineLocationOn } from "react-icons/md";
 import { GooglePlaceReview } from "src/domain/models/GooglePlaceReview";
 import {
     getImageSizeOf,
@@ -36,6 +36,7 @@ type Props = {
     priceRange: PriceRange | null;
     showRelatedPlaces?: boolean;
     onClickShowRelatedPlaces?: () => void;
+    onClickDeletePlace?: () => void;
 };
 
 export const PlacePreview = ({
@@ -45,6 +46,7 @@ export const PlacePreview = ({
     categories,
     priceRange,
     onClickShowRelatedPlaces,
+    onClickDeletePlace,
 }: Props) => {
     const [selectedImage, setSelectedImage] = useState<string | null>(null);
     const [isLargerThan700] = useMediaQuery("(min-width: 700px)");
@@ -116,6 +118,13 @@ export const PlacePreview = ({
                             label="関連した場所を表示"
                             icon={MdOutlineLocationOn}
                             onClick={onClickShowRelatedPlaces}
+                        />
+                    )}
+                    {onClickDeletePlace && (
+                        <ChipAction
+                            label="削除"
+                            icon={MdOutlineDeleteOutline}
+                            onClick={onClickDeletePlace}
                         />
                     )}
                 </HStack>

--- a/src/view/plandetail/PlanPlaceList.tsx
+++ b/src/view/plandetail/PlanPlaceList.tsx
@@ -6,12 +6,14 @@ type Props = {
     plan: Plan;
     createdBasedOnCurrentLocation?: boolean;
     onClickShowRelatedPlaces?: (placeId: string) => void;
+    onClickDeletePlace?: (placeId: string) => void;
 };
 
 export function PlanPlaceList({
     plan,
     createdBasedOnCurrentLocation,
     onClickShowRelatedPlaces,
+    onClickDeletePlace,
 }: Props) {
     return (
         <VStack spacing="16px" w="100%">
@@ -35,6 +37,11 @@ export function PlanPlaceList({
                     onClickShowRelatedPlaces={
                         onClickShowRelatedPlaces
                             ? () => onClickShowRelatedPlaces(place.id)
+                            : undefined
+                    }
+                    onClickDeletePlace={
+                        onClickDeletePlace
+                            ? () => onClickDeletePlace(place.id)
                             : undefined
                     }
                 />


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/9a1deb9b-05ce-4cec-b34b-7ccd3c3e18f9)|![image](https://github.com/poroto-app/poroto/assets/55840281/6f9a975b-f07c-4dad-884a-9f65dbe75271)|
|![image](https://github.com/poroto-app/poroto/assets/55840281/23d55ad0-aa4c-422d-9d7a-8a51cadd17bb)|![image](https://github.com/poroto-app/poroto/assets/55840281/4af79961-cfd8-421a-868b-126fc97b4bf1)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 詳細ページから編集操作ができるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 削除ボタンから場所の削除ができることを確認
- [x] 「関連した場所を表示」から入れ替え操作ができることを確認

```shell
# poroto
export BRANCH_POROTO=feature/replace_place_from_detail_palce
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````