### PR TITLE
画像のアンビエントブラーのコントラストを弱くする

### DIFF
--- a/src/view/plandetail/header/PlaceImageGallery.tsx
+++ b/src/view/plandetail/header/PlaceImageGallery.tsx
@@ -39,7 +39,7 @@ export const PlaceImageGallery = ({
                 scale={5}
                 margin={4}
                 blur={5}
-                contrast={500}
+                contrast={120}
                 src={getImageSizeOf(
                     ImageSizes.Large,
                     places[currentPage].images[0]


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|<img width="479" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/ee976ab0-3a06-41f9-be02-49cacb684cfe">|<img width="675" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/75d730ac-4502-42cc-b0d1-175f22c0b0d6">|
|<img width="658" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/9b10edac-637b-4e5a-9556-4825e754c65b">|<img width="701" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/a534ed0e-a3ab-4598-991d-37d5893a6a61">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 茶や青の画像が来ると背景色が強くなりすぎてしまうため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 茶や青の画像が使われる場所を確認（`四十八漁場 町田駅前店`, `東京都庭園美術館`）

```shell
# poroto
export BRANCH_POROTO=feature/card_blur_contrast
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````