### PR TITLE
プランを作成したユーザーの情報を表示する

### DIFF
--- a/src/data/graphql/PlannerGraphQlApi.ts
+++ b/src/data/graphql/PlannerGraphQlApi.ts
@@ -21,11 +21,13 @@ import {
     ReplacePlaceOfPlanCandidateDocument,
     SavePlanFromCandidateDocument,
     UpdateLikeAtPlaceInPlanCandidateDocument,
+    UserFullFragmentFragment,
 } from "src/data/graphql/generated";
 import { GraphQlRepository } from "src/data/graphql/GraphQlRepository";
 import { PlaceEntity } from "src/domain/models/PlaceEntity";
 import { PlanCandidateEntity } from "src/domain/models/PlanCandidateEntity";
 import { PlanEntity } from "src/domain/models/PlanEntity";
+import { UserEntity } from "src/domain/models/UserEntity";
 import {
     AddPlaceToPlanOfPlanCandidateRequest,
     AutoReorderPlacesInPlanCandidateRequest,
@@ -472,6 +474,8 @@ function fromGraphqlPlanEntity(plan: GraphQlPlanEntity): PlanEntity {
             toPlaceId: transition.to.id,
             durationInMinutes: transition.duration,
         })),
+        author:
+            plan.author === null ? null : fromGraphQlUserEntity(plan.author),
     };
 }
 
@@ -512,5 +516,15 @@ function fromGraphqlPlaceEntity(place: GraphQlPlaceEntity): PlaceEntity {
               }
             : null,
         likeCount: place.likeCount,
+    };
+}
+
+function fromGraphQlUserEntity(
+    userEntity: UserFullFragmentFragment
+): UserEntity {
+    return {
+        id: userEntity.id,
+        name: userEntity.name,
+        photoUrl: userEntity.photoUrl ?? null,
     };
 }

--- a/src/domain/factory/Plan.ts
+++ b/src/domain/factory/Plan.ts
@@ -1,12 +1,8 @@
 import { createPlaceFromPlaceEntity } from "src/domain/factory/Place";
 import { Plan } from "src/domain/models/Plan";
 import { PlanEntity } from "src/domain/models/PlanEntity";
-import { User } from "src/domain/models/User";
 
-export function createPlanFromPlanEntity(
-    entity: PlanEntity,
-    author: User | null
-): Plan {
+export function createPlanFromPlanEntity(entity: PlanEntity): Plan {
     return {
         id: entity.id,
         title: entity.title,
@@ -17,6 +13,13 @@ export function createPlanFromPlanEntity(
             toPlaceId: transition.toPlaceId,
             durationInMinutes: transition.durationInMinutes,
         })),
-        author,
+        author:
+            entity.author === null
+                ? null
+                : {
+                      id: entity.author.id,
+                      name: entity.author.name,
+                      avatarImage: entity.author.photoUrl,
+                  },
     };
 }

--- a/src/domain/models/PlanEntity.ts
+++ b/src/domain/models/PlanEntity.ts
@@ -1,4 +1,5 @@
 import { PlaceEntity } from "src/domain/models/PlaceEntity";
+import { UserEntity } from "src/domain/user/UserApi";
 
 export type PlanEntity = {
     id: string;
@@ -15,4 +16,5 @@ export type PlanEntity = {
         priceRangeMax: number;
         googlePriceLevel: number;
     };
+    author: UserEntity | null;
 };

--- a/src/domain/models/UserEntity.ts
+++ b/src/domain/models/UserEntity.ts
@@ -1,0 +1,5 @@
+export type UserEntity = {
+    id: string;
+    name: string;
+    photoUrl: string | null;
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -197,9 +197,8 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
         const response = await plannerApi.fetchPlans({
             pageKey: null,
         });
-        // TODO: ユーザー情報を取得する
         plans = response.plans.map((entity) =>
-            createPlanFromPlanEntity(entity, null)
+            createPlanFromPlanEntity(entity)
         );
         nextPageKey = response.nextPageKey;
     } catch (e) {

--- a/src/redux/editPlanCandidate.ts
+++ b/src/redux/editPlanCandidate.ts
@@ -82,12 +82,12 @@ export const replacePlaceOfPlanCandidate = createAsyncThunk(
 
         dispatch(
             updatePlanOfPlanCandidate({
-                plan: createPlanFromPlanEntity(plan, null),
+                plan: createPlanFromPlanEntity(plan),
             })
         );
 
         return {
-            plan: createPlanFromPlanEntity(plan, null),
+            plan: createPlanFromPlanEntity(plan),
         };
     }
 );
@@ -142,12 +142,12 @@ export const addPlaceToPlanOfPlanCandidate = createAsyncThunk(
 
         dispatch(
             updatePlanOfPlanCandidate({
-                plan: createPlanFromPlanEntity(plan, null),
+                plan: createPlanFromPlanEntity(plan),
             })
         );
 
         return {
-            plan: createPlanFromPlanEntity(plan, null),
+            plan: createPlanFromPlanEntity(plan),
         };
     }
 );
@@ -176,12 +176,12 @@ export const deletePlaceFromPlanOfPlanCandidate = createAsyncThunk(
 
         dispatch(
             updatePlanOfPlanCandidate({
-                plan: createPlanFromPlanEntity(plan, null),
+                plan: createPlanFromPlanEntity(plan),
             })
         );
 
         return {
-            plan: createPlanFromPlanEntity(plan, null),
+            plan: createPlanFromPlanEntity(plan),
         };
     }
 );

--- a/src/redux/plan.ts
+++ b/src/redux/plan.ts
@@ -9,7 +9,6 @@ import {
     RequestStatuses,
 } from "src/domain/models/RequestStatus";
 import { PlannerApi } from "src/domain/plan/PlannerApi";
-import { createUserFromEntity } from "src/domain/user/UserApi";
 import { RootState } from "src/redux/redux";
 
 export type PlanState = {
@@ -73,9 +72,8 @@ export const fetchPlansRecentlyCreated = createAsyncThunk<{
         pageKey: nextPageTokenPlansRecentlyCreated,
     });
 
-    // TODO: ユーザー情報を取得する
     return {
-        plans: plans.map((plan) => createPlanFromPlanEntity(plan, null)),
+        plans: plans.map((plan) => createPlanFromPlanEntity(plan)),
         nextPageToken: nextPageKey,
     };
 });
@@ -100,9 +98,8 @@ export const fetchNearbyPlans = createAsyncThunk(
             limit,
         });
 
-        // TODO: ユーザー情報を取得する
         return {
-            plans: plans.map((plan) => createPlanFromPlanEntity(plan, null)),
+            plans: plans.map((plan) => createPlanFromPlanEntity(plan)),
             nextPageToken: pageKey,
         };
     }
@@ -115,9 +112,7 @@ export const fetchPlan = createAsyncThunk(
         const plannerApi: PlannerApi = new PlannerGraphQlApi();
         const response = await plannerApi.fetchPlan({ planId });
         // TODO: ユーザー情報を取得する
-        return response.plan
-            ? createPlanFromPlanEntity(response.plan, null)
-            : null;
+        return response.plan ? createPlanFromPlanEntity(response.plan) : null;
     }
 );
 
@@ -129,10 +124,9 @@ export const fetchPlansByUser = createAsyncThunk(
     async ({ userId }: FetchPlansByUserProps) => {
         const plannerApi: PlannerApi = new PlannerGraphQlApi();
         const response = await plannerApi.fetchPlansByUser({ userId });
-        const author = createUserFromEntity(response.author);
         return {
             plans: response.plans.map((planEntity) =>
-                createPlanFromPlanEntity(planEntity, author)
+                createPlanFromPlanEntity(planEntity)
             ),
         };
     }

--- a/src/redux/planCandidate.ts
+++ b/src/redux/planCandidate.ts
@@ -117,7 +117,7 @@ export const createPlanFromLocation = createAsyncThunk(
 
         const session = response.session;
         const plans: Plan[] = response.plans.map((planEntity) =>
-            createPlanFromPlanEntity(planEntity, null)
+            createPlanFromPlanEntity(planEntity)
         );
         dispatch(
             setCreatedPlans({
@@ -141,9 +141,8 @@ export const createPlanFromPlace = createAsyncThunk(
             placeId,
             createPlanSessionId,
         });
-        // TODO: ユーザー情報を取得する
         return {
-            plan: createPlanFromPlanEntity(plan, null),
+            plan: createPlanFromPlanEntity(plan),
         };
     }
 );
@@ -170,7 +169,7 @@ export const fetchCachedCreatedPlans = createAsyncThunk(
         }
 
         const plans: Plan[] = response.plans.map((p) =>
-            createPlanFromPlanEntity(p, null)
+            createPlanFromPlanEntity(p)
         );
         return {
             session,
@@ -272,9 +271,8 @@ export const updatePlacesOrderInPlanCandidate = createAsyncThunk(
             planId,
             placeIds,
         });
-        // TODO: ユーザー情報を取得する
         return {
-            plan: createPlanFromPlanEntity(response.plan, null),
+            plan: createPlanFromPlanEntity(response.plan),
         };
     }
 );
@@ -300,7 +298,7 @@ export const updateLikeAtPlaceInPlanCandidate = createAsyncThunk(
             });
         return {
             likedPlaceIds,
-            plans: plans.map((plan) => createPlanFromPlanEntity(plan, null)),
+            plans: plans.map((plan) => createPlanFromPlanEntity(plan)),
         };
     }
 );
@@ -321,7 +319,7 @@ export const autoReorderPlacesInPlanCandidate = createAsyncThunk(
             planId,
         });
         return {
-            plan: createPlanFromPlanEntity(response.plan, null),
+            plan: createPlanFromPlanEntity(response.plan),
         };
     }
 );

--- a/src/stories/mock/plan.ts
+++ b/src/stories/mock/plan.ts
@@ -17,7 +17,11 @@ export const mockPlan: Plan = {
         },
     ],
     places: [mockPlaces.tokyo, mockPlaces.marunouchi],
-    author: null,
+    author: {
+        id: "1",
+        name: "Taro Yamada",
+        avatarImage: "https://placehold.jp/150x150.png",
+    },
 };
 
 const mockPlanBookStore: Plan = {

--- a/src/stories/plan/PlanPreview.stories.tsx
+++ b/src/stories/plan/PlanPreview.stories.tsx
@@ -17,7 +17,11 @@ export const Primary: Story = {
             id: "plan",
             title: "プランタイトル",
             timeInMinutes: 30,
-            author: null,
+            author: {
+                id: "author",
+                name: "Taro Yamada",
+                avatarImage: "https://picsum.photos/450/600",
+            },
             transitions: [
                 {
                     fromPlaceId: mockPlaces.bookStore.id,
@@ -29,6 +33,48 @@ export const Primary: Story = {
         },
     },
 };
+
+export const WoAuthor: Story = {
+    args: {
+        plan: {
+            id: "plan",
+            title: "プランタイトル",
+            timeInMinutes: 30,
+            author: null,
+            transitions: [
+                {
+                    fromPlaceId: mockPlaces.bookStore.id,
+                    toPlaceId: mockPlaces.tokyo.id,
+                    durationInMinutes: 10,
+                },
+            ],
+            places: [mockPlaces.bookStore, mockPlaces.tokyo],
+        },
+    },
+}
+
+export const LongName: Story = {
+    args: {
+        plan: {
+            id: "plan",
+            title: "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum.",
+            timeInMinutes: 30,
+            author: {
+                id: "author",
+                name: "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum.",
+                avatarImage: "https://picsum.photos/450/600",
+            },
+            transitions: [
+                {
+                    fromPlaceId: mockPlaces.bookStore.id,
+                    toPlaceId: mockPlaces.tokyo.id,
+                    durationInMinutes: 10,
+                },
+            ],
+            places: [mockPlaces.bookStore, mockPlaces.tokyo],
+        },
+    },
+}
 
 export const PlaceHolder: Story = {
     args: {

--- a/src/stories/plan/PlanPreview.stories.tsx
+++ b/src/stories/plan/PlanPreview.stories.tsx
@@ -51,7 +51,7 @@ export const WoAuthor: Story = {
             places: [mockPlaces.bookStore, mockPlaces.tokyo],
         },
     },
-}
+};
 
 export const LongName: Story = {
     args: {
@@ -74,7 +74,7 @@ export const LongName: Story = {
             places: [mockPlaces.bookStore, mockPlaces.tokyo],
         },
     },
-}
+};
 
 export const PlaceHolder: Story = {
     args: {

--- a/src/view/plan/PlanPageThumbnail.tsx
+++ b/src/view/plan/PlanPageThumbnail.tsx
@@ -1,4 +1,4 @@
-import { Text, VStack } from "@chakra-ui/react";
+import { Avatar, HStack, Text, VStack } from "@chakra-ui/react";
 import { Plan } from "src/domain/models/Plan";
 import { PlanThumbnail } from "src/view/plan/PlanThumbnail";
 
@@ -12,7 +12,7 @@ export function PlanPageThumbnail({ plan }: Props) {
         .filter((v) => v !== null);
 
     return (
-        <VStack w="100%" alignItems="flex-start" px="16px">
+        <VStack w="100%" alignItems="flex-start" px="16px" pb="16px">
             {thumbnails.length > 0 && <PlanThumbnail images={thumbnails} />}
             <Text
                 as="h1"
@@ -22,6 +22,18 @@ export function PlanPageThumbnail({ plan }: Props) {
             >
                 {plan.title}
             </Text>
+            {plan.author && (
+                <HStack>
+                    <Avatar
+                        size="sm"
+                        name={plan.author.name}
+                        src={plan.author.avatarImage}
+                    />
+                    <Text fontSize="14px" color="#222222">
+                        {plan.author.name}
+                    </Text>
+                </HStack>
+            )}
         </VStack>
     );
 }

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -30,7 +30,7 @@ export function PlanPreview({ plan, link }: Props) {
         .filter((v) => v !== null);
 
     return (
-        <VStack w="100%" maxW="600px" alignItems="flex-start">
+        <VStack w="100%" maxW="600px" alignItems="flex-start" overflow="hidden">
             <PlanThumbnail images={thumbnails} link={link} />
             <LinkWrapper href={link}>
                 <Text fontWeight="bold" fontSize="1.1rem" color="#222222">

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -51,7 +51,9 @@ export function PlanPreview({ plan, link }: Props) {
                         textOverflow="ellipsis"
                         fontSize={12}
                         color="rgba(8, 19, 26, 0.66)"
-                    >{plan.author.name}</Text>
+                    >
+                        {plan.author.name}
+                    </Text>
                 </HStack>
             )}
         </VStack>

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@chakra-ui/next-js";
-import { HStack, Text, VStack } from "@chakra-ui/react";
+import { Avatar, HStack, Text, VStack } from "@chakra-ui/react";
 import { ReactNode } from "react";
 import { Plan } from "src/domain/models/Plan";
 import { PlanThumbnail } from "src/view/plan/PlanThumbnail";
@@ -30,18 +30,30 @@ export function PlanPreview({ plan, link }: Props) {
         .filter((v) => v !== null);
 
     return (
-        <VStack w="100%" maxW="600px">
+        <VStack w="100%" maxW="600px" alignItems="flex-start">
             <PlanThumbnail images={thumbnails} link={link} />
             <LinkWrapper href={link}>
-                <VStack w="100%" alignItems="flex-start" spacing={1}>
-                    <Text fontWeight="bold" fontSize="1.1rem" color="#222222">
-                        {plan.title}
-                    </Text>
-                    <HStack w="100%" justifyContent="flex-start">
-                        {/* TODO: 最初の地点までの徒歩時間を移動距離を表示 */}
-                    </HStack>
-                </VStack>
+                <Text fontWeight="bold" fontSize="1.1rem" color="#222222">
+                    {plan.title}
+                </Text>
             </LinkWrapper>
+            {plan.author && (
+                <HStack w="100%">
+                    <Avatar
+                        name={plan.author.name}
+                        src={plan.author.avatarImage}
+                        size="xs"
+                    />
+                    <Text
+                        w="100%"
+                        overflowX="hidden"
+                        whiteSpace="nowrap"
+                        textOverflow="ellipsis"
+                        fontSize={12}
+                        color="rgba(8, 19, 26, 0.66)"
+                    >{plan.author.name}</Text>
+                </HStack>
+            )}
         </VStack>
     );
 }


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

- プラン一覧ページ、プラン詳細画面で作者の画像と名前が表示されるようにした

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/9e5d9628-9000-4d07-bc2b-b95c97af3c9d)|![image](https://github.com/poroto-app/poroto/assets/55840281/1d9a7cc4-b5ca-47e8-91ed-37222b405ba3)|
|![image](https://github.com/poroto-app/poroto/assets/55840281/c1ccc0d4-e015-4fb1-a090-e5070a9d5aa6)|![image](https://github.com/poroto-app/poroto/assets/55840281/fc3e2342-5468-4adb-a92c-48ff88b85cab)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- https://github.com/poroto-app/planner/pull/415

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 他のユーザーの存在を感じられるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] ログインして作成したプランの場合、ユーザー情報がプラン一覧で表示されることを確認
- [x] ログインして作成したプランの場合、ユーザー情報がプラン詳細画面で表示されることを確認

```shell
# poroto
export BRANCH_POROTO=feature/plan_with_author
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=feature/plan_with_author_data
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````