### PR TITLE
[UI修正] プラン詳細画面のヘッダーが見きれないようにする

### DIFF
--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -76,9 +76,7 @@ export default function PlanPage() {
             <NavBar />
             <Box
                 w="100%"
-                h={`calc(100vh - ${Size.NavBar.height})`}
-                minH="700px"
-                maxH="850px"
+                minH={`calc(100vh - ${Size.NavBar.height})`}
             >
                 <PlanDetailPageHeader
                     plan={plan}

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -1,4 +1,4 @@
-import { Box, Center, useToast, VStack } from "@chakra-ui/react";
+import { Center, useToast, VStack } from "@chakra-ui/react";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
@@ -99,12 +99,12 @@ export default function PlanPage() {
                 spacing="16px"
                 pb="32px"
             >
-                <Box w="100%">
+                <PlanPageSection title="プランの情報">
                     <PlanInfoSection
                         durationInMinutes={plan.timeInMinutes}
                         priceRange={getPlanPriceRange(plan.places)}
                     />
-                </Box>
+                </PlanPageSection>
                 <PlanPageSection title="プラン">
                     {/*TODO: ログインユーザーがLIKEした場所を反映できるようにする*/}
                     <PlanPlaceList plan={plan} likePlaceIds={[]} />

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -2,6 +2,7 @@ import { Box, Center, useToast, VStack } from "@chakra-ui/react";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
+import { getPlanPriceRange } from "src/domain/models/Plan";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import {
     fetchPlan,
@@ -14,6 +15,7 @@ import { LoadingModal } from "src/view/common/LoadingModal";
 import { NavBar } from "src/view/common/NavBar";
 import { NotFound } from "src/view/common/NotFound";
 import { Size } from "src/view/constants/size";
+import { isPC } from "src/view/constants/userAgent";
 import { SavePlanAsImageButton } from "src/view/plan/button/SavePlanAsImageButton";
 import { SearchRouteByGoogleMapButton } from "src/view/plan/button/SearchRouteByGoogleMapButton";
 import { PlaceMap } from "src/view/plan/PlaceMap";
@@ -21,6 +23,7 @@ import { PlanCreatedDialog } from "src/view/plan/PlanCreatedDialog";
 import { FooterHeight } from "src/view/plan/PlanFooter";
 import { PlanPageSection } from "src/view/plan/section/PlanPageSection";
 import { PlanDetailPageHeader } from "src/view/plandetail/header/PlanDetailPageHeader";
+import { PlanInfoSection } from "src/view/plandetail/PlanInfoSection";
 import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
 
 export default function PlanPage() {
@@ -74,9 +77,9 @@ export default function PlanPage() {
                 <title>{plan.title} | poroto</title>
             </Head>
             <NavBar />
-            <Box
+            <VStack
                 w="100%"
-                minH={`calc(100vh - ${Size.NavBar.height})`}
+                minH={!isPC && `calc(100vh - ${Size.NavBar.height})`}
             >
                 <PlanDetailPageHeader
                     plan={plan}
@@ -86,7 +89,7 @@ export default function PlanPage() {
                     onUpdateLikePlace={() => 0}
                     onCopyPlanUrl={handleOnCopyPlanUrl}
                 />
-            </Box>
+            </VStack>
             <VStack
                 maxWidth="990px"
                 w="100%"
@@ -96,6 +99,12 @@ export default function PlanPage() {
                 spacing="16px"
                 pb="32px"
             >
+                <Box w="100%">
+                    <PlanInfoSection
+                        durationInMinutes={plan.timeInMinutes}
+                        priceRange={getPlanPriceRange(plan.places)}
+                    />
+                </Box>
                 <PlanPageSection title="プラン">
                     {/*TODO: ログインユーザーがLIKEした場所を反映できるようにする*/}
                     <PlanPlaceList plan={plan} likePlaceIds={[]} />

--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -190,6 +190,12 @@ const PlanDetail = () => {
                     spacing="16px"
                     boxSizing="border-box"
                 >
+                    <PlanPageSection title="プランの情報">
+                        <PlanInfoSection
+                            durationInMinutes={plan.timeInMinutes}
+                            priceRange={getPlanPriceRange(plan.places)}
+                        />
+                    </PlanPageSection>
                     <PlanPageSection title="プラン">
                         <PlanPlaceList
                             plan={plan}

--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -172,9 +172,7 @@ const PlanDetail = () => {
                 />
                 <Box
                     w="100%"
-                    h={`calc(100vh - ${Size.NavBar.height} - ${FooterHeight}px)`}
-                    minH="700px"
-                    maxH="850px"
+                    minH={`calc(100vh - ${Size.NavBar.height} - ${FooterHeight}px)`}
                 >
                     <PlanDetailPageHeader
                         plan={plan}

--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -174,7 +174,10 @@ const PlanDetail = () => {
                 />
                 <VStack
                     w="100%"
-                    minH={!isPC && `calc(100vh - ${Size.NavBar.height} - ${FooterHeight}px)`}
+                    minH={
+                        !isPC &&
+                        `calc(100vh - ${Size.NavBar.height} - ${FooterHeight}px)`
+                    }
                 >
                     <PlanDetailPageHeader
                         plan={plan}

--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -1,8 +1,8 @@
-import { Box, Button, Center, VStack } from "@chakra-ui/react";
+import { Button, Center, VStack } from "@chakra-ui/react";
 import { getAuth } from "@firebase/auth";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
-import { Plan } from "src/domain/models/Plan";
+import { getPlanPriceRange, Plan } from "src/domain/models/Plan";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { setShowPlanCreatedModal } from "src/redux/plan";
 import {
@@ -21,6 +21,7 @@ import { NotFound } from "src/view/common/NotFound";
 import { Colors } from "src/view/constants/color";
 import { Routes } from "src/view/constants/router";
 import { Size } from "src/view/constants/size";
+import { isPC } from "src/view/constants/userAgent";
 import { useLocation } from "src/view/hooks/useLocation";
 import { usePlaceLikeInPlanCandidate } from "src/view/hooks/usePlaceLikeInPlanCandidate";
 import { usePlanPlaceAdd } from "src/view/hooks/usePlanPlaceAdd";
@@ -34,6 +35,7 @@ import { DialogAddPlace } from "src/view/plancandidate/DialogAddPlace";
 import { DialogDeletePlace } from "src/view/plancandidate/DialogDeletePlace";
 import { DialogReplacePlace } from "src/view/plancandidate/DialogReplacePlace";
 import { PlanDetailPageHeader } from "src/view/plandetail/header/PlanDetailPageHeader";
+import { PlanInfoSection } from "src/view/plandetail/PlanInfoSection";
 import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
 
 const PlanDetail = () => {
@@ -170,9 +172,9 @@ const PlanDetail = () => {
                         sessionId as string
                     )}
                 />
-                <Box
+                <VStack
                     w="100%"
-                    minH={`calc(100vh - ${Size.NavBar.height} - ${FooterHeight}px)`}
+                    minH={!isPC && `calc(100vh - ${Size.NavBar.height} - ${FooterHeight}px)`}
                 >
                     <PlanDetailPageHeader
                         plan={plan}
@@ -181,7 +183,7 @@ const PlanDetail = () => {
                             updateLikeAtPlace({ placeId, like: isLiked })
                         }
                     />
-                </Box>
+                </VStack>
                 <VStack
                     maxWidth="990px"
                     w="100%"

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -5,6 +5,7 @@ export const Size = {
         height: "50px",
     },
     PlanDetailHeader: {
+        maxH: "900px",
         maxW: "500px",
         px: "16px",
         imageH: "300px",

--- a/src/view/plandetail/PlanInfoSection.tsx
+++ b/src/view/plandetail/PlanInfoSection.tsx
@@ -1,0 +1,35 @@
+import { SimpleGrid } from "@chakra-ui/react";
+import { PriceRange } from "src/domain/models/PriceRange";
+import {
+    PlanInfoTagBudget,
+    PlanInfoTagDuration,
+} from "src/view/plandetail/header/PlanInfoTag";
+
+export function PlanInfoSection({
+    durationInMinutes,
+    priceRange,
+}: {
+    durationInMinutes: number;
+    priceRange: PriceRange;
+}) {
+    return (
+        <SimpleGrid
+            columns={{ base: 1, md: 2 }}
+            spacing={2}
+            w="100%"
+            alignSelf="center"
+            overflowX="auto"
+            flexWrap={"wrap"}
+            scrollSnapType="x mandatory"
+            scrollPaddingLeft="16px"
+        >
+            <PlanInfoTagDuration durationInMinutes={durationInMinutes} />
+            {(priceRange.min !== 0 || priceRange.max !== 0) && (
+                <PlanInfoTagBudget
+                    minBudget={priceRange.min}
+                    maxBudget={priceRange.max}
+                />
+            )}
+        </SimpleGrid>
+    );
+}

--- a/src/view/plandetail/PlanInfoSection.tsx
+++ b/src/view/plandetail/PlanInfoSection.tsx
@@ -1,5 +1,6 @@
-import { SimpleGrid } from "@chakra-ui/react";
+import { HStack } from "@chakra-ui/react";
 import { PriceRange } from "src/domain/models/PriceRange";
+import { isPC } from "src/view/constants/userAgent";
 import {
     PlanInfoTagBudget,
     PlanInfoTagDuration,
@@ -13,13 +14,12 @@ export function PlanInfoSection({
     priceRange: PriceRange;
 }) {
     return (
-        <SimpleGrid
-            columns={{ base: 1, md: 2 }}
+        <HStack
             spacing={2}
             w="100%"
             alignSelf="center"
             overflowX="auto"
-            flexWrap={"wrap"}
+            flexWrap={isPC ? "wrap" : "nowrap"}
             scrollSnapType="x mandatory"
             scrollPaddingLeft="16px"
         >
@@ -30,6 +30,6 @@ export function PlanInfoSection({
                     maxBudget={priceRange.max}
                 />
             )}
-        </SimpleGrid>
+        </HStack>
     );
 }

--- a/src/view/plandetail/header/PlaceImageGallery.tsx
+++ b/src/view/plandetail/header/PlaceImageGallery.tsx
@@ -39,6 +39,7 @@ export const PlaceImageGallery = ({
                 scale={5}
                 margin={4}
                 blur={5}
+                contrast={500}
                 src={getImageSizeOf(
                     ImageSizes.Large,
                     places[currentPage].images[0]
@@ -148,11 +149,13 @@ function AmbientBackgroundImage({
     scale,
     margin,
     blur,
+    contrast,
 }: {
     src: string;
     scale: number;
     margin: number;
     blur: number;
+    contrast: number;
 }) {
     return (
         <Center
@@ -170,7 +173,7 @@ function AmbientBackgroundImage({
                 objectFit="cover"
                 backgroundColor="black"
                 transform={`scale(${scale})`}
-                filter={`blur(${blur}px)`}
+                filter={`contrast(${contrast}%)  blur(${blur}px)`}
                 src={src}
             />
         </Center>

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -1,9 +1,9 @@
 import {
     Avatar,
     Box,
+    Center,
     HStack,
     Icon,
-    SimpleGrid,
     Text,
     useMediaQuery,
     VStack,
@@ -11,15 +11,10 @@ import {
 import { useState } from "react";
 import { MdLink } from "react-icons/md";
 import { ImageSize } from "src/domain/models/Image";
-import { getPlanPriceRange, Plan } from "src/domain/models/Plan";
-import { PriceRange } from "src/domain/models/PriceRange";
+import { Plan } from "src/domain/models/Plan";
 import { Size } from "src/view/constants/size";
 import { PlaceImageGallery } from "src/view/plandetail/header/PlaceImageGallery";
 import { PlaceList } from "src/view/plandetail/header/PlaceList";
-import {
-    PlanInfoTagBudget,
-    PlanInfoTagDuration,
-} from "src/view/plandetail/header/PlanInfoTag";
 
 type Props = {
     plan: Plan;
@@ -29,7 +24,6 @@ type Props = {
     onCopyPlanUrl?: () => void;
 };
 
-// TODO: プラン候補ページに配置する
 export function PlanDetailPageHeader({
     plan,
     likedPlaceIds,
@@ -45,6 +39,7 @@ export function PlanDetailPageHeader({
     );
     return (
         <VStack
+            flex={1}
             w="100%"
             h="100%"
             py="32px"
@@ -52,36 +47,37 @@ export function PlanDetailPageHeader({
             spacing="16px"
             overflow="hidden"
         >
-            <Box px={Size.PlanDetailHeader.px} zIndex={0}>
-                <PlaceImageGallery
-                    places={placesWithImages}
-                    currentPage={currentPage}
-                    likedPlaceIds={likedPlaceIds}
-                    onUpdateLikePlace={onUpdateLikePlace}
-                    onPageChange={(page) => setCurrentPage(page)}
-                />
-            </Box>
-            <Box
-                zIndex={1}
-                alignSelf="center"
-                w={!isLargerThanHeaderWidth && "100%"}
-                maxW={
-                    isLargerThanHeaderWidth
-                        ? "100%"
-                        : Size.PlanDetailHeader.maxW
-                }
-            >
-                <PlaceList
-                    places={plan.places}
-                    onClickPlace={({ index }) => setCurrentPage(index)}
-                />
-            </Box>
+            <VStack w="100%" flex={1}>
+                <Center px={Size.PlanDetailHeader.px} flex={1} zIndex={0}>
+                    <PlaceImageGallery
+                        places={placesWithImages}
+                        currentPage={currentPage}
+                        likedPlaceIds={likedPlaceIds}
+                        onUpdateLikePlace={onUpdateLikePlace}
+                        onPageChange={(page) => setCurrentPage(page)}
+                    />
+                </Center>
+                <Box
+                    zIndex={1}
+                    alignSelf="center"
+                    w={!isLargerThanHeaderWidth && "100%"}
+                    maxW={
+                        isLargerThanHeaderWidth
+                            ? "100%"
+                            : Size.PlanDetailHeader.maxW
+                    }
+                >
+                    <PlaceList
+                        places={plan.places}
+                        onClickPlace={({ index }) => setCurrentPage(index)}
+                    />
+                </Box>
+            </VStack>
             <VStack
                 w="100%"
                 spacing="16px"
                 alignItems="flex-start"
                 justifyContent="flex-end"
-                flex={1}
                 zIndex={1}
             >
                 <VStack
@@ -106,16 +102,6 @@ export function PlanDetailPageHeader({
                         </HStack>
                     )}
                 </VStack>
-                <Box
-                    alignSelf="center"
-                    w="100%"
-                    maxW={Size.PlanDetailHeader.maxW}
-                >
-                    <PlanInfoSection
-                        durationInMinutes={plan.timeInMinutes}
-                        priceRange={getPlanPriceRange(plan.places)}
-                    />
-                </Box>
                 <HStack
                     w="100%"
                     maxW={Size.PlanDetailHeader.maxW}
@@ -145,35 +131,5 @@ export function PlanDetailPageHeader({
                 </HStack>
             </VStack>
         </VStack>
-    );
-}
-
-function PlanInfoSection({
-    durationInMinutes,
-    priceRange,
-}: {
-    durationInMinutes: number;
-    priceRange: PriceRange;
-}) {
-    return (
-        <SimpleGrid
-            columns={{ base: 1, md: 2 }}
-            spacing={2}
-            w="100%"
-            px={Size.PlanDetailHeader.px}
-            alignSelf="center"
-            overflowX="auto"
-            flexWrap={"wrap"}
-            scrollSnapType="x mandatory"
-            scrollPaddingLeft="16px"
-        >
-            <PlanInfoTagDuration durationInMinutes={durationInMinutes} />
-            {(priceRange.min !== 0 || priceRange.max !== 0) && (
-                <PlanInfoTagBudget
-                    minBudget={priceRange.min}
-                    maxBudget={priceRange.max}
-                />
-            )}
-        </SimpleGrid>
     );
 }

--- a/src/view/plandetail/header/PlanInfoTag.tsx
+++ b/src/view/plandetail/header/PlanInfoTag.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const PlanInfoTag = ({ title, icon, children }: Props) => {
     return (
-        <Box display="inline-block" whiteSpace="nowrap">
+        <Box display="inline-block" whiteSpace="nowrap" flex={1}>
             <HStack
                 backgroundColor="white"
                 border="1px solid rgba(0,0,0,.2)"

--- a/src/view/plandetail/header/PlanInfoTag.tsx
+++ b/src/view/plandetail/header/PlanInfoTag.tsx
@@ -14,14 +14,15 @@ export const PlanInfoTag = ({ title, icon, children }: Props) => {
     return (
         <Box display="inline-block" whiteSpace="nowrap">
             <HStack
-                backgroundColor="rgba(255,255,255,0.8)"
+                backgroundColor="white"
+                border="1px solid rgba(0,0,0,.2)"
                 borderRadius="10px"
                 px="12px"
                 py="8px"
                 spacing={4}
             >
                 <Center
-                    backgroundColor="#C5C5C5"
+                    backgroundColor="#EFEEEE"
                     w="48px"
                     h="48px"
                     borderRadius="10px"

--- a/src/view/plandetail/header/PlanInfoTag.tsx
+++ b/src/view/plandetail/header/PlanInfoTag.tsx
@@ -22,7 +22,7 @@ export const PlanInfoTag = ({ title, icon, children }: Props) => {
                 spacing={4}
             >
                 <Center
-                    backgroundColor="#EFEEEE"
+                    backgroundColor="#F9ECDD"
                     w="48px"
                     h="48px"
                     borderRadius="10px"


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- 要素が多いため、画面の高さから見切れた要素が閲覧できない状態になっていた不具合を修正

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/1bdfed76-96c0-4503-aed1-0a1339ed990b)|![image](https://github.com/poroto-app/poroto/assets/55840281/cc0675c4-d167-46ab-bda8-bffd7a7533f5)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 保存されたプランの画面を確認
- [x] プラン候補の詳細画面を確認 

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````