### PR TITLE
特定の場所に対していいねで評価できるようにする

### DIFF
--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -12,6 +12,7 @@ import {
     useMediaQuery,
     VStack,
 } from "@chakra-ui/react";
+import { motion } from "framer-motion";
 import { useState } from "react";
 import { IconType } from "react-icons";
 import {
@@ -32,7 +33,6 @@ import { ImageSliderPreview } from "src/view/common/ImageSliderPreview";
 import { getPlaceCategoryIcon } from "src/view/plan/PlaceCategoryIcon";
 import { PlaceInfoTab } from "src/view/plandetail/PlaceInfoTab";
 import styled from "styled-components";
-import { motion } from 'framer-motion';
 
 type Props = {
     name: string;
@@ -84,6 +84,8 @@ export const PlacePreview = ({
         // ここでいいねが押されたことをバックエンドに送信する処理を追加する
     };
 
+    const [likeCount, setLikeCount] = useState(65000); // Mock count for demonstration
+
     if (isEmptyLocation) {
         return (
             <Container p="16px" w="100%">
@@ -119,36 +121,14 @@ export const PlacePreview = ({
                 p="16px"
                 overflow="hidden"
             >
-                <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <motion.button
-                        onClick={handleLikeClick}
-                        style={{
-                            marginRight: '10px', 
-                            border: 'none',
-                            backgroundColor: 'transparent',
-                            cursor: 'pointer',
-                            display: 'flex',
-                            alignItems: 'center',
-                            fontSize: '1.6rem', 
-                        }}
-                        whileTap={{ scale: 1.1 }} 
-                        whileHover={{ scale: 1.2 }} 
-                    >
-                        {isLiked ? (
-                            <MdFavorite style={{ color: 'red' }} />
-                        ) : (
-                            <MdFavoriteBorder />
-                        )}
-                    </motion.button>
-                    <Text
-                        fontSize="1.15rem"
-                        as="h2"
-                        fontWeight="bold"
-                        color="#222222"
-                    >
-                        {name}
-                    </Text>
-                </div>
+                <Text
+                    fontSize="1.15rem"
+                    as="h2"
+                    fontWeight="bold"
+                    color="#222222"
+                >
+                    {name}
+                </Text>
                 <PlaceInfoTab
                     categories={categories}
                     googlePlaceReviews={googlePlaceReviews}
@@ -170,6 +150,34 @@ export const PlacePreview = ({
                             onClick={onClickDeletePlace}
                         />
                     )}
+                </HStack>
+                <HStack alignItems="center" marginTop="4px">
+                    <motion.button
+                        onClick={handleLikeClick}
+                        style={{
+                            marginRight: "10px",
+                            border: "none",
+                            backgroundColor: "transparent",
+                            cursor: "pointer",
+                            display: "flex",
+                            alignItems: "center",
+                            fontSize: "1.6rem",
+                        }}
+                        whileTap={{ scale: 1.1 }}
+                        whileHover={{ scale: 1.2 }}
+                    >
+                        {isLiked ? (
+                            <MdFavorite style={{ color: "red" }} />
+                        ) : (
+                            <MdFavoriteBorder />
+                        )}
+                    </motion.button>
+                    <Text
+                        fontSize="0.8rem"
+                        as="h2"
+                        fontWeight="bold"
+                        color="#222222"
+                    >{`いいね！${likeCount.toLocaleString()}件`}</Text>
                 </HStack>
             </VStack>
             {/* 画像を拡大表示するためのモーダル */}

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -152,32 +152,11 @@ export const PlacePreview = ({
                     )}
                 </HStack>
                 <HStack alignItems="center" marginTop="4px">
-                    <motion.button
-                        onClick={handleLikeClick}
-                        style={{
-                            marginRight: "10px",
-                            border: "none",
-                            backgroundColor: "transparent",
-                            cursor: "pointer",
-                            display: "flex",
-                            alignItems: "center",
-                            fontSize: "1.6rem",
-                        }}
-                        whileTap={{ scale: 1.1 }}
-                        whileHover={{ scale: 1.2 }}
-                    >
-                        {isLiked ? (
-                            <MdFavorite style={{ color: "red" }} />
-                        ) : (
-                            <MdFavoriteBorder />
-                        )}
-                    </motion.button>
-                    <Text
-                        fontSize="0.8rem"
-                        as="h2"
-                        fontWeight="bold"
-                        color="#222222"
-                    >{`いいね！${likeCount.toLocaleString()}件`}</Text>
+                    <LikeButton
+                        isLiked={isLiked}
+                        likeCount={likeCount}
+                        handleLikeClick={handleLikeClick}
+                    />
                 </HStack>
             </VStack>
             <Modal isOpen={!!selectedImage} onClose={closeModal} size="xl">
@@ -255,5 +234,38 @@ const ChipAction = ({
             <Icon w="16px" h="16px" as={icon} />
             <Text fontSize="0.8rem">{label}</Text>
         </HStack>
+    );
+};
+
+const LikeButton = ({ isLiked, likeCount, handleLikeClick }) => {
+    return (
+        <>
+            <motion.button
+                onClick={handleLikeClick}
+                style={{
+                    marginRight: "10px",
+                    border: "none",
+                    backgroundColor: "transparent",
+                    cursor: "pointer",
+                    display: "flex",
+                    alignItems: "center",
+                    fontSize: "1.6rem",
+                }}
+                whileTap={{ scale: 1.1 }}
+                whileHover={{ scale: 1.2 }}
+            >
+                {isLiked ? (
+                    <MdFavorite style={{ color: "red" }} />
+                ) : (
+                    <MdFavoriteBorder />
+                )}
+            </motion.button>
+            <Text
+                fontSize="0.8rem"
+                as="h2"
+                fontWeight="bold"
+                color="#222222"
+            >{`いいね！${likeCount.toLocaleString()}件`}</Text>
+        </>
     );
 };

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -151,13 +151,16 @@ export const PlacePreview = ({
                         />
                     )}
                 </HStack>
-                <HStack alignItems="center" marginTop="4px">
-                    <LikeButton
-                        isLiked={isLiked}
-                        likeCount={likeCount}
-                        handleLikeClick={handleLikeClick}
-                    />
-                </HStack>
+                userComponent=
+                {process.env.APP_ENV !== "production" && (
+                    <HStack alignItems="center" marginTop="4px">
+                        <LikeButton
+                            isLiked={isLiked}
+                            likeCount={likeCount}
+                            handleLikeClick={handleLikeClick}
+                        />
+                    </HStack>
+                )}
             </VStack>
             <Modal isOpen={!!selectedImage} onClose={closeModal} size="xl">
                 <ModalOverlay />

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -152,13 +152,11 @@ export const PlacePreview = ({
                     )}
                 </HStack>
                 {process.env.APP_ENV !== "production" && (
-                    <HStack alignItems="center" marginTop="4px">
-                        <LikeButton
-                            isLiked={isLiked}
-                            likeCount={likeCount}
-                            handleLikeClick={handleLikeClick}
-                        />
-                    </HStack>
+                    <LikeButton
+                        isLiked={isLiked}
+                        likeCount={likeCount}
+                        handleLikeClick={handleLikeClick}
+                    />
                 )}
             </VStack>
             <Modal isOpen={!!selectedImage} onClose={closeModal} size="xl">
@@ -240,34 +238,32 @@ const ChipAction = ({
 };
 
 const LikeButton = ({ isLiked, likeCount, handleLikeClick }) => {
-    return (
-        <>
-            <motion.button
-                onClick={handleLikeClick}
-                style={{
-                    marginRight: "10px",
-                    border: "none",
-                    backgroundColor: "transparent",
-                    cursor: "pointer",
-                    display: "flex",
-                    alignItems: "center",
-                    fontSize: "1.6rem",
-                }}
-                whileTap={{ scale: 1.1 }}
-                whileHover={{ scale: 1.2 }}
-            >
-                {isLiked ? (
-                    <MdFavorite style={{ color: "red" }} />
-                ) : (
-                    <MdFavoriteBorder />
-                )}
-            </motion.button>
-            <Text
-                fontSize="0.8rem"
-                as="h2"
-                fontWeight="bold"
-                color="#222222"
-            >{`いいね！${likeCount.toLocaleString()}件`}</Text>
-        </>
-    );
+    return <HStack alignItems="center" marginTop="4px">
+        <motion.button
+            onClick={handleLikeClick}
+            style={{
+                marginRight: "10px",
+                border: "none",
+                backgroundColor: "transparent",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                fontSize: "1.6rem",
+            }}
+            whileTap={{ scale: 1.1 }}
+            whileHover={{ scale: 1.2 }}
+        >
+            {isLiked ? (
+                <MdFavorite style={{ color: "red" }} />
+            ) : (
+                <MdFavoriteBorder />
+            )}
+        </motion.button>
+        <Text
+            fontSize="0.8rem"
+            as="h2"
+            fontWeight="bold"
+            color="#222222"
+        >{`いいね！${likeCount.toLocaleString()}件`}</Text>
+    </HStack>
 };

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -66,6 +66,8 @@ export const PlacePreview = ({
         setSelectedImage(null);
     };
 
+    const [isliked, setIsLiked] = useState(false);
+
     if (isEmptyLocation) {
         return (
             <Container p="16px" w="100%">

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -76,12 +76,12 @@ export const PlacePreview = ({
 
     const handleLikeClick = () => {
         setIsLiked(!isLiked);
-        // ここでいいねが押されたことをバックエンドに送信する処理を追加する
+        //TODO: ここでいいねが押されたことをバックエンドに送信する処理を追加する
     };
 
     const handleDoubleClick = () => {
         setIsLiked(true);
-        // ここでいいねが押されたことをバックエンドに送信する処理を追加する
+        //TODO: ここでいいねが押されたことをバックエンドに送信する処理を追加する
     };
 
     const [likeCount, setLikeCount] = useState(65000); // Mock count for demonstration
@@ -180,7 +180,6 @@ export const PlacePreview = ({
                     >{`いいね！${likeCount.toLocaleString()}件`}</Text>
                 </HStack>
             </VStack>
-            {/* 画像を拡大表示するためのモーダル */}
             <Modal isOpen={!!selectedImage} onClose={closeModal} size="xl">
                 <ModalOverlay />
                 <ModalContent>

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -151,7 +151,6 @@ export const PlacePreview = ({
                         />
                     )}
                 </HStack>
-                userComponent=
                 {process.env.APP_ENV !== "production" && (
                     <HStack alignItems="center" marginTop="4px">
                         <LikeButton

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -126,6 +126,24 @@ export const PlacePreview = ({
                 >
                     {name}
                 </Text>
+                <button
+                    onClick={handleLikeClick}
+                    style={{
+                        marginLeft: '10px', 
+                        border: 'none',
+                        backgroundColor: 'transparent',
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        fontSize: '1.6rem', 
+                    }}
+                >
+                    {isLiked ? (
+                        <MdFavorite style={{ color: 'red' }} />
+                    ) : (
+                        <MdFavoriteBorder />
+                    )}
+                </button>
                 <PlaceInfoTab
                     categories={categories}
                     googlePlaceReviews={googlePlaceReviews}
@@ -148,11 +166,6 @@ export const PlacePreview = ({
                         />
                     )}
                 </HStack>
-                <ChipAction
-                    label={isLiked ? "いいね済み" : "いいね"}
-                    icon={isLiked ? MdFavorite : MdFavoriteBorder}
-                    onClick={handleLikeClick}
-                />
             </VStack>
             {/* 画像を拡大表示するためのモーダル */}
             <Modal isOpen={!!selectedImage} onClose={closeModal} size="xl">

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -75,6 +75,12 @@ export const PlacePreview = ({
 
     const handleLikeClick = () => {
         setIsLiked(!isLiked);
+        // ここでいいねが押されたことをバックエンドに送信する処理を追加する
+    };
+
+    const handleDoubleClick = () => {
+        setIsLiked(true);
+        // ここでいいねが押されたことをバックエンドに送信する処理を追加する
     };
 
     if (isEmptyLocation) {
@@ -95,7 +101,7 @@ export const PlacePreview = ({
     }
 
     return (
-        <Container>
+        <Container onDoubleClick={handleDoubleClick}>
             <ImagePreviewContainer hasImage={images.length > 0}>
                 {images.length > 0 && (
                     <ImageSliderPreview

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -14,7 +14,7 @@ import {
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { IconType } from "react-icons";
-import { MdOutlineDeleteOutline, MdOutlineLocationOn } from "react-icons/md";
+import { MdFavorite, MdFavoriteBorder, MdOutlineDeleteOutline, MdOutlineLocationOn } from "react-icons/md";
 import { GooglePlaceReview } from "src/domain/models/GooglePlaceReview";
 import {
     getImageSizeOf,
@@ -66,10 +66,10 @@ export const PlacePreview = ({
         setSelectedImage(null);
     };
 
-    const [isliked, setIsLiked] = useState(false);
+    const [isLiked, setIsLiked] = useState(false);
 
     const handleLikeClick = () => {
-        setIsLiked(!isliked);
+        setIsLiked(!isLiked);
     };
     
     if (isEmptyLocation) {
@@ -137,6 +137,7 @@ export const PlacePreview = ({
                         />
                     )}
                 </HStack>
+                <ChipAction label={isLiked ? "いいね済み" : "いいね"} icon={isLiked ? MdFavorite : MdFavoriteBorder} onClick={handleLikeClick} />
             </VStack>
             {/* 画像を拡大表示するためのモーダル */}
             <Modal isOpen={!!selectedImage} onClose={closeModal} size="xl">

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -238,32 +238,34 @@ const ChipAction = ({
 };
 
 const LikeButton = ({ isLiked, likeCount, handleLikeClick }) => {
-    return <HStack alignItems="center" marginTop="4px">
-        <motion.button
-            onClick={handleLikeClick}
-            style={{
-                marginRight: "10px",
-                border: "none",
-                backgroundColor: "transparent",
-                cursor: "pointer",
-                display: "flex",
-                alignItems: "center",
-                fontSize: "1.6rem",
-            }}
-            whileTap={{ scale: 1.1 }}
-            whileHover={{ scale: 1.2 }}
-        >
-            {isLiked ? (
-                <MdFavorite style={{ color: "red" }} />
-            ) : (
-                <MdFavoriteBorder />
-            )}
-        </motion.button>
-        <Text
-            fontSize="0.8rem"
-            as="h2"
-            fontWeight="bold"
-            color="#222222"
-        >{`いいね！${likeCount.toLocaleString()}件`}</Text>
-    </HStack>
+    return (
+        <HStack alignItems="center" marginTop="4px">
+            <motion.button
+                onClick={handleLikeClick}
+                style={{
+                    marginRight: "10px",
+                    border: "none",
+                    backgroundColor: "transparent",
+                    cursor: "pointer",
+                    display: "flex",
+                    alignItems: "center",
+                    fontSize: "1.6rem",
+                }}
+                whileTap={{ scale: 1.1 }}
+                whileHover={{ scale: 1.2 }}
+            >
+                {isLiked ? (
+                    <MdFavorite style={{ color: "red" }} />
+                ) : (
+                    <MdFavoriteBorder />
+                )}
+            </motion.button>
+            <Text
+                fontSize="0.8rem"
+                as="h2"
+                fontWeight="bold"
+                color="#222222"
+            >{`いいね！${likeCount.toLocaleString()}件`}</Text>
+        </HStack>
+    );
 };

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -118,32 +118,34 @@ export const PlacePreview = ({
                 p="16px"
                 overflow="hidden"
             >
-                <Text
-                    fontSize="1.15rem"
-                    as="h2"
-                    fontWeight="bold"
-                    color="#222222"
-                >
-                    {name}
-                </Text>
-                <button
-                    onClick={handleLikeClick}
-                    style={{
-                        marginLeft: '10px', 
-                        border: 'none',
-                        backgroundColor: 'transparent',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        fontSize: '1.6rem', 
-                    }}
-                >
-                    {isLiked ? (
-                        <MdFavorite style={{ color: 'red' }} />
-                    ) : (
-                        <MdFavoriteBorder />
-                    )}
-                </button>
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <button
+                            onClick={handleLikeClick}
+                            style={{
+                                marginRight: '10px', 
+                                border: 'none',
+                                backgroundColor: 'transparent',
+                                cursor: 'pointer',
+                                display: 'flex',
+                                alignItems: 'center',
+                                fontSize: '1.6rem', 
+                            }}
+                        >
+                            {isLiked ? (
+                                <MdFavorite style={{ color: 'red' }} />
+                            ) : (
+                                <MdFavoriteBorder />
+                            )}
+                    </button>
+                    <Text
+                        fontSize="1.15rem"
+                        as="h2"
+                        fontWeight="bold"
+                        color="#222222"
+                    >
+                        {name}
+                    </Text>
+                </div>
                 <PlaceInfoTab
                     categories={categories}
                     googlePlaceReviews={googlePlaceReviews}

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -68,6 +68,10 @@ export const PlacePreview = ({
 
     const [isliked, setIsLiked] = useState(false);
 
+    const handleLikeClick = () => {
+        setIsLiked(!isliked);
+    };
+    
     if (isEmptyLocation) {
         return (
             <Container p="16px" w="100%">

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -14,7 +14,12 @@ import {
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { IconType } from "react-icons";
-import { MdFavorite, MdFavoriteBorder, MdOutlineDeleteOutline, MdOutlineLocationOn } from "react-icons/md";
+import {
+    MdFavorite,
+    MdFavoriteBorder,
+    MdOutlineDeleteOutline,
+    MdOutlineLocationOn,
+} from "react-icons/md";
 import { GooglePlaceReview } from "src/domain/models/GooglePlaceReview";
 import {
     getImageSizeOf,
@@ -71,7 +76,7 @@ export const PlacePreview = ({
     const handleLikeClick = () => {
         setIsLiked(!isLiked);
     };
-    
+
     if (isEmptyLocation) {
         return (
             <Container p="16px" w="100%">
@@ -137,7 +142,11 @@ export const PlacePreview = ({
                         />
                     )}
                 </HStack>
-                <ChipAction label={isLiked ? "いいね済み" : "いいね"} icon={isLiked ? MdFavorite : MdFavoriteBorder} onClick={handleLikeClick} />
+                <ChipAction
+                    label={isLiked ? "いいね済み" : "いいね"}
+                    icon={isLiked ? MdFavorite : MdFavoriteBorder}
+                    onClick={handleLikeClick}
+                />
             </VStack>
             {/* 画像を拡大表示するためのモーダル */}
             <Modal isOpen={!!selectedImage} onClose={closeModal} size="xl">

--- a/src/view/plandetail/PlacePreview.tsx
+++ b/src/view/plandetail/PlacePreview.tsx
@@ -32,6 +32,7 @@ import { ImageSliderPreview } from "src/view/common/ImageSliderPreview";
 import { getPlaceCategoryIcon } from "src/view/plan/PlaceCategoryIcon";
 import { PlaceInfoTab } from "src/view/plandetail/PlaceInfoTab";
 import styled from "styled-components";
+import { motion } from 'framer-motion';
 
 type Props = {
     name: string;
@@ -119,24 +120,26 @@ export const PlacePreview = ({
                 overflow="hidden"
             >
                 <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <button
-                            onClick={handleLikeClick}
-                            style={{
-                                marginRight: '10px', 
-                                border: 'none',
-                                backgroundColor: 'transparent',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                fontSize: '1.6rem', 
-                            }}
-                        >
-                            {isLiked ? (
-                                <MdFavorite style={{ color: 'red' }} />
-                            ) : (
-                                <MdFavoriteBorder />
-                            )}
-                    </button>
+                    <motion.button
+                        onClick={handleLikeClick}
+                        style={{
+                            marginRight: '10px', 
+                            border: 'none',
+                            backgroundColor: 'transparent',
+                            cursor: 'pointer',
+                            display: 'flex',
+                            alignItems: 'center',
+                            fontSize: '1.6rem', 
+                        }}
+                        whileTap={{ scale: 1.1 }} 
+                        whileHover={{ scale: 1.2 }} 
+                    >
+                        {isLiked ? (
+                            <MdFavorite style={{ color: 'red' }} />
+                        ) : (
+                            <MdFavoriteBorder />
+                        )}
+                    </motion.button>
                     <Text
                         fontSize="1.15rem"
                         as="h2"


### PR DESCRIPTION
### 修正の概要
特定の場所に対していいねを押せるようにした。

|before| after |
|---|-------|
||<img width="920" alt="image" src="https://github.com/poroto-app/poroto/assets/90236945/16df0133-e86c-491d-bf9b-1de42b888ec2">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [ ] プランが表示されていることを確認
- [ ] プランが作成できることを確認
- [ ] プランが保存できることを確認
- [ ] ハートをクリックすると赤色のハートになることを確認
- [ ] いいねした状態（赤色のハート）でもう一度ハートをクリックするといいねした状態（無色のハート）になることを確認
- [ ] カードをダブルクリックすると赤色のハートになるを確認

```shell
# poroto
export BRANCH_POROTO=feature/add_like_button
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````