### PR TITLE
興味選択画面で位置情報を拒否してホームに戻ると画面が固定されるバグを修正

### DIFF
--- a/src/view/common/FullscreenDialog.tsx
+++ b/src/view/common/FullscreenDialog.tsx
@@ -70,7 +70,7 @@ export function FullscreenDialog({
         // コンポーネントが表示されなくなったときに、スクロール位置を元に戻す
         return () => {
             resetFixScroll();
-        }
+        };
     }, []);
 
     useEffect(() => {

--- a/src/view/common/FullscreenDialog.tsx
+++ b/src/view/common/FullscreenDialog.tsx
@@ -67,6 +67,13 @@ export function FullscreenDialog({
     };
 
     useEffect(() => {
+        // コンポーネントが表示されなくなったときに、スクロール位置を元に戻す
+        return () => {
+            resetFixScroll();
+        }
+    }, []);
+
+    useEffect(() => {
         if (visible) {
             fixScroll();
         } else {


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

位置情報利用の権限を拒否し、このダイアログが表示されたときに
ホームに戻ると画面がスクロールできないバグを修正した。

<img width="698" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/2e795d92-e1bd-42c3-be58-21441ce30b81">

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] 戻るボタンを押してスクロールができることを確認

```shell
# poroto
export BRANCH_POROTO=feature/fix_location_dialog_go_back_home
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````