### PR TITLE
トップページでプランの画像を見ようとするとページ遷移をするバグを修正

### DIFF
--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -1,5 +1,7 @@
+import { Link } from "@chakra-ui/next-js";
 import { Splide, SplideSlide } from "@splidejs/react-splide";
 import "@splidejs/splide/css";
+import { ReactNode } from "react";
 import {
     getImageSizeOf,
     Image as ImageType,
@@ -11,6 +13,7 @@ import styled from "styled-components";
 type Props = {
     images: ImageType[];
     imageSize?: ImageSize;
+    href?: string;
     borderRadius?: number | string;
     onClickImage?: (image: ImageType) => void;
 };
@@ -18,6 +21,7 @@ type Props = {
 export function ImageSliderPreview({
     images,
     imageSize = ImageSizes.Large,
+    href,
     borderRadius,
     onClickImage,
 }: Props) {
@@ -32,12 +36,14 @@ export function ImageSliderPreview({
         >
             {images.map((image, i) => (
                 <SlideItem key={i}>
-                    <ImageWithSkeleton
-                        key={i}
-                        src={getImageSizeOf(imageSize, image)}
-                        isGoogleImage={image.isGoogleImage}
-                        onClick={() => onClickImage && onClickImage(image)}
-                    />
+                    <LinkWrapper href={href}>
+                        <ImageWithSkeleton
+                            key={i}
+                            src={getImageSizeOf(imageSize, image)}
+                            isGoogleImage={image.isGoogleImage}
+                            onClick={() => onClickImage && onClickImage(image)}
+                        />
+                    </LinkWrapper>
                 </SlideItem>
             ))}
         </SlideContainer>
@@ -94,3 +100,19 @@ const SlideItem = styled(SplideSlide)`
     width: 100%;
     height: 100%;
 `;
+
+function LinkWrapper({
+    href,
+    children,
+}: {
+    href?: string;
+    children?: ReactNode;
+}) {
+    if (href)
+        return (
+            <Link href={href} w="100%" h="100%">
+                {children}
+            </Link>
+        );
+    return <>{children}</>;
+}

--- a/src/view/plan/PlanThumbnail.tsx
+++ b/src/view/plan/PlanThumbnail.tsx
@@ -1,7 +1,5 @@
-import { Link } from "@chakra-ui/next-js";
 import { Box } from "@chakra-ui/react";
 import "@splidejs/splide/css";
-import { ReactNode } from "react";
 import {
     getDefaultPlaceImage,
     Image,
@@ -27,29 +25,12 @@ export const PlanThumbnail = ({
 
     return (
         <Box w="100%" h="300px">
-            <LinkWrapper href={link}>
-                <ImageSliderPreview
-                    images={images}
-                    imageSize={imageSize}
-                    borderRadius="10px"
-                />
-            </LinkWrapper>
+            <ImageSliderPreview
+                images={images}
+                imageSize={imageSize}
+                borderRadius="10px"
+                href={link}
+            />
         </Box>
     );
 };
-
-function LinkWrapper({
-    href,
-    children,
-}: {
-    href?: string;
-    children?: ReactNode;
-}) {
-    if (href)
-        return (
-            <Link href={href} w="100%" h="100%">
-                {children}
-            </Link>
-        );
-    return <>{children}</>;
-}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- トップページで画像のページングボタンをクリックしたときに、画面遷移がされないように修正
![image](https://github.com/poroto-app/poroto/assets/55840281/f8e3c1c2-b59a-41d8-bd8f-092190a4a159)

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- PC版で画像のスワイプができるようにするため
### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] トップページのプランをクリックすると遷移することを確認
- [x] トップページのプランの画像をページングするボタンをクリックすると前後の画像を見られることを確認

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````