### PR TITLE
プラン詳細画面で戻るボタンを押したときに一覧ページに戻るようにする

### DIFF
--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -151,7 +151,12 @@ const PlanDetail = () => {
     return (
         <>
             <Center flexDirection="column" pb={`${FooterHeight}px`}>
-                <NavBar canGoBack />
+                <NavBar
+                    canGoBack
+                    defaultPath={Routes.plans.planCandidate.index(
+                        sessionId as string
+                    )}
+                />
                 <VStack
                     maxWidth="990px"
                     w="100%"

--- a/src/view/common/NavBar.tsx
+++ b/src/view/common/NavBar.tsx
@@ -13,9 +13,11 @@ import styled from "styled-components";
 type Props = {
     canGoBack?: boolean;
     onBack?: () => void;
+    // 履歴がないときに戻るときのデフォルトのパス
+    defaultPath?: string;
 };
 
-export const NavBar = ({ canGoBack }: Props) => {
+export const NavBar = ({ canGoBack, defaultPath }: Props) => {
     const router = useRouter();
     const { historyStack } = reduxHistorySelector();
     const { user, signInWithGoogle, logout } = useAuth();
@@ -26,7 +28,8 @@ export const NavBar = ({ canGoBack }: Props) => {
 
         // 一つ前のページがporotoのページでない
         if (historyStack.length <= 1) {
-            await router.push("/");
+            if (defaultPath) await router.push(defaultPath);
+            else await router.push("/");
             return;
         }
 


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- プラン詳細ページで戻るボタンを押したとき、履歴が無いとporotoのトップページに移動するようになっている
- これを、プラン一覧ページに戻るようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- より直感的なナビゲーションを行えるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] プラン詳細ページでリロードして履歴を消す -> 戻るボタンを押すと、プラン候補一覧ページに戻ることを確認

```shell
# poroto
export BRANCH_POROTO=feature/back_plan_candidate
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````