### PR TITLE
ドルマークから円マークへ変更

### DIFF
--- a/src/view/plan/PlanSummary.tsx
+++ b/src/view/plan/PlanSummary.tsx
@@ -1,7 +1,7 @@
 import { Box, Icon, Text, VStack } from "@chakra-ui/react";
 import { ReactNode } from "react";
 import { IconType } from "react-icons";
-import { MdAttachMoney, MdSchedule } from "react-icons/md";
+import { MdCurrencyYen, MdSchedule } from "react-icons/md";
 import { DateHelper } from "src/domain/util/date";
 import styled from "styled-components";
 
@@ -67,7 +67,7 @@ export const PlanSummaryBudget = ({
     maxBudget: number;
 }) => {
     return (
-        <PlanSummary title="予算" icon={MdAttachMoney}>
+        <PlanSummary title="予算" icon={MdCurrencyYen}>
             <VStack alignItems="flex-start" w="100%" spacing={0}>
                 {minBudget > 0 && <Text>{`${minBudget}`}</Text>}
                 {maxBudget > 0 && <Text>{`~${maxBudget}円`}</Text>}


### PR DESCRIPTION
### 修正の概要
ドルマークに設定したので円マークへ変更しました。
|before| after |
|---|-------|
||<img width="297" alt="image" src="https://github.com/poroto-app/poroto/assets/90236945/48227d7e-b801-4386-b061-debca020d0b1">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
plan plase listのところは円マークになっていたのに情報のところはドルマークになっていた。
一致するようにした。そもそもドルマークに設定した自分が悪かった。

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認

```shell
# poroto
export BRANCH_POROTO=feature/planpage_summary_icon_change
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````