### PR TITLE
プラン詳細ページに広告を配置

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -28,6 +28,7 @@ declare global {
             // ==============================
             ADSENSE_CLIENT: string
             ADSENSE_SLOT_TOP_PAGE_IN_ARTICLE: string
+            ADSENSE_SLOT_PLAN_DETAIL_IN_ARTICLE: string
         }
     }
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -38,8 +38,10 @@ const nextConfig = {
         PLANNER_API_ENDPOINT: `${process.env.PLANNER_API_PROTOCOL}://${process.env.PLANNER_API_HOST}`,
         GCP_API_KEY: process.env.GCP_API_KEY,
 
+        // Google Adsense
         ADSENSE_CLIENT: process.env.ADSENSE_CLIENT,
         ADSENSE_SLOT_TOP_PAGE_IN_ARTICLE: process.env.ADSENSE_SLOT_TOP_PAGE_IN_ARTICLE,
+        ADSENSE_SLOT_PLAN_DETAIL_IN_ARTICLE: process.env.ADSENSE_SLOT_PLAN_DETAIL_IN_ARTICLE,
 
         FIREBASE_API_KEY: process.env.FIREBASE_API_KEY,
         FIREBASE_AUTH_DOMAIN: process.env.FIREBASE_AUTH_DOMAIN,

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -10,6 +10,7 @@ import {
     setShowPlanCreatedModal,
 } from "src/redux/plan";
 import { useAppDispatch } from "src/redux/redux";
+import { AdInPlanDetail } from "src/view/ad/AdInPlanDetail";
 import { ErrorPage } from "src/view/common/ErrorPage";
 import { LoadingModal } from "src/view/common/LoadingModal";
 import { NavBar } from "src/view/common/NavBar";
@@ -100,10 +101,13 @@ export default function PlanPage() {
                 pb="32px"
             >
                 <PlanPageSection title="プランの情報">
-                    <PlanInfoSection
-                        durationInMinutes={plan.timeInMinutes}
-                        priceRange={getPlanPriceRange(plan.places)}
-                    />
+                    <VStack>
+                        <PlanInfoSection
+                            durationInMinutes={plan.timeInMinutes}
+                            priceRange={getPlanPriceRange(plan.places)}
+                        />
+                        <AdInPlanDetail />
+                    </VStack>
                 </PlanPageSection>
                 <PlanPageSection title="プラン">
                     {/*TODO: ログインユーザーがLIKEした場所を反映できるようにする*/}

--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -14,6 +14,7 @@ import {
     updatePreviewPlanId,
 } from "src/redux/planCandidate";
 import { useAppDispatch } from "src/redux/redux";
+import { AdInPlanDetail } from "src/view/ad/AdInPlanDetail";
 import { ErrorPage } from "src/view/common/ErrorPage";
 import { LoadingModal } from "src/view/common/LoadingModal";
 import { NavBar } from "src/view/common/NavBar";
@@ -196,10 +197,13 @@ const PlanDetail = () => {
                     boxSizing="border-box"
                 >
                     <PlanPageSection title="プランの情報">
-                        <PlanInfoSection
-                            durationInMinutes={plan.timeInMinutes}
-                            priceRange={getPlanPriceRange(plan.places)}
-                        />
+                        <VStack>
+                            <PlanInfoSection
+                                durationInMinutes={plan.timeInMinutes}
+                                priceRange={getPlanPriceRange(plan.places)}
+                            />
+                            <AdInPlanDetail />
+                        </VStack>
                     </PlanPageSection>
                     <PlanPageSection title="プラン">
                         <PlanPlaceList

--- a/src/view/ad/AdInPlanDetail.tsx
+++ b/src/view/ad/AdInPlanDetail.tsx
@@ -1,0 +1,42 @@
+import { Box, Center, Text } from "@chakra-ui/react";
+import { GoogleAdsense } from "src/view/ad/GoogleAdsense";
+
+export function AdInPlanDetail() {
+    return (
+        <Box w="100%">
+            <AdComponent />
+        </Box>
+    );
+}
+
+function AdComponent() {
+    if (process.env.APP_ENV !== "production") {
+        return (
+            <Center
+                w="100%"
+                h="100%"
+                minH="200px"
+                maxW="100%"
+                backgroundColor="#EEEEEE"
+                userSelect="none"
+            >
+                <Text>Infeed</Text>
+            </Center>
+        );
+    }
+
+    return (
+        // 記事内広告では、最低50pxの高さが必要
+        <GoogleAdsense
+            format="fluid"
+            parentStyle={{ width: "100%", height: "100%" }}
+            style={{
+                margin: "0 auto",
+                minHeight: "200px",
+                textAlign: "center",
+            }}
+            layout="in-article"
+            slot={process.env.ADSENSE_SLOT_PLAN_DETAIL_IN_ARTICLE}
+        />
+    );
+}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

- 修正対象
  - 保存済みプラン
  - 作成中のプラン

|before| after |
|---|-------|
||<img width="403" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/9625a2da-708f-47c4-8d1b-0c6c5a9f8ead">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- https://github.com/poroto-app/infrastructure/pull/40

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- より多くの場所で広告が表示されるようにするため
- ユーザーにストレスをかけることなく広告を表示するため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プラン詳細ページに広告が配置されていることを確認
- [x] 保存済みプランのページに広告が配置されていることを確認 

```shell
# poroto
export BRANCH_POROTO=feature/ads_in_plan_detail
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````