### PR TITLE
近くのプランを表示するコンポーネントのバグを修正

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,7 +9,6 @@ import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { PlannerApi } from "src/domain/plan/PlannerApi";
 import { reduxAuthSelector } from "src/redux/auth";
 import {
-    fetchNearbyPlans,
     fetchPlansByUser,
     fetchPlansRecentlyCreated,
     pushPlansRecentlyCreated,
@@ -19,11 +18,10 @@ import {
 import { useAppDispatch } from "src/redux/redux";
 import { NavBar } from "src/view/common/NavBar";
 import { Size } from "src/view/constants/size";
-import { useLocation } from "src/view/hooks/useLocation";
+import { useNearbyPlans } from "src/view/hooks/useNearbyPlans";
+import { NearbyPlanList } from "src/view/plan/NearbyPlanList";
 import { PlanList } from "src/view/plan/PlanList";
 import { CreatePlanSection } from "src/view/top/CreatePlanSection";
-import { LocationUnavailable } from "src/view/top/LocationUnavailable";
-import { NearbyPlansNotFound } from "src/view/top/NearbyPlansNotFound";
 import {
     PlanListSectionTitle,
     PlanSections,
@@ -43,6 +41,13 @@ const IndexPage = (props: Props) => {
         fetchPlansRecentlyCreatedRequestStatus,
         fetchPlansByUserRequestStatus,
     } = reduxPlanSelector();
+    const {
+        plansNearby,
+        locationPermission,
+        isFetchingCurrentLocation,
+        isFetchingNearbyPlans,
+        fetchNearbyPlans,
+    } = useNearbyPlans();
     const { user } = reduxAuthSelector();
 
     useEffect(() => {
@@ -102,7 +107,13 @@ const IndexPage = (props: Props) => {
                         </PlanList>
                     )}
                     {/* TODO: 拒否設定されている場合の対処をする */}
-                    <NearByPlans />
+                    <NearbyPlanList
+                        plans={plansNearby}
+                        locationPermission={locationPermission}
+                        isFetchingCurrentLocation={isFetchingCurrentLocation}
+                        isFetchingNearbyPlans={isFetchingNearbyPlans}
+                        onRequestFetchNearByPlans={fetchNearbyPlans}
+                    />
                     {/* TODO: React 18に対応 */}
                     {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
                     {/* @ts-ignore */}
@@ -126,70 +137,6 @@ const IndexPage = (props: Props) => {
                 </VStack>
             </Center>
         </VStack>
-    );
-};
-
-const NearByPlans = () => {
-    const dispatch = useAppDispatch();
-    const { plansNearby, fetchNearbyPlansRequestStatus } = reduxPlanSelector();
-    const {
-        fetchCurrentLocationStatus,
-        isLocationPermissionGranted,
-        checkGeolocationPermission,
-        getCurrentLocation,
-    } = useLocation();
-
-    const handleOnFetchNearByPlans = async () => {
-        // TODO: 現在地取得中のダイアログを表示する
-        // (Arcというブラウザで開くと現在地取得にものすごい時間がかかってずっとプレースホルダーが表示される)
-        const currentLocation = await getCurrentLocation();
-        if (!currentLocation) return;
-        dispatch(fetchNearbyPlans({ currentLocation, limit: 5 }));
-    };
-
-    // 位置情報が利用可能な場合は付近で作成されたプランを取得する
-    useEffect(() => {
-        const fetchNearbyPlansWithCurrentLocation = async () => {
-            const isGranted = await checkGeolocationPermission();
-            if (!isGranted) return;
-
-            await handleOnFetchNearByPlans();
-        };
-
-        fetchNearbyPlansWithCurrentLocation().then();
-    }, []);
-
-    const emptyComponent = () => {
-        if (
-            // 位置情報取得が拒否されていることを確認した場合のみ表示する
-            isLocationPermissionGranted === false
-        ) {
-            return (
-                <LocationUnavailable
-                    isUpdating={
-                        fetchCurrentLocationStatus === RequestStatuses.PENDING
-                    }
-                    isLocationAvailable={isLocationPermissionGranted}
-                    onClickSwitch={handleOnFetchNearByPlans}
-                />
-            );
-        }
-
-        if (plansNearby !== null && plansNearby.length === 0) {
-            return <NearbyPlansNotFound />;
-        }
-    };
-
-    return (
-        <PlanList
-            plans={plansNearby}
-            empty={emptyComponent()}
-            isLoading={
-                fetchNearbyPlansRequestStatus === RequestStatuses.PENDING
-            }
-        >
-            <PlanListSectionTitle section={PlanSections.NearBy} />
-        </PlanList>
     );
 };
 

--- a/src/stories/plan/NearbyPlanList.stories.tsx
+++ b/src/stories/plan/NearbyPlanList.stories.tsx
@@ -1,0 +1,72 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { mockPlans } from "src/stories/mock/plan";
+import { LocationPermissions } from "src/view/hooks/useLocation";
+import { NearbyPlanList } from "src/view/plan/NearbyPlanList";
+
+export default {
+    title: "plan/NearbyPlanList",
+    component: NearbyPlanList,
+    tags: ["autodocs"],
+    parameters: {},
+} as Meta<typeof NearbyPlanList>;
+
+type Story = StoryObj<typeof NearbyPlanList>;
+
+export const Primary: Story = {
+    args: {
+        plans: [mockPlans.cafe, mockPlans.bookStore, mockPlans.tokyo],
+        locationPermission: LocationPermissions.GRANTED,
+        isFetchingNearbyPlans: false,
+        isFetchingCurrentLocation: false,
+    },
+};
+
+export const Empty: Story = {
+    args: {
+        plans: [],
+        locationPermission: LocationPermissions.GRANTED,
+        isFetchingNearbyPlans: false,
+        isFetchingCurrentLocation: false,
+        onRequestFetchNearByPlans: () => 0,
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        plans: null,
+        locationPermission: LocationPermissions.GRANTED,
+        isFetchingNearbyPlans: true,
+        isFetchingCurrentLocation: false,
+        onRequestFetchNearByPlans: () => 0,
+    },
+};
+
+export const LocationPending: Story = {
+    args: {
+        plans: null,
+        locationPermission: LocationPermissions.PROMPT,
+        isFetchingNearbyPlans: false,
+        isFetchingCurrentLocation: false,
+        onRequestFetchNearByPlans: () => 0,
+    },
+};
+
+export const FetchingCurrentLocation: Story = {
+    args: {
+        plans: null,
+        locationPermission: LocationPermissions.GRANTED,
+        isFetchingNearbyPlans: false,
+        isFetchingCurrentLocation: true,
+        onRequestFetchNearByPlans: () => 0,
+    },
+};
+
+export const LocationUnavailable: Story = {
+    args: {
+        plans: null,
+        locationPermission: LocationPermissions.DENIED,
+        isFetchingNearbyPlans: false,
+        isFetchingCurrentLocation: false,
+        onRequestFetchNearByPlans: () => 0,
+    },
+};

--- a/src/stories/top/LocationUnavailable.stories.tsx
+++ b/src/stories/top/LocationUnavailable.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
+import { LocationPermissions } from "src/view/hooks/useLocation";
 import { LocationUnavailable } from "src/view/top/LocationUnavailable";
-import {LocationPermissions} from "src/view/hooks/useLocation";
 
 export default {
     title: "top/LocationUnavailable",

--- a/src/stories/top/LocationUnavailable.stories.tsx
+++ b/src/stories/top/LocationUnavailable.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { LocationUnavailable } from "src/view/top/LocationUnavailable";
+import {LocationPermissions} from "src/view/hooks/useLocation";
 
 export default {
     title: "top/LocationUnavailable",
@@ -13,7 +14,7 @@ type Story = StoryObj<typeof LocationUnavailable>;
 export const Primary: Story = {
     args: {
         isUpdating: false,
-        isLocationAvailable: false,
+        locationPermission: LocationPermissions.DENIED,
         onClickSwitch: () => {
             console.log("onClickSwitch");
         },

--- a/src/view/hooks/useLocation.ts
+++ b/src/view/hooks/useLocation.ts
@@ -75,11 +75,13 @@ export const useLocation = () => {
                 const currentLocation = await fetchCurrentLocation();
                 setLocation(currentLocation);
                 setRequestStatus(RequestStatuses.FULFILLED);
+                setLocationPermission(LocationPermissions.GRANTED);
                 setIsPermissionGranted(true);
                 return currentLocation;
             } catch (e) {
                 setLocation(null);
                 setRequestStatus(RequestStatuses.REJECTED);
+                setLocationPermission(LocationPermissions.DENIED);
                 setIsPermissionGranted(false);
                 return null;
             }

--- a/src/view/hooks/useLocation.ts
+++ b/src/view/hooks/useLocation.ts
@@ -5,6 +5,14 @@ import {
     RequestStatuses,
 } from "src/domain/models/RequestStatus";
 
+export const LocationPermissions = {
+    GRANTED: "GRANTED",
+    DENIED: "DENIED",
+    PROMPT: "PROMPT",
+};
+export type LocationPermission =
+    (typeof LocationPermissions)[keyof typeof LocationPermissions];
+
 const fetchCurrentLocation = async (): Promise<GeoLocation | null> => {
     if (!navigator.geolocation) {
         console.info("cannot use the geolocation API");
@@ -31,9 +39,12 @@ export const useLocation = () => {
     const [requestStatus, setRequestStatus] = useState<RequestStatus | null>(
         null
     );
+    // TODO: DELETE ME!
     const [isPermissionGranted, setIsPermissionGranted] = useState<
         boolean | null
     >(null);
+    const [locationPermission, setLocationPermission] =
+        useState<LocationPermission | null>(null);
 
     const checkGeolocationPermission = async (): Promise<boolean> => {
         const result = await navigator.permissions.query({
@@ -41,6 +52,19 @@ export const useLocation = () => {
         });
         const isGranted = result.state === "granted";
         setIsPermissionGranted(isGranted);
+
+        switch (result.state) {
+            case "granted":
+                setLocationPermission(LocationPermissions.GRANTED);
+                break;
+            case "prompt":
+                setLocationPermission(LocationPermissions.PROMPT);
+                break;
+            case "denied":
+                setLocationPermission(LocationPermissions.DENIED);
+                break;
+        }
+
         return isGranted;
     };
 
@@ -74,6 +98,7 @@ export const useLocation = () => {
     }, []);
 
     return {
+        locationPermission,
         isLocationPermissionGranted: isPermissionGranted,
         fetchCurrentLocationStatus: requestStatus,
         location,

--- a/src/view/hooks/useNearbyPlans.tsx
+++ b/src/view/hooks/useNearbyPlans.tsx
@@ -18,8 +18,6 @@ export const useNearbyPlans = () => {
     } = useLocation();
 
     const fetchNearbyPlans = async (): Promise<void> => {
-        // TODO: 現在地取得中のダイアログを表示する
-        // (Arcというブラウザで開くと現在地取得にものすごい時間がかかってずっとプレースホルダーが表示される)
         const currentLocation = await getCurrentLocation();
         if (!currentLocation) return;
         dispatch(fetchNearbyPlansAction({ currentLocation, limit: 5 }));

--- a/src/view/hooks/useNearbyPlans.tsx
+++ b/src/view/hooks/useNearbyPlans.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { RequestStatuses } from "src/domain/models/RequestStatus";
+import {
+    fetchNearbyPlans as fetchNearbyPlansAction,
+    reduxPlanSelector,
+} from "src/redux/plan";
+import { useAppDispatch } from "src/redux/redux";
+import { useLocation } from "src/view/hooks/useLocation";
+
+export const useNearbyPlans = () => {
+    const dispatch = useAppDispatch();
+    const { plansNearby, fetchNearbyPlansRequestStatus } = reduxPlanSelector();
+    const {
+        locationPermission,
+        fetchCurrentLocationStatus,
+        checkGeolocationPermission,
+        getCurrentLocation,
+    } = useLocation();
+
+    const fetchNearbyPlans = async (): Promise<void> => {
+        // TODO: 現在地取得中のダイアログを表示する
+        // (Arcというブラウザで開くと現在地取得にものすごい時間がかかってずっとプレースホルダーが表示される)
+        const currentLocation = await getCurrentLocation();
+        if (!currentLocation) return;
+        dispatch(fetchNearbyPlansAction({ currentLocation, limit: 5 }));
+    };
+
+    // 位置情報が利用可能な場合は付近で作成されたプランを取得する
+    useEffect(() => {
+        const fetchNearbyPlansWithCurrentLocation = async () => {
+            const isGranted = await checkGeolocationPermission();
+            if (!isGranted) return;
+
+            await fetchNearbyPlans();
+        };
+
+        fetchNearbyPlansWithCurrentLocation().then();
+    }, []);
+
+    return {
+        plansNearby,
+        locationPermission,
+        fetchNearbyPlans,
+        isFetchingCurrentLocation:
+            fetchCurrentLocationStatus === RequestStatuses.PENDING,
+        isFetchingNearbyPlans:
+            fetchNearbyPlansRequestStatus === RequestStatuses.PENDING,
+    };
+};

--- a/src/view/plan/NearbyPlanList.tsx
+++ b/src/view/plan/NearbyPlanList.tsx
@@ -1,4 +1,5 @@
 import { Plan } from "src/domain/models/Plan";
+import { isPC } from "src/view/constants/userAgent";
 import {
     LocationPermission,
     LocationPermissions,
@@ -38,6 +39,7 @@ export function NearbyPlanList({
                 />
             }
             isLoading={isFetchingNearbyPlans}
+            numPlaceHolders={isPC ? 3 : 1}
         >
             <PlanListSectionTitle section={PlanSections.NearBy} />
         </PlanList>

--- a/src/view/plan/NearbyPlanList.tsx
+++ b/src/view/plan/NearbyPlanList.tsx
@@ -1,0 +1,74 @@
+import { Plan } from "src/domain/models/Plan";
+import {
+    LocationPermission,
+    LocationPermissions,
+} from "src/view/hooks/useLocation";
+import { PlanList } from "src/view/plan/PlanList";
+import { LocationUnavailable } from "src/view/top/LocationUnavailable";
+import { NearbyPlansNotFound } from "src/view/top/NearbyPlansNotFound";
+import {
+    PlanListSectionTitle,
+    PlanSections,
+} from "src/view/top/PlanListSectionTitle";
+
+type Props = {
+    plans: Plan[] | null;
+    locationPermission: LocationPermission | null;
+    isFetchingNearbyPlans: boolean;
+    isFetchingCurrentLocation: boolean;
+    onRequestFetchNearByPlans: () => void;
+};
+
+export function NearbyPlanList({
+    plans,
+    locationPermission,
+    isFetchingNearbyPlans,
+    isFetchingCurrentLocation,
+    onRequestFetchNearByPlans,
+}: Props) {
+    return (
+        <PlanList
+            plans={plans}
+            empty={
+                <Empty
+                    plans={plans}
+                    locationPermission={locationPermission}
+                    isFetchingCurrentLocation={isFetchingCurrentLocation}
+                    onRequestFetchNearByPlans={onRequestFetchNearByPlans}
+                />
+            }
+            isLoading={isFetchingNearbyPlans}
+        >
+            <PlanListSectionTitle section={PlanSections.NearBy} />
+        </PlanList>
+    );
+}
+
+export function Empty({
+    plans,
+    locationPermission,
+    isFetchingCurrentLocation,
+    onRequestFetchNearByPlans,
+}: {
+    plans: Plan[] | null;
+    locationPermission: LocationPermission | null;
+    isFetchingCurrentLocation: boolean;
+    onRequestFetchNearByPlans: () => void;
+}) {
+    if (
+        locationPermission !== LocationPermissions.GRANTED ||
+        isFetchingCurrentLocation
+    ) {
+        return (
+            <LocationUnavailable
+                locationPermission={locationPermission}
+                isUpdating={isFetchingCurrentLocation}
+                onClickSwitch={onRequestFetchNearByPlans}
+            />
+        );
+    }
+
+    if (!!plans && plans.length === 0) {
+        return <NearbyPlansNotFound />;
+    }
+}

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -15,31 +15,51 @@ type Props = {
 };
 
 export function PlanList({ plans, isLoading = false, children, empty }: Props) {
-    return (
-        <VStack w="100%" spacing={4} alignItems="center">
-            {children}
-            {!plans || isLoading ? (
+    if (!plans || plans.length == 0 || isLoading) {
+        if (empty && !isLoading) {
+            return (
+                <Container>
+                    {children}
+                    {empty}
+                </Container>
+            );
+        }
+
+        return (
+            <Container>
+                {children}
                 <GridLayout>
                     {createArrayWithSize(6).map((i) => (
                         <PlanPreview key={i} plan={null} />
                     ))}
                 </GridLayout>
-            ) : plans.length === 0 && empty ? (
-                empty
-            ) : (
-                <GridLayout>
-                    {plans.map((plan, index) => (
-                        <>
-                            <PlanPreview
-                                key={index}
-                                link={Routes.plans.plan(plan.id)}
-                                plan={plan}
-                            />
-                            {(index + 1) % 6 === 0 && <AdInPlanList />}
-                        </>
-                    ))}
-                </GridLayout>
-            )}
+            </Container>
+        );
+    }
+
+    return (
+        <Container>
+            {children}
+            <GridLayout>
+                {plans.map((plan, index) => (
+                    <>
+                        <PlanPreview
+                            key={index}
+                            link={Routes.plans.plan(plan.id)}
+                            plan={plan}
+                        />
+                        {(index + 1) % 6 === 0 && <AdInPlanList />}
+                    </>
+                ))}
+            </GridLayout>
+        </Container>
+    );
+}
+
+function Container({ children }: { children: ReactNode }) {
+    return (
+        <VStack w="100%" spacing={4} alignItems="center">
+            {children}
         </VStack>
     );
 }

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -11,10 +11,17 @@ type Props = {
     children?: ReactNode;
     isLoading?: boolean;
     plans: Plan[] | null;
+    numPlaceHolders?: number;
     empty?: ReactNode;
 };
 
-export function PlanList({ plans, isLoading = false, children, empty }: Props) {
+export function PlanList({
+    plans,
+    isLoading = false,
+    children,
+    empty,
+    numPlaceHolders = 6,
+}: Props) {
     if (!plans || plans.length == 0 || isLoading) {
         if (empty && !isLoading) {
             return (
@@ -29,7 +36,7 @@ export function PlanList({ plans, isLoading = false, children, empty }: Props) {
             <Container>
                 {children}
                 <GridLayout>
-                    {createArrayWithSize(6).map((i) => (
+                    {createArrayWithSize(numPlaceHolders).map((i) => (
                         <PlanPreview key={i} plan={null} />
                     ))}
                 </GridLayout>

--- a/src/view/top/LocationUnavailable.tsx
+++ b/src/view/top/LocationUnavailable.tsx
@@ -31,7 +31,9 @@ export function LocationUnavailable({
                 }}
             />
             <Text fontWeight="bold" fontSize="20px">
-                位置情報をオンにしてプランを取得
+                {locationPermission === LocationPermissions.DENIED
+                    ? "設定から位置情報を許可してください"
+                    : "位置情報をオンにしてプランを取得"}
             </Text>
             <Switch
                 size="lg"

--- a/src/view/top/LocationUnavailable.tsx
+++ b/src/view/top/LocationUnavailable.tsx
@@ -31,7 +31,9 @@ export function LocationUnavailable({
                 }}
             />
             <Text fontWeight="bold" fontSize="20px">
-                {locationPermission === LocationPermissions.DENIED
+                {locationPermission === LocationPermissions.GRANTED
+                    ? "近くのプランを探しています..."
+                    : locationPermission === LocationPermissions.DENIED
                     ? "設定から位置情報を許可してください"
                     : "位置情報をオンにしてプランを取得"}
             </Text>

--- a/src/view/top/LocationUnavailable.tsx
+++ b/src/view/top/LocationUnavailable.tsx
@@ -1,19 +1,23 @@
 import { Switch, Text, VStack } from "@chakra-ui/react";
 import MapIcon from "src/view/assets/svg/map.svg";
+import {
+    LocationPermission,
+    LocationPermissions,
+} from "src/view/hooks/useLocation";
 
 type Props = {
+    locationPermission: LocationPermission | null;
     isUpdating: boolean;
-    isLocationAvailable: boolean;
     onClickSwitch: () => void;
 };
 
 export function LocationUnavailable({
+    locationPermission,
     isUpdating,
-    isLocationAvailable,
     onClickSwitch,
 }: Props) {
     const handleOnClickSwitch = () => {
-        if (isLocationAvailable) return;
+        if (locationPermission === LocationPermissions.GRANTED) return;
         onClickSwitch();
     };
 
@@ -31,7 +35,10 @@ export function LocationUnavailable({
             </Text>
             <Switch
                 size="lg"
-                isChecked={isUpdating || isLocationAvailable}
+                isChecked={
+                    isUpdating ||
+                    locationPermission === LocationPermissions.GRANTED
+                }
                 isDisabled={isUpdating}
                 onChange={handleOnClickSwitch}
             />


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

位置情報が拒否されているときに、プレースホルダーではなくメッセージが表示されるように修正した

||before| after |
|---|---|-------|
|許可未設定時|<img width="1262" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/61296d41-8c56-4ecd-897a-ac1bd92b5546">|<img width="1278" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/d7005079-2e38-4a4d-84d1-3c4eb3222341">|
|拒否時|<img width="1187" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/2f39d238-4cdc-4082-9ac7-a793675da3b5">|<img width="997" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/23c13096-2f38-4f7d-93a0-bd0d138a636c">|
### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] storybook上で挙動を確認（http://localhost:6006/?path=/docs/plan-nearbyplanlist--docs）
- [x] ブラウザから権限をリセットし、拒否設定を行ったときに「設定から許可する」ようにメッセージが表示される
- [x] ブラウザから権限をリセットし、許可設定を行ったときに取得中のメッセージが表示される
<img width="683" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/1991b19b-b859-4e4b-ada8-950388ce740b">
 

```shell
# poroto
export BRANCH_POROTO=feature/nearby_plan_list
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````