### PR TITLE
値がDOMに渡らないようにする

### DIFF
--- a/src/view/common/RoundedButton.tsx
+++ b/src/view/common/RoundedButton.tsx
@@ -20,20 +20,21 @@ export function RoundedButton({
         <Rounded
             onClick={onClick}
             disabled={disabled ?? false}
-            outlined={outlined ?? false}
+            $outlined={outlined ?? false}
         >
             {children}
         </Rounded>
     );
 }
 
-const Rounded = styled.div<{ disabled: boolean; outlined: boolean }>`
-    background-color: ${({ disabled, outlined }) =>
-        disabled ? "#8b8b8b" : outlined ? "white" : Colors.primary["400"]};
+const Rounded = styled.div<{ disabled: boolean; $outlined: boolean }>`
+    background-color: ${({ disabled, $outlined }) =>
+        disabled ? "#8b8b8b" : $outlined ? "white" : Colors.primary["400"]};
     border-radius: 100px;
-    border: ${({ outlined }) =>
-        outlined ? `2px solid ${Colors.primary["400"]}` : "none"};
-    color: ${({ outlined }) => (outlined ? Colors.primary["400"] : "#ffffff")};
+    border: ${({ $outlined }) =>
+        $outlined ? `2px solid ${Colors.primary["400"]}` : "none"};
+    color: ${({ $outlined }) =>
+        $outlined ? Colors.primary["400"] : "#ffffff"};
     cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
     display: flex;
     font-weight: bold;


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

場所を検索する画面で発生した以下のエラーを解消した
```
client.js:1 Warning: Received `false` for a non-boolean attribute `outlined`.
If you want to write it to the DOM, pass a string instead: outlined="false" or outlined={value.toString()}.
If you used to conditionally omit it with outlined={condition && value}, pass outlined={condition ? value : undefined} instead.
```
原因はStyledComponentにpropsを渡すときに、DOMに直接描画されない値は`$XXX`のような方法で書かなければいけないということだった。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 場所を検索する画面で提示したエラーが発生しない

```shell
# poroto
export BRANCH_POROTO=feature/styled_components_props
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````