### PR TITLE
Google Mapの中心部を操作できるようにする

### DIFF
--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -1,4 +1,4 @@
-import { Box, VStack } from "@chakra-ui/react";
+import { Box, Center, VStack } from "@chakra-ui/react";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -22,12 +22,12 @@ import {
     setSelectedLocation,
 } from "src/redux/placeSearch";
 import { useAppDispatch } from "src/redux/redux";
-import { Layout } from "src/view/common/Layout";
 import { NavBar } from "src/view/common/NavBar";
 import { RoundedIconButton } from "src/view/common/RoundedIconButton";
 import { locationSinjukuStation } from "src/view/constants/location";
 import { PageMetaData } from "src/view/constants/meta";
 import { Routes } from "src/view/constants/router";
+import { Size } from "src/view/constants/size";
 import { zIndex } from "src/view/constants/zIndex";
 import { useLocation } from "src/view/hooks/useLocation";
 import { FetchLocationDialog } from "src/view/location/FetchLocationDialog";
@@ -150,72 +150,87 @@ function PlaceSearchPage() {
         );
 
     return (
-        <Layout
-            navBar={<NavBar />}
-            fillComponent={
-                <MapPinSelector
-                    center={mapCenter}
-                    onSelectLocation={handleOnSelectLocation}
-                    pinnedLocation={placeSelected?.location}
-                />
-            }
-        >
-            <VStack
-                w="100%"
-                h="100%"
-                pt="24px"
-                px="8px"
-                spacing={4}
-                position="relative"
-                zIndex={10}
-            >
-                <Box w="100%">
-                    <PlaceSearchBar onSearch={handleOnSearch} />
-                </Box>
-                <Box
-                    w="100%"
-                    backgroundColor="white"
-                    borderRadius={5}
-                    boxShadow={
-                        placeSearchResults &&
-                        placeSearchResults.length !== 0 &&
-                        "0px 5px 20px 0px rgb(0 0 0 / 10%)"
-                    }
-                >
-                    <PlaceSearchResults
-                        places={(placeSearchResults || []).slice(0, 5)}
-                        onClickPlace={handleOnClickPlace}
+        <VStack w="100%" h="100%" spacing={0}>
+            <Head>
+                <title>好きな場所からプランを作る | poroto</title>
+            </Head>
+            <NavBar />
+            <VStack w="100%" h="100%" position="relative">
+                <Box position="absolute" top={0} right={0} bottom={0} left={0}>
+                    <MapPinSelector
+                        center={mapCenter}
+                        onSelectLocation={handleOnSelectLocation}
+                        pinnedLocation={placeSelected?.location}
                     />
                 </Box>
-            </VStack>
-            {/*
+                <VStack
+                    w="100%"
+                    maxW={Size.mainContentWidth}
+                    pt="24px"
+                    px="8px"
+                    spacing={4}
+                    position="relative"
+                    zIndex={10}
+                >
+                    <Box w="100%">
+                        <PlaceSearchBar onSearch={handleOnSearch} />
+                    </Box>
+                    <Box
+                        w="100%"
+                        backgroundColor="white"
+                        borderRadius={5}
+                        boxShadow={
+                            placeSearchResults &&
+                            placeSearchResults.length !== 0 &&
+                            "0px 5px 20px 0px rgb(0 0 0 / 10%)"
+                        }
+                    >
+                        <PlaceSearchResults
+                            places={(placeSearchResults || []).slice(0, 5)}
+                            onClickPlace={handleOnClickPlace}
+                        />
+                    </Box>
+                </VStack>
+                {/*
             MEMO:
             `space-between` で余白をつけようとすると、その部分を選択できなくなってしまうため、
             `position: fixed;` で位置を調整している
          */}
-            <Box
-                position="fixed"
-                left={0}
-                bottom="32px"
-                right={0}
-                px="8px"
-                zIndex={zIndex.footer}
-            >
-                <Head>
-                    <title>好きな場所からプランを作る | poroto</title>
-                </Head>
-                <Layout>
-                    <RoundedIconButton
-                        icon={placeSelected ? MdDone : MdOutlineTouchApp}
-                        disabled={placeSelected === null}
-                        onClick={handleOnCreatePlan}
-                    >
-                        {placeSelected
-                            ? "指定した場所からプランを作成"
-                            : "タップして場所を選択"}
-                    </RoundedIconButton>
-                </Layout>
-            </Box>
-        </Layout>
+                <SearchButton
+                    placeSelected={placeSelected !== null}
+                    onClick={handleOnCreatePlan}
+                />
+            </VStack>
+        </VStack>
     );
 }
+
+const SearchButton = ({
+    placeSelected,
+    onClick,
+}: {
+    placeSelected: boolean;
+    onClick: () => void;
+}) => {
+    return (
+        <Center
+            position="fixed"
+            left={0}
+            bottom={0}
+            right={0}
+            zIndex={zIndex.footer}
+        >
+            <Box px="8px" pb="32px" w="100%" maxW={Size.mainContentWidth}>
+                <RoundedIconButton
+                    icon={placeSelected ? MdDone : MdOutlineTouchApp}
+                    disabled={!placeSelected}
+                    onClick={onClick}
+                >
+                    {placeSelected
+                        ? "タップして場所を選択"
+                        : "指定した場所からプランを作成"}
+                </RoundedIconButton>
+            </Box>
+        </Center>
+    );
+};

--- a/src/view/common/Layout.tsx
+++ b/src/view/common/Layout.tsx
@@ -5,10 +5,9 @@ import { Size } from "src/view/constants/size";
 type Props = {
     navBar?: ReactNode;
     children: ReactNode;
-    fillComponent?: ReactNode;
 };
 
-export function Layout({ navBar, children, fillComponent }: Props) {
+export function Layout({ navBar, children }: Props) {
     return (
         <Box
             w="100%"
@@ -26,18 +25,6 @@ export function Layout({ navBar, children, fillComponent }: Props) {
                 justifyContent="flex-start"
                 position="relative"
             >
-                {fillComponent && (
-                    <Box
-                        position="absolute"
-                        top={0}
-                        right={0}
-                        bottom={0}
-                        left={0}
-                        zIndex={0}
-                    >
-                        {fillComponent}
-                    </Box>
-                )}
                 <Box maxWidth={Size.mainContentWidth} w="100%" h="100%">
                     {children}
                 </Box>

--- a/src/view/common/MapViewer.tsx
+++ b/src/view/common/MapViewer.tsx
@@ -1,5 +1,5 @@
 import { GoogleMap, useLoadScript } from "@react-google-maps/api";
-import { ReactNode } from "react";
+import {ReactNode, useEffect, useState} from "react";
 import { GooglePlacesApi } from "src/data/map/GooglePlacesApi";
 
 export type MapViewerProps = {
@@ -19,6 +19,14 @@ export function MapViewer({
     onClick,
     children,
 }: MapViewerProps) {
+    const [mapCenter, setMapCenter] = useState(center);
+
+    useEffect(() => {
+        // 再描画を避けるため、同じ座標の場合は何もしない
+        if (center.lat == mapCenter?.lat && center.lng == mapCenter?.lng) return;
+        setMapCenter(center);
+    }, [center]);
+
     const { isLoaded } = useLoadScript({
         googleMapsApiKey: process.env.GCP_API_KEY,
         // MEMO: GooglePlacesAPIと利用するGoogle Maps Javascript APIのバージョンは同じにする必要がある
@@ -34,7 +42,7 @@ export function MapViewer({
     return (
         <GoogleMap
             zoom={zoom}
-            center={center}
+            center={mapCenter}
             mapContainerStyle={{ width: "100%", height: "100%" }}
             options={options && options()}
             onClick={onClick}

--- a/src/view/common/MapViewer.tsx
+++ b/src/view/common/MapViewer.tsx
@@ -1,5 +1,5 @@
 import { GoogleMap, useLoadScript } from "@react-google-maps/api";
-import {ReactNode, useEffect, useState} from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { GooglePlacesApi } from "src/data/map/GooglePlacesApi";
 
 export type MapViewerProps = {
@@ -23,7 +23,9 @@ export function MapViewer({
 
     useEffect(() => {
         // 再描画を避けるため、同じ座標の場合は何もしない
-        if (center.lat == mapCenter?.lat && center.lng == mapCenter?.lng) return;
+        if (center.lat == mapCenter?.lat && center.lng == mapCenter?.lng) {
+            return;
+        }
         setMapCenter(center);
     }, [center]);
 


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|みための変化はない|![image](https://github.com/poroto-app/poroto/assets/55840281/8c43623f-5433-4bf5-9e72-7944695b1583)|

- 中心部をドラッグしようとすると、うまく操作できなくなっていたバグを修正（productionで試すとわかりやすい）
- また、現在地をGoogle Mapの描画範囲外に出した上で、場所をクリックで選択すると、選択した場所ではなく、現在地のところが中心として描画されてしまうバグを修正

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 適切に地図操作をできるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] 画面中央部でドラッグやズーム操作ができる
- [x] 場所を文字列で検索して、選択すると、その場所が地図の中心に来る
- [x] 任意の場所をクリックで選択したときに、選択したところがピンで表示され、カメラの移動は発生しない

```shell
# poroto
export BRANCH_POROTO=feature/map_control
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````