### PR TITLE
プラン候補のRedux Sliceをリファクタ

### DIFF
--- a/src/data/graphql/PlannerGraphQlApi.ts
+++ b/src/data/graphql/PlannerGraphQlApi.ts
@@ -487,8 +487,7 @@ function fromGraphqlPlanEntity(plan: GraphQlPlanEntity): PlanEntity {
             toPlaceId: transition.to.id,
             durationInMinutes: transition.duration,
         })),
-        author:
-            plan.author === null ? null : fromGraphQlUserEntity(plan.author),
+        author: plan.author ? fromGraphQlUserEntity(plan.author) : null,
     };
 }
 

--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -8,10 +8,10 @@ import { setShowPlanCreatedModal } from "src/redux/plan";
 import {
     autoReorderPlacesInPlanCandidate,
     fetchCachedCreatedPlans,
-    updatePreviewPlanId,
     reduxPlanCandidateSelector,
     resetPlanCandidates,
     savePlanFromCandidate,
+    updatePreviewPlanId,
 } from "src/redux/planCandidate";
 import { useAppDispatch } from "src/redux/redux";
 import { ErrorPage } from "src/view/common/ErrorPage";

--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -8,7 +8,7 @@ import { setShowPlanCreatedModal } from "src/redux/plan";
 import {
     autoReorderPlacesInPlanCandidate,
     fetchCachedCreatedPlans,
-    fetchPlanDetail,
+    updatePreviewPlanId,
     reduxPlanCandidateSelector,
     resetPlanCandidates,
     savePlanFromCandidate,
@@ -110,7 +110,7 @@ const PlanDetail = () => {
     useEffect(() => {
         if (!createPlanSession) return;
         if (planId && typeof planId === "string") {
-            dispatch(fetchPlanDetail({ planId }));
+            dispatch(updatePreviewPlanId({ planId }));
         }
     }, [planId, createPlanSession]);
 

--- a/src/redux/planCandidate.ts
+++ b/src/redux/planCandidate.ts
@@ -17,16 +17,12 @@ import { RootState } from "src/redux/redux";
 
 export type PlanCandidateState = {
     createPlanSession: string | null;
+    planIdPreview: string | null;
     likedPlaceIds: string[] | null;
     createdBasedOnCurrentLocation: boolean | null;
     plansCreated: Plan[] | null;
     placesAvailableForPlan: Place[] | null;
 
-    // TODO: 取得中か存在しないのかを見分けられるようにする
-    //  （画面に大きく依存するもののため、専用のsliceを作成する）
-    // TODO: preview id等で対象のplan idを指定し、`plansCreated`の更新に反応できるようにする
-    planIdPreview: string | null;
-    // preview: Plan | null;
 
     categoryCandidates: LocationCategoryWithPlace[] | null;
     categoriesAccepted: LocationCategory[] | null;

--- a/src/redux/planCandidate.ts
+++ b/src/redux/planCandidate.ts
@@ -341,7 +341,7 @@ export const slice = createSlice({
                 payload.createdBasedOnCurrentLocation;
             state.likedPlaceIds = [];
         },
-        fetchPlanDetail: (
+        updatePreviewPlanId: (
             state,
             { payload }: PayloadAction<{ planId: string }>
         ) => {
@@ -634,7 +634,7 @@ export const slice = createSlice({
 });
 
 export const {
-    fetchPlanDetail,
+    updatePreviewPlanId,
 
     setCreatedPlans,
     updatePlanOfPlanCandidate,

--- a/src/redux/planCandidate.ts
+++ b/src/redux/planCandidate.ts
@@ -23,7 +23,6 @@ export type PlanCandidateState = {
     plansCreated: Plan[] | null;
     placesAvailableForPlan: Place[] | null;
 
-
     categoryCandidates: LocationCategoryWithPlace[] | null;
     categoriesAccepted: LocationCategory[] | null;
     categoriesRejected: LocationCategory[] | null;
@@ -436,13 +435,16 @@ export const slice = createSlice({
             );
             if (planIndexToUpdate < 0) return;
 
-            const isContainsAllPlacesIds = state.plansCreated[planIndexToUpdate].places.some(
-                (place) => !payload.placeIds.includes(place.id)
-            );
+            const isContainsAllPlacesIds = state.plansCreated[
+                planIndexToUpdate
+            ].places.some((place) => !payload.placeIds.includes(place.id));
             if (isContainsAllPlacesIds) return;
 
-            state.plansCreated[planIndexToUpdate].places = payload.placeIds.map((placeId) =>
-                state.plansCreated[planIndexToUpdate].places.find((place) => place.id === placeId)
+            state.plansCreated[planIndexToUpdate].places = payload.placeIds.map(
+                (placeId) =>
+                    state.plansCreated[planIndexToUpdate].places.find(
+                        (place) => place.id === placeId
+                    )
             );
         },
     },
@@ -653,7 +655,9 @@ export const {
 const { reorderPlacesInPreview } = slice.actions;
 
 export const reduxPlanCandidateSelector = () => {
-    const planCandidateState = useSelector((state: RootState) => state.planCandidate);
+    const planCandidateState = useSelector(
+        (state: RootState) => state.planCandidate
+    );
 
     const planCandidatePreview = planCandidateState.plansCreated?.find(
         (plan) => plan.id === planCandidateState.planIdPreview
@@ -663,6 +667,6 @@ export const reduxPlanCandidateSelector = () => {
         ...planCandidateState,
         preview: planCandidatePreview,
     };
-}
+};
 
 export const planCandidateReducer = slice.reducer;


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- 作成されたプラン候補の中から一つを選択し、プラン詳細画面を開くときの状態管理方法をリファクタした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 今までは作成されたプラン一覧のなかから対応するプランを取得し、`preview`という変数にコピーを作成していた
- この方法では現在参照しているプランの内容を書き換えるときに`preview`とプラン一覧の両方を更新する必要があった。
- そこで、コピーを作成するかわりに一覧の中から、`preview`に対応する最新のデータを抜き出せるようにした
- これにより、一覧を編集すると、`preview`に相当する部分も更新されるようになった
### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] プラン一覧のなかから特定のプランを選択し、表示できることを確認
- [x] 場所の追加・並び替え操作がリアルタイムに反映されることを確認 

```shell
# poroto
export BRANCH_POROTO=feature/refactor_plan_candidate_preview
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````