### PR TITLE
プラン完成時に表示されるダイアログからURLをコピーできるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # editor
 .idea/
+.vscode/
 
 # dependencies
 /node_modules

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -42,8 +42,8 @@ export default function PlanPage() {
         navigator.clipboard.writeText(url);
 
         toast({
-            title: "URLを共有",
-            description: "URLがクリップボードにコピーされました。",
+            title: "しおりのURLをコピーしました",
+            description: "作ったしおりを共有してみましょう！",
             status: "success",
             duration: 3000, // ポップアップが表示される時間（ミリ秒）
             isClosable: true,

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -125,6 +125,10 @@ export default function PlanPage() {
             <PlanCreatedDialog
                 visible={showPlanCreatedModal}
                 onClickClose={() => dispatch(setShowPlanCreatedModal(false))}
+                onClickCopyUrl={() => {
+                    dispatch(setShowPlanCreatedModal(false));
+                    handleOnCopyPlanUrl();
+                }}
             />
         </Center>
     );

--- a/src/view/plan/PlanCreatedDialog.tsx
+++ b/src/view/plan/PlanCreatedDialog.tsx
@@ -4,10 +4,15 @@ import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 
 export type Props = {
     visible: boolean;
+    onClickCopyUrl: () => void;
     onClickClose: () => void;
 };
 
-export function PlanCreatedDialog({ onClickClose, visible }: Props) {
+export function PlanCreatedDialog({
+    onClickCopyUrl,
+    onClickClose,
+    visible,
+}: Props) {
     return (
         <FullscreenDialog onClickOutside={onClickClose} visible={visible}>
             <VStack
@@ -15,7 +20,7 @@ export function PlanCreatedDialog({ onClickClose, visible }: Props) {
                 borderRadius="30px"
                 maxW="100%"
                 px="32px"
-                py="48px"
+                py="16px"
                 spacing="24px"
             >
                 <HappyNewsIcon
@@ -23,24 +28,38 @@ export function PlanCreatedDialog({ onClickClose, visible }: Props) {
                     style={{
                         width: "100%",
                         height: "300px",
+                        marginTop: "32px",
                     }}
                 />
                 <Text fontSize="24px" fontWeight="bold">
-                    プランが完成しました!
+                    しおりが完成しました!
                 </Text>
-                <Box
-                    as="button"
-                    w="100%"
-                    px="16px"
-                    py="8px"
-                    border="3px solid black"
-                    borderRadius="20px"
-                    fontWeight="bold"
-                    fontSize="16px"
-                    onClick={onClickClose}
-                >
-                    とじる
-                </Box>
+                <VStack spacing="8px" w="100%">
+                    <Box
+                        as="button"
+                        w="100%"
+                        px="16px"
+                        py="8px"
+                        border="3px solid black"
+                        borderRadius="20px"
+                        fontWeight="bold"
+                        fontSize="16px"
+                        onClick={onClickCopyUrl}
+                    >
+                        しおりのURLをコピー
+                    </Box>
+                    <Box
+                        as="button"
+                        w="100%"
+                        px="16px"
+                        py="8px"
+                        fontWeight="bold"
+                        fontSize="16px"
+                        onClick={onClickClose}
+                    >
+                        とじる
+                    </Box>
+                </VStack>
             </VStack>
         </FullscreenDialog>
     );


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/6e2c61ba-ad32-4b7f-bdb1-b25b6e027a8e)|![image](https://github.com/poroto-app/poroto/assets/55840281/3998118d-2c79-4265-9ba6-3ce42d31893c)|
|![image](https://github.com/poroto-app/poroto/assets/55840281/e28864da-4102-48ac-8122-8c5b566364c5)|![image](https://github.com/poroto-app/poroto/assets/55840281/d7e11ece-c7c0-49c5-8911-41a95cbe2914)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- URLコピーをやりやすい方法で配置することで、ユーザーが作成したプランにアクセスできなくなることを防ぐ

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] プラン保存時にひょうじされるダイアログからURLをコピーできることを確認

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````