### PR TITLE
ログインユーザーに紐づくプランが一件もない場合にプレースホルダーが表示されてしまう不具合を修正

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -41,6 +41,7 @@ const IndexPage = (props: Props) => {
         nextPageTokenPlansRecentlyCreated,
         plansByUser,
         fetchPlansRecentlyCreatedRequestStatus,
+        fetchPlansByUserRequestStatus,
     } = reduxPlanSelector();
     const { user } = reduxAuthSelector();
 
@@ -85,7 +86,7 @@ const IndexPage = (props: Props) => {
                     pb="48px"
                     spacing="24px"
                 >
-                    {user && (
+                    {plansByUser && plansByUser.length > 0 && (
                         <PlanList plans={plansByUser}>
                             <Text
                                 as="h2"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -131,7 +131,7 @@ const IndexPage = (props: Props) => {
 
 const NearByPlans = () => {
     const dispatch = useAppDispatch();
-    const { plansNearby } = reduxPlanSelector();
+    const { plansNearby, fetchNearbyPlansRequestStatus } = reduxPlanSelector();
     const {
         fetchCurrentLocationStatus,
         isLocationPermissionGranted,
@@ -140,6 +140,8 @@ const NearByPlans = () => {
     } = useLocation();
 
     const handleOnFetchNearByPlans = async () => {
+        // TODO: 現在地取得中のダイアログを表示する
+        // (Arcというブラウザで開くと現在地取得にものすごい時間がかかってずっとプレースホルダーが表示される)
         const currentLocation = await getCurrentLocation();
         if (!currentLocation) return;
         dispatch(fetchNearbyPlans({ currentLocation, limit: 5 }));
@@ -179,7 +181,13 @@ const NearByPlans = () => {
     };
 
     return (
-        <PlanList plans={plansNearby} empty={emptyComponent()}>
+        <PlanList
+            plans={plansNearby}
+            empty={emptyComponent()}
+            isLoading={
+                fetchNearbyPlansRequestStatus === RequestStatuses.PENDING
+            }
+        >
             <PlanListSectionTitle section={PlanSections.NearBy} />
         </PlanList>
     );

--- a/src/redux/plan.ts
+++ b/src/redux/plan.ts
@@ -16,7 +16,6 @@ export type PlanState = {
     nextPageTokenPlansRecentlyCreated: string | null;
 
     plansNearby: Plan[] | null;
-    plansNearbyRequestStatus: RequestStatus | null;
     nextPageTokenPlansNearby: string | null;
 
     plansByUser: Plan[] | null;
@@ -27,6 +26,7 @@ export type PlanState = {
     showPlanCreatedModal: boolean;
 
     fetchPlansRecentlyCreatedRequestStatus: RequestStatus | null;
+    fetchNearbyPlansRequestStatus: RequestStatus | null;
     fetchPlanRequestStatus: RequestStatus | null;
     fetchPlansByUserRequestStatus: RequestStatus | null;
 };
@@ -36,7 +36,6 @@ const initialState: PlanState = {
     nextPageTokenPlansRecentlyCreated: null,
 
     plansNearby: null,
-    plansNearbyRequestStatus: null,
     nextPageTokenPlansNearby: null,
 
     plansByUser: null,
@@ -46,6 +45,7 @@ const initialState: PlanState = {
     showPlanCreatedModal: false,
 
     fetchPlansRecentlyCreatedRequestStatus: null,
+    fetchNearbyPlansRequestStatus: null,
     fetchPlanRequestStatus: null,
     fetchPlansByUserRequestStatus: null,
 };
@@ -209,19 +209,19 @@ export const slice = createSlice({
                     RequestStatuses.REJECTED;
             })
             // Fetch Nearby Plans
-            .addCase(fetchNearbyPlans.pending, (state) => {
-                state.plansNearbyRequestStatus = RequestStatuses.PENDING;
+            .addCase(fetchNearbyPlans.pending, (state, action) => {
+                state.fetchNearbyPlansRequestStatus = RequestStatuses.PENDING;
             })
             .addCase(fetchNearbyPlans.fulfilled, (state, { payload }) => {
-                state.plansNearbyRequestStatus = RequestStatuses.FULFILLED;
+                state.fetchNearbyPlansRequestStatus = RequestStatuses.FULFILLED;
                 if (!payload) return;
 
                 if (state.plansNearby === null) state.plansNearby = [];
                 state.plansNearby.push(...payload.plans);
                 state.nextPageTokenPlansNearby = payload.nextPageToken;
             })
-            .addCase(fetchNearbyPlans.rejected, (state) => {
-                state.plansNearbyRequestStatus = RequestStatuses.REJECTED;
+            .addCase(fetchNearbyPlans.rejected, (state, action) => {
+                state.fetchNearbyPlansRequestStatus = RequestStatuses.REJECTED;
             });
     },
 });

--- a/src/stories/mock/user.ts
+++ b/src/stories/mock/user.ts
@@ -1,0 +1,7 @@
+import { User } from "src/domain/models/User";
+
+export const mockUser: User = {
+    id: "test",
+    name: "Alice",
+    avatarImage: "https://placehold.jp/150x150.png",
+};

--- a/src/stories/plan/PlanList.stories.tsx
+++ b/src/stories/plan/PlanList.stories.tsx
@@ -20,3 +20,29 @@ export const Primary: Story = {
         })),
     },
 };
+
+export const Null: Story = {
+    args: {
+        plans: null,
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        plans: null,
+        isLoading: true,
+    },
+};
+
+export const Empty: Story = {
+    args: {
+        plans: [],
+    },
+};
+
+export const EmptyWithComponent: Story = {
+    args: {
+        plans: [],
+        empty: <p>Empty</p>,
+    },
+};

--- a/src/stories/plan/PlanListUser.stories.tsx
+++ b/src/stories/plan/PlanListUser.stories.tsx
@@ -1,0 +1,46 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { createArrayWithSize } from "src/domain/util/array";
+import { mockPlan } from "src/stories/mock/plan";
+import { mockUser } from "src/stories/mock/user";
+import { PlanListUser } from "src/view/plan/PlanListUser";
+
+export default {
+    title: "plan/PlanListUser",
+    component: PlanListUser,
+    tags: ["autodocs"],
+    parameters: {},
+} as Meta<typeof PlanListUser>;
+
+type Story = StoryObj<typeof PlanListUser>;
+
+export const Primary: Story = {
+    args: {
+        user: mockUser,
+        plans: createArrayWithSize(5).map((i) => ({
+            id: i,
+            ...mockPlan,
+        })),
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        user: mockUser,
+        plans: null,
+        isLoading: true,
+    },
+};
+
+export const Empty: Story = {
+    args: {
+        user: mockUser,
+        plans: [],
+    },
+};
+
+export const NotLogin: Story = {
+    args: {
+        user: null,
+        plans: [],
+    },
+};

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -9,24 +9,23 @@ import { AdInPlanList } from "../ad/AdInPlanList";
 
 type Props = {
     children?: ReactNode;
+    isLoading?: boolean;
     plans: Plan[] | null;
     empty?: ReactNode;
 };
 
-export function PlanList({ plans, children, empty }: Props) {
+export function PlanList({ plans, isLoading = false, children, empty }: Props) {
     return (
         <VStack w="100%" spacing={4} alignItems="center">
             {children}
-            {plans === null || plans.length === 0 ? (
-                empty ? (
-                    empty
-                ) : (
-                    <GridLayout>
-                        {createArrayWithSize(6).map((i) => (
-                            <PlanPreview key={i} plan={null} />
-                        ))}
-                    </GridLayout>
-                )
+            {!plans || isLoading ? (
+                <GridLayout>
+                    {createArrayWithSize(6).map((i) => (
+                        <PlanPreview key={i} plan={null} />
+                    ))}
+                </GridLayout>
+            ) : plans.length === 0 && empty ? (
+                empty
             ) : (
                 <GridLayout>
                     {plans.map((plan, index) => (

--- a/src/view/plan/PlanListUser.tsx
+++ b/src/view/plan/PlanListUser.tsx
@@ -1,0 +1,30 @@
+import { Text } from "@chakra-ui/react";
+import { Plan } from "src/domain/models/Plan";
+import { User } from "src/domain/models/User";
+import { PlanList } from "src/view/plan/PlanList";
+
+type Props = {
+    user: User | null;
+    plans: Plan[];
+    isLoading?: boolean;
+};
+
+export function PlanListUser({ user, plans, isLoading = false }: Props) {
+    if (!user) return <></>;
+
+    return (
+        <PlanList plans={plans} isLoading={isLoading}>
+            <Text
+                as="h2"
+                fontSize="20px"
+                fontWeight="bold"
+                w="100%"
+                maxW="600px"
+                textAlign="center"
+                py="16x"
+            >
+                保存したプラン
+            </Text>
+        </PlanList>
+    );
+}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

- ログインユーザーに紐づくプランがない場合は何も表示しない
- TODO: 付近のプランが無いときと同様に専用のコンポーネントを表示する

|before| after（プランがない場合） |  after |
|---|-------| --- |
|<img width="410" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/3e8fb589-b257-46f1-803f-85cbebdcc647">|<img width="421" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/80b98f6e-66ff-4b35-aefe-9b7a3a3459ab">|<img width="415" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/82bbb5fb-c941-4a35-b045-873a92a43328">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] storybookですべての状態に対応できていることを確認：http://localhost:6006/?path=/docs/plan-planlist--docs
- [x] ログインユーザーに紐づくプランが一度もない場合にプレースホルダーが表示されないことを確認
- [x] ログインユーザーに紐づくプランがある場合はそれが表示されることを確認  

```shell
# poroto
export BRANCH_POROTO=feature/fix_saved_user_plans
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````