### PR TITLE
プラン一覧の下に表示される「ここからでもプランを作れますよ」の場所候補を削除する

### DIFF
--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -28,6 +28,7 @@ import { RoundedIconButton } from "src/view/common/RoundedIconButton";
 import { locationSinjukuStation } from "src/view/constants/location";
 import { PageMetaData } from "src/view/constants/meta";
 import { Routes } from "src/view/constants/router";
+import { zIndex } from "src/view/constants/zIndex";
 import { useLocation } from "src/view/hooks/useLocation";
 import { FetchLocationDialog } from "src/view/location/FetchLocationDialog";
 import { MapPinSelector } from "src/view/place/MapPinSelector";
@@ -192,7 +193,14 @@ function PlaceSearchPage() {
             `space-between` で余白をつけようとすると、その部分を選択できなくなってしまうため、
             `position: fixed;` で位置を調整している
          */}
-            <Box position="fixed" left={0} bottom="32px" right={0} px="8px">
+            <Box
+                position="fixed"
+                left={0}
+                bottom="32px"
+                right={0}
+                px="8px"
+                zIndex={zIndex.footer}
+            >
                 <Head>
                     <title>好きな場所からプランを作る | poroto</title>
                 </Head>

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@chakra-ui/next-js";
-import { Box, Text, VStack } from "@chakra-ui/react";
+import { Box, Center, Text, VStack } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
@@ -163,24 +163,11 @@ const SelectPlanPage = () => {
 
     return (
         <Layout navBar={<NavBar />}>
-            <GeneratingPlanDialog
-                visible={[
-                    RequestStatuses.PENDING,
-                    RequestStatuses.REJECTED,
-                ].includes(createPlanFromPlaceRequestStatus)}
-                onClose={() =>
-                    dispatch(resetCreatePlanFromPlaceRequestStatus())
-                }
-                failed={
-                    createPlanFromPlaceRequestStatus ===
-                    RequestStatuses.REJECTED
-                }
-            />
-            <VStack
+            <Center
                 w="100%"
+                h="100%"
                 px="16px"
                 py="16px"
-                spacing={8}
                 ref={refPlanCandidateGallery}
             >
                 <VStack spacing="32px" my="32px">
@@ -211,7 +198,7 @@ const SelectPlanPage = () => {
                         </ButtonWithBlur>
                     </Link>
                 </VStack>
-            </VStack>
+            </Center>
         </Layout>
     );
 };

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -211,14 +211,6 @@ const SelectPlanPage = () => {
                         </ButtonWithBlur>
                     </Link>
                 </VStack>
-                <AvailablePlaceSection
-                    places={placesAvailableForPlan}
-                    isFetching={
-                        fetchAvailablePlacesForPlanRequestStatus ===
-                        RequestStatuses.PENDING
-                    }
-                    onClickPlace={handleOnClickPlaceCandidate}
-                />
             </VStack>
         </Layout>
     );

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -55,7 +55,10 @@ const SelectPlanPage = () => {
         // プラン取得中は何もしない
         if (!plansCreated) return;
 
-        dispatch(fetchAvailablePlacesForPlan({ session: sessionId }));
+        // プランが存在しない場合、プランの候補となる場所を取得する
+        if(plansCreated.length === 0) {
+            dispatch(fetchAvailablePlacesForPlan({ session: sessionId }));
+        }
     }, [sessionId, plansCreated?.length]);
 
     // 指定した場所からプランを作成できたら、そのプランが選択されている状態にする

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -56,7 +56,7 @@ const SelectPlanPage = () => {
         if (!plansCreated) return;
 
         // プランが存在しない場合、プランの候補となる場所を取得する
-        if(plansCreated.length === 0) {
+        if (plansCreated.length === 0) {
             dispatch(fetchAvailablePlacesForPlan({ session: sessionId }));
         }
     }, [sessionId, plansCreated?.length]);

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -133,7 +133,7 @@ const SelectPlanPage = () => {
                     }
                 />
                 <VStack pb="48px" px="16px" w="100%">
-                    <VStack py="48px" spacing="32px">
+                    <VStack py="100px" spacing="32px">
                         <Box w="100%" maxW="300px">
                             <EmptyIcon
                                 viewBox="0 0 862.70323 644.78592"

--- a/src/view/common/Layout.tsx
+++ b/src/view/common/Layout.tsx
@@ -38,7 +38,7 @@ export function Layout({ navBar, children, fillComponent }: Props) {
                         {fillComponent}
                     </Box>
                 )}
-                <Box maxWidth={Size.mainContentWidth} w="100%">
+                <Box maxWidth={Size.mainContentWidth} w="100%" h="100%">
                     {children}
                 </Box>
             </Center>

--- a/src/view/plan/candidate/AvailablePlace.tsx
+++ b/src/view/plan/candidate/AvailablePlace.tsx
@@ -20,7 +20,13 @@ type Props = {
 
 export function AvailablePlace({ place, onClick }: Props) {
     return (
-        <VStack as="button" w="100%" overflow="hidden" spacing={0} onClick={onClick}>
+        <VStack
+            as="button"
+            w="100%"
+            overflow="hidden"
+            spacing={0}
+            onClick={onClick}
+        >
             <Box
                 position="relative"
                 w="100%"
@@ -60,9 +66,7 @@ export function AvailablePlace({ place, onClick }: Props) {
                                 : null
                         )}
                     />
-                    <Text py="4px">
-                        {place.name}
-                    </Text>
+                    <Text py="4px">{place.name}</Text>
                 </HStack>
             ) : (
                 <SkeletonText

--- a/src/view/plan/candidate/AvailablePlace.tsx
+++ b/src/view/plan/candidate/AvailablePlace.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 export function AvailablePlace({ place, onClick }: Props) {
     return (
-        <VStack w="100%" overflow="hidden" spacing={0} onClick={onClick}>
+        <VStack as="button" w="100%" overflow="hidden" spacing={0} onClick={onClick}>
             <Box
                 position="relative"
                 w="100%"
@@ -60,7 +60,7 @@ export function AvailablePlace({ place, onClick }: Props) {
                                 : null
                         )}
                     />
-                    <Text py="4px" w="100%">
+                    <Text py="4px">
                         {place.name}
                     </Text>
                 </HStack>


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- プラン候補一覧の画面から「プラン作成のための場所候補一覧」を削除した
- また、プランを作成できなかったときのUIの余白を変えるなどの改善を行った

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/ea20007b-8aa8-43cb-ab77-4203d7a902c7)|![image](https://github.com/poroto-app/poroto/assets/55840281/e13d1899-b6fb-4081-ab54-42ab9345a190)|
|![image](https://github.com/poroto-app/poroto/assets/55840281/7ae5e950-e71a-4f8c-a3d2-a19695547a65)|![image](https://github.com/poroto-app/poroto/assets/55840281/0c9f91ff-6a7f-448a-b63c-91071be867d4)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 不要な機能を削除するため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] プラン一覧を取得したときに、開発者ツール上で`FetchAvailablePlaces`のリクエストが発生していないことを確認
![image](https://github.com/poroto-app/poroto/assets/55840281/dae96169-310b-4ab2-973d-165e22a6aafe)

- [x] プランがひとつも作成できなかったページでは、候補となる場所の一覧が表示されることを確認
  -  Firestoreでプラン候補に含まれているプランを手動で消すか、以下のプランにアクセスすると確認できる
   - `http://localhost:3000/plans/select/e60adecb-9853-4cfd-ae69-23e5a81ff341`
  
```shell
# poroto
export BRANCH_POROTO=feature/remove_candidate_places_for_plan
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````