### PR TITLE
プランを取得するときに次のページを取得するためのトークンを受け取る

### DIFF
--- a/src/data/graphql/PlannerGraphQlApi.ts
+++ b/src/data/graphql/PlannerGraphQlApi.ts
@@ -74,15 +74,14 @@ export class PlannerGraphQlApi extends GraphQlRepository implements PlannerApi {
         const { data } = await this.client.query({
             query: FetchPlansDocument,
             variables: {
-                pageKey: request.pageKey,
+                input: {
+                    pageToken: request.pageKey,
+                },
             },
         });
         return {
-            plans: data.plans.map((plan) => fromGraphqlPlanEntity(plan)),
-            nextPageKey:
-                data.plans.length === 0
-                    ? null
-                    : data.plans[data.plans.length - 1].id,
+            plans: data.plans.plans.map((plan) => fromGraphqlPlanEntity(plan)),
+            nextPageKey: data.plans.nextPageToken ?? null,
         };
     }
 

--- a/src/data/graphql/documents/plan/query/plan_all.graphql
+++ b/src/data/graphql/documents/plan/query/plan_all.graphql
@@ -1,18 +1,21 @@
-query FetchPlans($pageKey: String) {
-    plans(pageKey: $pageKey) {
-        id
-        name
-        places {
-            ...PlaceFullFragment
-        }
-        timeInMinutes
-        transitions {
-            duration
-            from {
-                id
+query FetchPlans($input: PlansInput!) {
+    plans(input: $input) {
+        nextPageToken
+        plans {
+            id
+            name
+            places {
+                ...PlaceFullFragment
             }
-            to {
-                id
+            timeInMinutes
+            transitions {
+                duration
+                from {
+                    id
+                }
+                to {
+                    id
+                }
             }
         }
     }

--- a/src/data/graphql/generated.ts
+++ b/src/data/graphql/generated.ts
@@ -4,37 +4,39 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
 };
 
 export type AddPlaceToPlanCandidateAfterPlaceInput = {
-  placeId: Scalars['String'];
-  planCandidateId: Scalars['String'];
-  planId: Scalars['String'];
-  previousPlaceId: Scalars['String'];
+  placeId: Scalars['String']['input'];
+  planCandidateId: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
+  previousPlaceId: Scalars['String']['input'];
 };
 
 export type AddPlaceToPlanCandidateAfterPlaceOutput = {
   __typename?: 'AddPlaceToPlanCandidateAfterPlaceOutput';
   plan: Plan;
-  planCandidateId: Scalars['String'];
+  planCandidateId: Scalars['String']['output'];
 };
 
 export type AutoReorderPlacesInPlanCandidateInput = {
-  planCandidateId: Scalars['String'];
-  planId: Scalars['String'];
+  planCandidateId: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
 };
 
 export type AutoReorderPlacesInPlanCandidateOutput = {
   __typename?: 'AutoReorderPlacesInPlanCandidateOutput';
   plan: Plan;
-  planCandidateId: Scalars['String'];
+  planCandidateId: Scalars['String']['output'];
 };
 
 export type AvailablePlacesForPlan = {
@@ -43,15 +45,26 @@ export type AvailablePlacesForPlan = {
 };
 
 export type AvailablePlacesForPlanInput = {
-  session: Scalars['String'];
+  session: Scalars['String']['input'];
+};
+
+export type CachedCreatedPlans = {
+  __typename?: 'CachedCreatedPlans';
+  createdBasedOnCurrentLocation: Scalars['Boolean']['output'];
+  likedPlaceIds: Array<Scalars['ID']['output']>;
+  plans: Array<Plan>;
+};
+
+export type CachedCreatedPlansInput = {
+  session: Scalars['String']['input'];
 };
 
 export type ChangePlacesOrderInPlanCandidateInput = {
-  currentLatitude?: InputMaybe<Scalars['Float']>;
-  currentLongitude?: InputMaybe<Scalars['Float']>;
-  placeIds: Array<Scalars['String']>;
-  planId: Scalars['String'];
-  session: Scalars['String'];
+  currentLatitude?: InputMaybe<Scalars['Float']['input']>;
+  currentLongitude?: InputMaybe<Scalars['Float']['input']>;
+  placeIds: Array<Scalars['String']['input']>;
+  planId: Scalars['String']['input'];
+  session: Scalars['String']['input'];
 };
 
 export type ChangePlacesOrderInPlanCandidateOutput = {
@@ -60,11 +73,11 @@ export type ChangePlacesOrderInPlanCandidateOutput = {
 };
 
 export type CreatePlanByGooglePlaceIdInput = {
-  categoriesDisliked?: InputMaybe<Array<Scalars['String']>>;
-  categoriesPreferred?: InputMaybe<Array<Scalars['String']>>;
-  freeTime?: InputMaybe<Scalars['Int']>;
-  googlePlaceId: Scalars['String'];
-  planCandidateId?: InputMaybe<Scalars['String']>;
+  categoriesDisliked?: InputMaybe<Array<Scalars['String']['input']>>;
+  categoriesPreferred?: InputMaybe<Array<Scalars['String']['input']>>;
+  freeTime?: InputMaybe<Scalars['Int']['input']>;
+  googlePlaceId: Scalars['String']['input'];
+  planCandidateId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreatePlanByGooglePlaceIdOutput = {
@@ -73,85 +86,85 @@ export type CreatePlanByGooglePlaceIdOutput = {
 };
 
 export type CreatePlanByLocationInput = {
-  categoriesDisliked?: InputMaybe<Array<Scalars['String']>>;
-  categoriesPreferred?: InputMaybe<Array<Scalars['String']>>;
-  createdBasedOnCurrentLocation?: InputMaybe<Scalars['Boolean']>;
-  freeTime?: InputMaybe<Scalars['Int']>;
-  googlePlaceId?: InputMaybe<Scalars['String']>;
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
-  session?: InputMaybe<Scalars['String']>;
+  categoriesDisliked?: InputMaybe<Array<Scalars['String']['input']>>;
+  categoriesPreferred?: InputMaybe<Array<Scalars['String']['input']>>;
+  createdBasedOnCurrentLocation?: InputMaybe<Scalars['Boolean']['input']>;
+  freeTime?: InputMaybe<Scalars['Int']['input']>;
+  googlePlaceId?: InputMaybe<Scalars['String']['input']>;
+  latitude: Scalars['Float']['input'];
+  longitude: Scalars['Float']['input'];
+  session?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreatePlanByLocationOutput = {
   __typename?: 'CreatePlanByLocationOutput';
   plans: Array<Plan>;
-  session: Scalars['String'];
+  session: Scalars['String']['output'];
 };
 
 export type CreatePlanByPlaceInput = {
-  placeId: Scalars['String'];
-  session: Scalars['String'];
+  placeId: Scalars['String']['input'];
+  session: Scalars['String']['input'];
 };
 
 export type CreatePlanByPlaceOutput = {
   __typename?: 'CreatePlanByPlaceOutput';
   plan: Plan;
-  session: Scalars['String'];
+  session: Scalars['String']['output'];
 };
 
 export type DeletePlaceFromPlanCandidateInput = {
-  placeId: Scalars['String'];
-  planCandidateId: Scalars['String'];
-  planId: Scalars['String'];
+  placeId: Scalars['String']['input'];
+  planCandidateId: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
 };
 
 export type DeletePlaceFromPlanCandidateOutput = {
   __typename?: 'DeletePlaceFromPlanCandidateOutput';
   plan: Plan;
-  planCandidateId: Scalars['String'];
+  planCandidateId: Scalars['String']['output'];
 };
 
 export type EditPlanTitleOfPlanCandidateInput = {
-  planCandidateId: Scalars['String'];
-  planId: Scalars['String'];
-  title: Scalars['String'];
+  planCandidateId: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
+  title: Scalars['String']['input'];
 };
 
 export type EditPlanTitleOfPlanCandidateOutput = {
   __typename?: 'EditPlanTitleOfPlanCandidateOutput';
   plan: Plan;
-  planCandidateId: Scalars['String'];
+  planCandidateId: Scalars['String']['output'];
 };
 
 export type FirebaseUserInput = {
-  firebaseAuthToken: Scalars['String'];
-  firebaseUserId: Scalars['String'];
+  firebaseAuthToken: Scalars['String']['input'];
+  firebaseUserId: Scalars['String']['input'];
 };
 
 export type GeoLocation = {
   __typename?: 'GeoLocation';
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
+  latitude: Scalars['Float']['output'];
+  longitude: Scalars['Float']['output'];
 };
 
 export type GooglePlaceReview = {
   __typename?: 'GooglePlaceReview';
-  authorName: Scalars['String'];
-  authorPhotoUrl?: Maybe<Scalars['String']>;
-  authorUrl?: Maybe<Scalars['String']>;
-  language?: Maybe<Scalars['String']>;
-  originalLanguage?: Maybe<Scalars['String']>;
-  rating: Scalars['Int'];
-  text?: Maybe<Scalars['String']>;
-  time: Scalars['Int'];
+  authorName: Scalars['String']['output'];
+  authorPhotoUrl?: Maybe<Scalars['String']['output']>;
+  authorUrl?: Maybe<Scalars['String']['output']>;
+  language?: Maybe<Scalars['String']['output']>;
+  originalLanguage?: Maybe<Scalars['String']['output']>;
+  rating: Scalars['Int']['output'];
+  text?: Maybe<Scalars['String']['output']>;
+  time: Scalars['Int']['output'];
 };
 
 export type Image = {
   __typename?: 'Image';
-  default: Scalars['String'];
-  large?: Maybe<Scalars['String']>;
-  small?: Maybe<Scalars['String']>;
+  default: Scalars['String']['output'];
+  large?: Maybe<Scalars['String']['output']>;
+  small?: Maybe<Scalars['String']['output']>;
 };
 
 export enum ImageSize {
@@ -160,9 +173,9 @@ export enum ImageSize {
 }
 
 export type LikeToPlaceInPlanCandidateInput = {
-  like: Scalars['Boolean'];
-  placeId: Scalars['String'];
-  planCandidateId: Scalars['String'];
+  like: Scalars['Boolean']['input'];
+  placeId: Scalars['String']['input'];
+  planCandidateId: Scalars['String']['input'];
 };
 
 export type LikeToPlaceInPlanCandidateOutput = {
@@ -172,10 +185,10 @@ export type LikeToPlaceInPlanCandidateOutput = {
 
 export type LocationCategory = {
   __typename?: 'LocationCategory';
-  defaultPhotoUrl: Scalars['String'];
-  displayName: Scalars['String'];
-  name: Scalars['String'];
-  photo?: Maybe<Scalars['String']>;
+  defaultPhotoUrl: Scalars['String']['output'];
+  displayName: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  photo?: Maybe<Scalars['String']['output']>;
 };
 
 export type Mutation = {
@@ -189,7 +202,7 @@ export type Mutation = {
   deletePlaceFromPlanCandidate: DeletePlaceFromPlanCandidateOutput;
   editPlanTitleOfPlanCandidate: EditPlanTitleOfPlanCandidateOutput;
   likeToPlaceInPlanCandidate: LikeToPlaceInPlanCandidateOutput;
-  ping: Scalars['String'];
+  ping: Scalars['String']['output'];
   replacePlaceOfPlanCandidate: ReplacePlaceOfPlanCandidateOutput;
   savePlanFromCandidate: SavePlanFromCandidateOutput;
 };
@@ -241,7 +254,7 @@ export type MutationLikeToPlaceInPlanCandidateArgs = {
 
 
 export type MutationPingArgs = {
-  message: Scalars['String'];
+  message: Scalars['String']['input'];
 };
 
 
@@ -256,46 +269,46 @@ export type MutationSavePlanFromCandidateArgs = {
 
 export type NearbyLocationCategory = {
   __typename?: 'NearbyLocationCategory';
-  defaultPhotoUrl: Scalars['String'];
-  displayName: Scalars['String'];
-  id: Scalars['String'];
+  defaultPhotoUrl: Scalars['String']['output'];
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
   places: Array<Place>;
 };
 
 export type NearbyPlaceCategoriesInput = {
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
+  latitude: Scalars['Float']['input'];
+  longitude: Scalars['Float']['input'];
 };
 
 export type NearbyPlaceCategoryOutput = {
   __typename?: 'NearbyPlaceCategoryOutput';
   categories: Array<NearbyLocationCategory>;
-  planCandidateId: Scalars['ID'];
+  planCandidateId: Scalars['ID']['output'];
 };
 
 export type Place = {
   __typename?: 'Place';
   categories: Array<PlaceCategory>;
-  estimatedStayDuration: Scalars['Int'];
-  googlePlaceId: Scalars['String'];
+  estimatedStayDuration: Scalars['Int']['output'];
+  googlePlaceId: Scalars['String']['output'];
   googleReviews: Array<GooglePlaceReview>;
-  id: Scalars['String'];
+  id: Scalars['String']['output'];
   images: Array<Image>;
-  likeCount: Scalars['Int'];
+  likeCount: Scalars['Int']['output'];
   location: GeoLocation;
-  name: Scalars['String'];
+  name: Scalars['String']['output'];
   priceRange?: Maybe<PriceRange>;
 };
 
 export type PlaceCategory = {
   __typename?: 'PlaceCategory';
-  id: Scalars['String'];
-  name: Scalars['String'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type PlacesToAddForPlanCandidateInput = {
-  planCandidateId: Scalars['ID'];
-  planId: Scalars['ID'];
+  planCandidateId: Scalars['ID']['input'];
+  planId: Scalars['ID']['input'];
 };
 
 export type PlacesToAddForPlanCandidateOutput = {
@@ -304,9 +317,9 @@ export type PlacesToAddForPlanCandidateOutput = {
 };
 
 export type PlacesToReplaceForPlanCandidateInput = {
-  placeId: Scalars['ID'];
-  planCandidateId: Scalars['ID'];
-  planId: Scalars['ID'];
+  placeId: Scalars['ID']['input'];
+  planCandidateId: Scalars['ID']['input'];
+  planId: Scalars['ID']['input'];
 };
 
 export type PlacesToReplaceForPlanCandidateOutput = {
@@ -316,25 +329,25 @@ export type PlacesToReplaceForPlanCandidateOutput = {
 
 export type Plan = {
   __typename?: 'Plan';
-  authorId?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
-  name: Scalars['String'];
+  authorId?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
   places: Array<Place>;
-  timeInMinutes: Scalars['Int'];
+  timeInMinutes: Scalars['Int']['output'];
   transitions: Array<Transition>;
 };
 
 export type PlanCandidate = {
   __typename?: 'PlanCandidate';
-  createdBasedOnCurrentLocation: Scalars['Boolean'];
-  id: Scalars['String'];
-  likedPlaceIds: Array<Scalars['String']>;
+  createdBasedOnCurrentLocation: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
+  likedPlaceIds: Array<Scalars['String']['output']>;
   plans: Array<Plan>;
 };
 
 export type PlanCandidateInput = {
-  planCandidateId: Scalars['ID'];
+  planCandidateId: Scalars['ID']['input'];
 };
 
 export type PlanCandidateOutput = {
@@ -343,20 +356,20 @@ export type PlanCandidateOutput = {
 };
 
 export type PlansByLocationInput = {
-  latitude: Scalars['Float'];
-  limit?: InputMaybe<Scalars['Int']>;
-  longitude: Scalars['Float'];
-  pageKey?: InputMaybe<Scalars['String']>;
+  latitude: Scalars['Float']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  longitude: Scalars['Float']['input'];
+  pageKey?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type PlansByLocationOutput = {
   __typename?: 'PlansByLocationOutput';
-  pageKey?: Maybe<Scalars['String']>;
+  pageKey?: Maybe<Scalars['String']['output']>;
   plans: Array<Plan>;
 };
 
 export type PlansByUserInput = {
-  userId: Scalars['String'];
+  userId: Scalars['String']['input'];
 };
 
 export type PlansByUserOutput = {
@@ -365,31 +378,48 @@ export type PlansByUserOutput = {
   plans: Array<Plan>;
 };
 
+export type PlansInput = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  pageToken?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type PlansOutput = {
+  __typename?: 'PlansOutput';
+  nextPageToken?: Maybe<Scalars['String']['output']>;
+  plans: Array<Plan>;
+};
+
 export type PriceRange = {
   __typename?: 'PriceRange';
-  googlePriceLevel: Scalars['Int'];
-  priceRangeMax: Scalars['Int'];
-  priceRangeMin: Scalars['Int'];
+  googlePriceLevel: Scalars['Int']['output'];
+  priceRangeMax: Scalars['Int']['output'];
+  priceRangeMin: Scalars['Int']['output'];
 };
 
 export type Query = {
   __typename?: 'Query';
   availablePlacesForPlan: AvailablePlacesForPlan;
+  cachedCreatedPlans: CachedCreatedPlans;
   firebaseUser: User;
   nearbyPlaceCategories: NearbyPlaceCategoryOutput;
   placesToAddForPlanCandidate: PlacesToAddForPlanCandidateOutput;
   placesToReplaceForPlanCandidate: PlacesToReplaceForPlanCandidateOutput;
   plan?: Maybe<Plan>;
   planCandidate: PlanCandidateOutput;
-  plans: Array<Plan>;
+  plans: PlansOutput;
   plansByLocation: PlansByLocationOutput;
   plansByUser: PlansByUserOutput;
-  version: Scalars['String'];
+  version: Scalars['String']['output'];
 };
 
 
 export type QueryAvailablePlacesForPlanArgs = {
   input: AvailablePlacesForPlanInput;
+};
+
+
+export type QueryCachedCreatedPlansArgs = {
+  input: CachedCreatedPlansInput;
 };
 
 
@@ -414,7 +444,7 @@ export type QueryPlacesToReplaceForPlanCandidateArgs = {
 
 
 export type QueryPlanArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 
@@ -424,7 +454,7 @@ export type QueryPlanCandidateArgs = {
 
 
 export type QueryPlansArgs = {
-  pageKey?: InputMaybe<Scalars['String']>;
+  input?: InputMaybe<PlansInput>;
 };
 
 
@@ -438,22 +468,22 @@ export type QueryPlansByUserArgs = {
 };
 
 export type ReplacePlaceOfPlanCandidateInput = {
-  placeIdToRemove: Scalars['String'];
-  placeIdToReplace: Scalars['String'];
-  planCandidateId: Scalars['String'];
-  planId: Scalars['String'];
+  placeIdToRemove: Scalars['String']['input'];
+  placeIdToReplace: Scalars['String']['input'];
+  planCandidateId: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
 };
 
 export type ReplacePlaceOfPlanCandidateOutput = {
   __typename?: 'ReplacePlaceOfPlanCandidateOutput';
   plan: Plan;
-  planCandidateId: Scalars['String'];
+  planCandidateId: Scalars['String']['output'];
 };
 
 export type SavePlanFromCandidateInput = {
-  authToken?: InputMaybe<Scalars['String']>;
-  planId: Scalars['String'];
-  session: Scalars['String'];
+  authToken?: InputMaybe<Scalars['String']['input']>;
+  planId: Scalars['String']['input'];
+  session: Scalars['String']['input'];
 };
 
 export type SavePlanFromCandidateOutput = {
@@ -463,16 +493,16 @@ export type SavePlanFromCandidateOutput = {
 
 export type Transition = {
   __typename?: 'Transition';
-  duration: Scalars['Int'];
+  duration: Scalars['Int']['output'];
   from?: Maybe<Place>;
   to: Place;
 };
 
 export type User = {
   __typename?: 'User';
-  id: Scalars['ID'];
-  name: Scalars['String'];
-  photoUrl?: Maybe<Scalars['String']>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  photoUrl?: Maybe<Scalars['String']['output']>;
 };
 
 export type PlaceFullFragmentFragment = { __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null };
@@ -482,31 +512,31 @@ export type PlanFullFragmentFragment = { __typename?: 'Plan', id: string, name: 
 export type PlanCandidateFullFragmentFragment = { __typename?: 'PlanCandidate', id: string, likedPlaceIds: Array<string>, createdBasedOnCurrentLocation: boolean, plans: Array<{ __typename?: 'Plan', id: string, name: string, timeInMinutes: number, authorId?: string | null, places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }>, transitions: Array<{ __typename?: 'Transition', duration: number, from?: { __typename?: 'Place', id: string } | null, to: { __typename?: 'Place', id: string } }> }> };
 
 export type FetchPlansQueryVariables = Exact<{
-  pageKey?: InputMaybe<Scalars['String']>;
+  input: PlansInput;
 }>;
 
 
-export type FetchPlansQuery = { __typename?: 'Query', plans: Array<{ __typename?: 'Plan', id: string, name: string, timeInMinutes: number, places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }>, transitions: Array<{ __typename?: 'Transition', duration: number, from?: { __typename?: 'Place', id: string } | null, to: { __typename?: 'Place', id: string } }> }> };
+export type FetchPlansQuery = { __typename?: 'Query', plans: { __typename?: 'PlansOutput', nextPageToken?: string | null, plans: Array<{ __typename?: 'Plan', id: string, name: string, timeInMinutes: number, places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }>, transitions: Array<{ __typename?: 'Transition', duration: number, from?: { __typename?: 'Place', id: string } | null, to: { __typename?: 'Place', id: string } }> }> } };
 
 export type FetchPlanByIdQueryVariables = Exact<{
-  planId: Scalars['String'];
+  planId: Scalars['String']['input'];
 }>;
 
 
 export type FetchPlanByIdQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, timeInMinutes: number, places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }>, transitions: Array<{ __typename?: 'Transition', duration: number, from?: { __typename?: 'Place', id: string } | null, to: { __typename?: 'Place', id: string } }> } | null };
 
 export type PlansByLocationQueryVariables = Exact<{
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
-  limit?: InputMaybe<Scalars['Int']>;
-  pageKey?: InputMaybe<Scalars['String']>;
+  latitude: Scalars['Float']['input'];
+  longitude: Scalars['Float']['input'];
+  limit?: Maybe<Scalars['Int']['input']>;
+  pageKey?: Maybe<Scalars['String']['input']>;
 }>;
 
 
 export type PlansByLocationQuery = { __typename?: 'Query', plansByLocation: { __typename?: 'PlansByLocationOutput', pageKey?: string | null, plans: Array<{ __typename?: 'Plan', id: string, name: string, timeInMinutes: number, places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }>, transitions: Array<{ __typename?: 'Transition', duration: number, from?: { __typename?: 'Place', id: string } | null, to: { __typename?: 'Place', id: string } }> }> } };
 
 export type PlansByUserQueryVariables = Exact<{
-  userId: Scalars['String'];
+  userId: Scalars['String']['input'];
 }>;
 
 
@@ -534,8 +564,8 @@ export type CreatePlanByLocationMutationVariables = Exact<{
 export type CreatePlanByLocationMutation = { __typename?: 'Mutation', createPlanByLocation: { __typename?: 'CreatePlanByLocationOutput', session: string, plans: Array<{ __typename?: 'Plan', id: string, name: string, timeInMinutes: number, authorId?: string | null, places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }>, transitions: Array<{ __typename?: 'Transition', duration: number, from?: { __typename?: 'Place', id: string } | null, to: { __typename?: 'Place', id: string } }> }> } };
 
 export type CreatePlanByPlaceMutationVariables = Exact<{
-  sessionId: Scalars['String'];
-  placeId: Scalars['String'];
+  sessionId: Scalars['String']['input'];
+  placeId: Scalars['String']['input'];
 }>;
 
 
@@ -563,9 +593,9 @@ export type ReplacePlaceOfPlanCandidateMutationVariables = Exact<{
 export type ReplacePlaceOfPlanCandidateMutation = { __typename?: 'Mutation', replacePlaceOfPlanCandidate: { __typename?: 'ReplacePlaceOfPlanCandidateOutput', planCandidateId: string, plan: { __typename?: 'Plan', id: string, name: string, timeInMinutes: number, authorId?: string | null, places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }>, transitions: Array<{ __typename?: 'Transition', duration: number, from?: { __typename?: 'Place', id: string } | null, to: { __typename?: 'Place', id: string } }> } } };
 
 export type SavePlanFromCandidateMutationVariables = Exact<{
-  session: Scalars['String'];
-  planId: Scalars['String'];
-  authToken?: InputMaybe<Scalars['String']>;
+  session: Scalars['String']['input'];
+  planId: Scalars['String']['input'];
+  authToken?: Maybe<Scalars['String']['input']>;
 }>;
 
 
@@ -586,15 +616,15 @@ export type ChangePlacesOrderInPlanCandidateMutationVariables = Exact<{
 export type ChangePlacesOrderInPlanCandidateMutation = { __typename?: 'Mutation', changePlacesOrderInPlanCandidate: { __typename?: 'ChangePlacesOrderInPlanCandidateOutput', plan: { __typename?: 'Plan', id: string, name: string, timeInMinutes: number, authorId?: string | null, places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }>, transitions: Array<{ __typename?: 'Transition', duration: number, from?: { __typename?: 'Place', id: string } | null, to: { __typename?: 'Place', id: string } }> } } };
 
 export type FetchAvailablePlacesForPlanCandidateQueryVariables = Exact<{
-  session: Scalars['String'];
+  session: Scalars['String']['input'];
 }>;
 
 
 export type FetchAvailablePlacesForPlanCandidateQuery = { __typename?: 'Query', availablePlacesForPlan: { __typename?: 'AvailablePlacesForPlan', places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }> } };
 
 export type NearbyPlaceCategoriesQueryVariables = Exact<{
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
+  latitude: Scalars['Float']['input'];
+  longitude: Scalars['Float']['input'];
 }>;
 
 
@@ -615,15 +645,15 @@ export type PlacesToReplaceForPlanOfPlanCandidateQueryVariables = Exact<{
 export type PlacesToReplaceForPlanOfPlanCandidateQuery = { __typename?: 'Query', placesToReplaceForPlanCandidate: { __typename?: 'PlacesToReplaceForPlanCandidateOutput', places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }> } };
 
 export type PlanCandidateQueryVariables = Exact<{
-  planCandidateId: Scalars['ID'];
+  planCandidateId: Scalars['ID']['input'];
 }>;
 
 
 export type PlanCandidateQuery = { __typename?: 'Query', planCandidate: { __typename?: 'PlanCandidateOutput', planCandidate?: { __typename?: 'PlanCandidate', createdBasedOnCurrentLocation: boolean, likedPlaceIds: Array<string>, plans: Array<{ __typename?: 'Plan', id: string, name: string, timeInMinutes: number, authorId?: string | null, places: Array<{ __typename?: 'Place', id: string, googlePlaceId: string, name: string, estimatedStayDuration: number, likeCount: number, images: Array<{ __typename?: 'Image', default: string, small?: string | null, large?: string | null }>, location: { __typename?: 'GeoLocation', longitude: number, latitude: number }, googleReviews: Array<{ __typename?: 'GooglePlaceReview', rating: number, text?: string | null, authorName: string, authorPhotoUrl?: string | null, authorUrl?: string | null, time: number }>, categories: Array<{ __typename?: 'PlaceCategory', id: string, name: string }>, priceRange?: { __typename?: 'PriceRange', priceRangeMin: number, priceRangeMax: number, googlePriceLevel: number } | null }>, transitions: Array<{ __typename?: 'Transition', duration: number, from?: { __typename?: 'Place', id: string } | null, to: { __typename?: 'Place', id: string } }> }> } | null } };
 
 export type FirebaseUserQueryVariables = Exact<{
-  firebaseUserId: Scalars['String'];
-  firebaseToken: Scalars['String'];
+  firebaseUserId: Scalars['String']['input'];
+  firebaseToken: Scalars['String']['input'];
 }>;
 
 
@@ -637,7 +667,7 @@ export type VersionQuery = { __typename?: 'Query', version: string };
 export const PlaceFullFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlaceFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Place"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"googlePlaceId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"images"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"default"}},{"kind":"Field","name":{"kind":"Name","value":"small"}},{"kind":"Field","name":{"kind":"Name","value":"large"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}},{"kind":"Field","name":{"kind":"Name","value":"estimatedStayDuration"}},{"kind":"Field","name":{"kind":"Name","value":"googleReviews"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rating"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"authorName"}},{"kind":"Field","name":{"kind":"Name","value":"authorPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"authorUrl"}},{"kind":"Field","name":{"kind":"Name","value":"time"}}]}},{"kind":"Field","name":{"kind":"Name","value":"categories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priceRange"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"priceRangeMin"}},{"kind":"Field","name":{"kind":"Name","value":"priceRangeMax"}},{"kind":"Field","name":{"kind":"Name","value":"googlePriceLevel"}}]}},{"kind":"Field","name":{"kind":"Name","value":"likeCount"}}]}}]} as unknown as DocumentNode<PlaceFullFragmentFragment, unknown>;
 export const PlanFullFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlanFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Plan"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"places"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PlaceFullFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"timeInMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"transitions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"from"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"to"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"authorId"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlaceFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Place"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"googlePlaceId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"images"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"default"}},{"kind":"Field","name":{"kind":"Name","value":"small"}},{"kind":"Field","name":{"kind":"Name","value":"large"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}},{"kind":"Field","name":{"kind":"Name","value":"estimatedStayDuration"}},{"kind":"Field","name":{"kind":"Name","value":"googleReviews"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rating"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"authorName"}},{"kind":"Field","name":{"kind":"Name","value":"authorPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"authorUrl"}},{"kind":"Field","name":{"kind":"Name","value":"time"}}]}},{"kind":"Field","name":{"kind":"Name","value":"categories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priceRange"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"priceRangeMin"}},{"kind":"Field","name":{"kind":"Name","value":"priceRangeMax"}},{"kind":"Field","name":{"kind":"Name","value":"googlePriceLevel"}}]}},{"kind":"Field","name":{"kind":"Name","value":"likeCount"}}]}}]} as unknown as DocumentNode<PlanFullFragmentFragment, unknown>;
 export const PlanCandidateFullFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlanCandidateFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PlanCandidate"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"plans"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PlanFullFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"likedPlaceIds"}},{"kind":"Field","name":{"kind":"Name","value":"createdBasedOnCurrentLocation"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlaceFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Place"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"googlePlaceId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"images"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"default"}},{"kind":"Field","name":{"kind":"Name","value":"small"}},{"kind":"Field","name":{"kind":"Name","value":"large"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}},{"kind":"Field","name":{"kind":"Name","value":"estimatedStayDuration"}},{"kind":"Field","name":{"kind":"Name","value":"googleReviews"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rating"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"authorName"}},{"kind":"Field","name":{"kind":"Name","value":"authorPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"authorUrl"}},{"kind":"Field","name":{"kind":"Name","value":"time"}}]}},{"kind":"Field","name":{"kind":"Name","value":"categories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priceRange"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"priceRangeMin"}},{"kind":"Field","name":{"kind":"Name","value":"priceRangeMax"}},{"kind":"Field","name":{"kind":"Name","value":"googlePriceLevel"}}]}},{"kind":"Field","name":{"kind":"Name","value":"likeCount"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlanFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Plan"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"places"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PlaceFullFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"timeInMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"transitions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"from"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"to"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"authorId"}}]}}]} as unknown as DocumentNode<PlanCandidateFullFragmentFragment, unknown>;
-export const FetchPlansDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FetchPlans"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"pageKey"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"plans"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"pageKey"},"value":{"kind":"Variable","name":{"kind":"Name","value":"pageKey"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"places"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PlaceFullFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"timeInMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"transitions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"from"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"to"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlaceFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Place"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"googlePlaceId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"images"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"default"}},{"kind":"Field","name":{"kind":"Name","value":"small"}},{"kind":"Field","name":{"kind":"Name","value":"large"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}},{"kind":"Field","name":{"kind":"Name","value":"estimatedStayDuration"}},{"kind":"Field","name":{"kind":"Name","value":"googleReviews"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rating"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"authorName"}},{"kind":"Field","name":{"kind":"Name","value":"authorPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"authorUrl"}},{"kind":"Field","name":{"kind":"Name","value":"time"}}]}},{"kind":"Field","name":{"kind":"Name","value":"categories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priceRange"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"priceRangeMin"}},{"kind":"Field","name":{"kind":"Name","value":"priceRangeMax"}},{"kind":"Field","name":{"kind":"Name","value":"googlePriceLevel"}}]}},{"kind":"Field","name":{"kind":"Name","value":"likeCount"}}]}}]} as unknown as DocumentNode<FetchPlansQuery, FetchPlansQueryVariables>;
+export const FetchPlansDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FetchPlans"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"PlansInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"plans"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nextPageToken"}},{"kind":"Field","name":{"kind":"Name","value":"plans"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"places"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PlaceFullFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"timeInMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"transitions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"from"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"to"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlaceFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Place"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"googlePlaceId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"images"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"default"}},{"kind":"Field","name":{"kind":"Name","value":"small"}},{"kind":"Field","name":{"kind":"Name","value":"large"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}},{"kind":"Field","name":{"kind":"Name","value":"estimatedStayDuration"}},{"kind":"Field","name":{"kind":"Name","value":"googleReviews"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rating"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"authorName"}},{"kind":"Field","name":{"kind":"Name","value":"authorPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"authorUrl"}},{"kind":"Field","name":{"kind":"Name","value":"time"}}]}},{"kind":"Field","name":{"kind":"Name","value":"categories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priceRange"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"priceRangeMin"}},{"kind":"Field","name":{"kind":"Name","value":"priceRangeMax"}},{"kind":"Field","name":{"kind":"Name","value":"googlePriceLevel"}}]}},{"kind":"Field","name":{"kind":"Name","value":"likeCount"}}]}}]} as unknown as DocumentNode<FetchPlansQuery, FetchPlansQueryVariables>;
 export const FetchPlanByIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FetchPlanById"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"planId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"plan"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"planId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"places"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PlaceFullFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"timeInMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"transitions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"from"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"to"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlaceFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Place"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"googlePlaceId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"images"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"default"}},{"kind":"Field","name":{"kind":"Name","value":"small"}},{"kind":"Field","name":{"kind":"Name","value":"large"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}},{"kind":"Field","name":{"kind":"Name","value":"estimatedStayDuration"}},{"kind":"Field","name":{"kind":"Name","value":"googleReviews"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rating"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"authorName"}},{"kind":"Field","name":{"kind":"Name","value":"authorPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"authorUrl"}},{"kind":"Field","name":{"kind":"Name","value":"time"}}]}},{"kind":"Field","name":{"kind":"Name","value":"categories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priceRange"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"priceRangeMin"}},{"kind":"Field","name":{"kind":"Name","value":"priceRangeMax"}},{"kind":"Field","name":{"kind":"Name","value":"googlePriceLevel"}}]}},{"kind":"Field","name":{"kind":"Name","value":"likeCount"}}]}}]} as unknown as DocumentNode<FetchPlanByIdQuery, FetchPlanByIdQueryVariables>;
 export const PlansByLocationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"PlansByLocation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"latitude"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Float"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"longitude"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Float"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"limit"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"pageKey"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"plansByLocation"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"latitude"},"value":{"kind":"Variable","name":{"kind":"Name","value":"latitude"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"longitude"},"value":{"kind":"Variable","name":{"kind":"Name","value":"longitude"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"limit"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"pageKey"},"value":{"kind":"Variable","name":{"kind":"Name","value":"pageKey"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"pageKey"}},{"kind":"Field","name":{"kind":"Name","value":"plans"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"places"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PlaceFullFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"timeInMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"transitions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"from"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"to"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlaceFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Place"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"googlePlaceId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"images"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"default"}},{"kind":"Field","name":{"kind":"Name","value":"small"}},{"kind":"Field","name":{"kind":"Name","value":"large"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}},{"kind":"Field","name":{"kind":"Name","value":"estimatedStayDuration"}},{"kind":"Field","name":{"kind":"Name","value":"googleReviews"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rating"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"authorName"}},{"kind":"Field","name":{"kind":"Name","value":"authorPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"authorUrl"}},{"kind":"Field","name":{"kind":"Name","value":"time"}}]}},{"kind":"Field","name":{"kind":"Name","value":"categories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priceRange"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"priceRangeMin"}},{"kind":"Field","name":{"kind":"Name","value":"priceRangeMax"}},{"kind":"Field","name":{"kind":"Name","value":"googlePriceLevel"}}]}},{"kind":"Field","name":{"kind":"Name","value":"likeCount"}}]}}]} as unknown as DocumentNode<PlansByLocationQuery, PlansByLocationQueryVariables>;
 export const PlansByUserDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"PlansByUser"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"plansByUser"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"userId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"plans"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"places"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PlaceFullFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"timeInMinutes"}},{"kind":"Field","name":{"kind":"Name","value":"transitions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"from"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"to"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"authorId"}}]}},{"kind":"Field","name":{"kind":"Name","value":"author"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"photoUrl"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PlaceFullFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Place"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"googlePlaceId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"images"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"default"}},{"kind":"Field","name":{"kind":"Name","value":"small"}},{"kind":"Field","name":{"kind":"Name","value":"large"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}},{"kind":"Field","name":{"kind":"Name","value":"estimatedStayDuration"}},{"kind":"Field","name":{"kind":"Name","value":"googleReviews"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rating"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"authorName"}},{"kind":"Field","name":{"kind":"Name","value":"authorPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"authorUrl"}},{"kind":"Field","name":{"kind":"Name","value":"time"}}]}},{"kind":"Field","name":{"kind":"Name","value":"categories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"priceRange"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"priceRangeMin"}},{"kind":"Field","name":{"kind":"Name","value":"priceRangeMax"}},{"kind":"Field","name":{"kind":"Name","value":"googlePriceLevel"}}]}},{"kind":"Field","name":{"kind":"Name","value":"likeCount"}}]}}]} as unknown as DocumentNode<PlansByUserQuery, PlansByUserQueryVariables>;


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- これまではNextPageTokenをporoto側で生成していた
- この修正により、plannerから`nextPageToken`を受け取り、それを用いて次のプランを取得できるようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- https://github.com/poroto-app/planner/pull/394

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] プランが順々に取得できることを確認

```shell
# poroto
export BRANCH_POROTO=feature/plans_query_cursor
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=feature/rdb_repository_replace
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````