### PR TITLE
プランを保存した直後にダイアログが表示されるようにする

### DIFF
--- a/.github/workflows/build_workflow.yaml
+++ b/.github/workflows/build_workflow.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT   
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - uses: actions/cache@v2
         id: yarn-cache 
         with:
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - uses: actions/cache@v2
         id: yarn-cache 
         with:
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - uses: actions/cache@v2
         id: yarn-cache 
         with:
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - uses: actions/cache@v2
         id: yarn-cache 
         with:
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - uses: actions/cache@v2
         id: yarn-cache 
         with:

--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -1,17 +1,13 @@
 import { Button, Center, VStack } from "@chakra-ui/react";
-import { getAuth } from "@firebase/auth";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
-import { getPlanPriceRange, Plan } from "src/domain/models/Plan";
+import { getPlanPriceRange } from "src/domain/models/Plan";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { reduxAuthSelector } from "src/redux/auth";
-import { setShowPlanCreatedModal } from "src/redux/plan";
 import {
     autoReorderPlacesInPlanCandidate,
     fetchCachedCreatedPlans,
     reduxPlanCandidateSelector,
-    resetPlanCandidates,
-    savePlanFromCandidate,
     updatePreviewPlanId,
 } from "src/redux/planCandidate";
 import { useAppDispatch } from "src/redux/redux";
@@ -26,6 +22,7 @@ import { Size } from "src/view/constants/size";
 import { isPC } from "src/view/constants/userAgent";
 import { useLocation } from "src/view/hooks/useLocation";
 import { usePlaceLikeInPlanCandidate } from "src/view/hooks/usePlaceLikeInPlanCandidate";
+import { usePlanCreate } from "src/view/hooks/usePlanCreate";
 import { usePlanPlaceAdd } from "src/view/hooks/usePlanPlaceAdd";
 import { usePlanPlaceDelete } from "src/view/hooks/usePlanPlaceDelete";
 import { usePlanPlaceReplace } from "src/view/hooks/usePlanPlaceReplace";
@@ -46,6 +43,11 @@ const PlanDetail = () => {
     const dispatch = useAppDispatch();
     const { getCurrentLocation, location: currentLocation } = useLocation();
     const { user, firebaseIdToken } = reduxAuthSelector();
+
+    const { createPlan, savePlanFromCandidateRequestStatus } = usePlanCreate({
+        planCandidateSetId: sessionId as string,
+        planId: planId as string,
+    });
 
     const {
         showRelatedPlaces,
@@ -92,7 +94,6 @@ const PlanDetail = () => {
         preview: plan,
         createdBasedOnCurrentLocation,
         createPlanSession,
-        savePlanFromCandidateRequestStatus,
         fetchCachedCreatedPlansRequestStatus,
     } = reduxPlanCandidateSelector();
 
@@ -140,31 +141,6 @@ const PlanDetail = () => {
         }
     }, [planId, createPlanSession]);
 
-    // プランが保存され次第、ページ遷移を行う
-    useEffect(() => {
-        if (!plan) return;
-        if (savePlanFromCandidateRequestStatus === RequestStatuses.FULFILLED) {
-            router.push(Routes.plans.plan(plan.id)).then();
-            dispatch(setShowPlanCreatedModal(true));
-            // 戻ったときに再リダイレクトされないようにする
-            dispatch(resetPlanCandidates());
-        }
-    }, [planId, savePlanFromCandidateRequestStatus]);
-
-    const handleOnSavePlan = async ({
-        session,
-        plan,
-    }: {
-        session: string;
-        plan: Plan;
-    }) => {
-        const auth = getAuth();
-        const authToken = await auth.currentUser?.getIdToken(true);
-        dispatch(
-            savePlanFromCandidate({ session, planId: plan.id, authToken })
-        );
-    };
-
     const handleOptimizeRoute = ({
         planCandidateId,
         planId,
@@ -174,6 +150,10 @@ const PlanDetail = () => {
     }): void => {
         dispatch(autoReorderPlacesInPlanCandidate({ planId, planCandidateId }));
     };
+
+    if (savePlanFromCandidateRequestStatus === RequestStatuses.PENDING) {
+        return <LoadingModal title="プランを作成しています" />;
+    }
 
     if (!plan) {
         // プラン候補取得失敗
@@ -285,9 +265,7 @@ const PlanDetail = () => {
                     color="white"
                     backgroundColor={Colors.primary["400"]}
                     borderRadius={10}
-                    onClick={() =>
-                        handleOnSavePlan({ session: createPlanSession, plan })
-                    }
+                    onClick={() => createPlan({ planId: plan.id })}
                 >
                     しおりとして保存
                 </Button>

--- a/src/view/hooks/usePlanCreate.ts
+++ b/src/view/hooks/usePlanCreate.ts
@@ -1,7 +1,6 @@
 import { getAuth } from "@firebase/auth";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
-import { useDispatch } from "react-redux";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { setShowPlanCreatedModal } from "src/redux/plan";
 import {
@@ -9,8 +8,8 @@ import {
     resetPlanCandidates,
     savePlanFromCandidate,
 } from "src/redux/planCandidate";
+import { useAppDispatch } from "src/redux/redux";
 import { Routes } from "src/view/constants/router";
-import {useAppDispatch} from "src/redux/redux";
 
 type Props = {
     planCandidateSetId: string;

--- a/src/view/hooks/usePlanCreate.ts
+++ b/src/view/hooks/usePlanCreate.ts
@@ -1,0 +1,52 @@
+import { getAuth } from "@firebase/auth";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { RequestStatuses } from "src/domain/models/RequestStatus";
+import { setShowPlanCreatedModal } from "src/redux/plan";
+import {
+    reduxPlanCandidateSelector,
+    resetPlanCandidates,
+    savePlanFromCandidate,
+} from "src/redux/planCandidate";
+import { Routes } from "src/view/constants/router";
+
+type Props = {
+    planCandidateSetId: string;
+    planId: string;
+};
+
+export const usePlanCreate = ({ planCandidateSetId, planId }: Props) => {
+    const dispatch = useDispatch();
+    const router = useRouter();
+    const { preview: plan, savePlanFromCandidateRequestStatus } =
+        reduxPlanCandidateSelector();
+
+    const createPlan = async ({ planId }: { planId: string }) => {
+        const auth = getAuth();
+        const authToken = await auth.currentUser?.getIdToken(true);
+        dispatch(
+            savePlanFromCandidate({
+                session: planCandidateSetId,
+                planId,
+                authToken,
+            })
+        );
+    };
+
+    // プランが保存され次第、ページ遷移を行う
+    useEffect(() => {
+        if (!plan) return;
+        if (savePlanFromCandidateRequestStatus === RequestStatuses.FULFILLED) {
+            router.push(Routes.plans.plan(plan.id)).then();
+            dispatch(setShowPlanCreatedModal(true));
+            // 戻ったときに再リダイレクトされないようにする
+            dispatch(resetPlanCandidates());
+        }
+    }, [planId, savePlanFromCandidateRequestStatus]);
+
+    return {
+        createPlan,
+        savePlanFromCandidateRequestStatus,
+    };
+};

--- a/src/view/hooks/usePlanCreate.ts
+++ b/src/view/hooks/usePlanCreate.ts
@@ -10,6 +10,7 @@ import {
     savePlanFromCandidate,
 } from "src/redux/planCandidate";
 import { Routes } from "src/view/constants/router";
+import {useAppDispatch} from "src/redux/redux";
 
 type Props = {
     planCandidateSetId: string;
@@ -17,7 +18,7 @@ type Props = {
 };
 
 export const usePlanCreate = ({ planCandidateSetId, planId }: Props) => {
-    const dispatch = useDispatch();
+    const dispatch = useAppDispatch();
     const router = useRouter();
     const { preview: plan, savePlanFromCandidateRequestStatus } =
         reduxPlanCandidateSelector();


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|保存するボタンを押した直後は画面が硬直する|<img width="1025" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/34feaffe-a7c9-4ea8-96a8-c04fb35d291d">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 保存ボタンを押したあときにダイアログが表示されることを確認
- [x] 保存後、戻るボタンを押したときにダイアログが表示されないことを確認 

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````