### PR TITLE
「関連した場所を表示」を押すと、入れ替え候補となる場所が表示されるようにする

### DIFF
--- a/src/data/graphql/PlannerGraphQlApi.ts
+++ b/src/data/graphql/PlannerGraphQlApi.ts
@@ -12,6 +12,7 @@ import {
     FetchPlansDocument,
     NearbyPlaceCategoriesDocument,
     PlacesToAddForPlanOfPlanCandidateDocument,
+    PlacesToReplaceForPlanOfPlanCandidateDocument,
     PlansByLocationDocument,
     PlansByUserDocument,
     ReplacePlaceOfPlanCandidateDocument,
@@ -34,6 +35,8 @@ import {
     FetchNearbyPlaceCategoriesRequest,
     FetchNearbyPlaceCategoriesResponse,
     FetchPlacesToAddForPlanOfPlanCandidateRequest,
+    FetchPlacesToReplaceForPlanOfPlanCandidateRequest,
+    FetchPlacesToReplaceForPlanOfPlanCandidateResponse,
     FetchPlanRequest,
     FetchPlanResponse,
     FetchPlansByLocationRequest,
@@ -207,19 +210,20 @@ export class PlannerGraphQlApi extends GraphQlRepository implements PlannerApi {
     }
 
     async fetchPlacesToReplaceForPlanOfPlanCandidate(
-        request: FetchPlacesToAddForPlanOfPlanCandidateRequest
-    ) {
+        request: FetchPlacesToReplaceForPlanOfPlanCandidateRequest
+    ): Promise<FetchPlacesToReplaceForPlanOfPlanCandidateResponse> {
         const { data } = await this.client.query({
-            query: PlacesToAddForPlanOfPlanCandidateDocument,
+            query: PlacesToReplaceForPlanOfPlanCandidateDocument,
             variables: {
                 input: {
                     planCandidateId: request.planCandidateId,
                     planId: request.planId,
+                    placeId: request.placeId,
                 },
             },
         });
         return {
-            places: data.placesToAddForPlanCandidate.places.map((place) =>
+            places: data.placesToReplaceForPlanCandidate.places.map((place) =>
                 fromGraphqlPlaceEntity(place)
             ),
         };


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
||![image](https://github.com/poroto-app/poroto/assets/55840281/8b9b8d6a-fb90-4c85-a683-a1ec8e144831)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- https://github.com/poroto-app/planner/pull/347

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- https://github.com/poroto-app/planner/pull/347
- この修正を入れたことで入れ替え候補の場所が取得できるようになったため、それに合わせてporotoでも修正した

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 4箇所程度の場所が表示されることを確認

```shell
# poroto
export BRANCH_POROTO=feature/places_to_replace
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=feature/improve_places_to_replace
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````