### PR TITLE
#527の修正　画像のみを選択可能にする

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,4 +2,4 @@ APP_ENV=development
 
 PLANNER_API_PROTOCOL=http
 PLANNER_API_HOST=localhost:8080
-CLOUD_STORAGE_POROTO_PLACE_IMAGES="gs://poroto-place-images"
+CLOUD_STORAGE_POROTO_PLACE_IMAGES="gs://place-photos-development"

--- a/src/view/plandetail/PlaceChipContextAction.tsx
+++ b/src/view/plandetail/PlaceChipContextAction.tsx
@@ -1,13 +1,13 @@
 import { Link } from "@chakra-ui/next-js";
-import { HStack,Icon,Text } from "@chakra-ui/react";
-import { useRef,useState } from "react";
+import { HStack, Icon, Text } from "@chakra-ui/react";
+import { useRef, useState } from "react";
 import { IconType } from "react-icons";
 import {
-MdOutlineCameraAlt,
-MdOutlineDeleteOutline,
-MdOutlineFindReplace
+    MdOutlineCameraAlt,
+    MdOutlineDeleteOutline,
+    MdOutlineFindReplace,
 } from "react-icons/md";
-import { SiGooglemaps,SiInstagram } from "react-icons/si";
+import { SiGooglemaps, SiInstagram } from "react-icons/si";
 import useUploadImage from "src/view/hooks/useUploadImage";
 import DialogUploadImage from "src/view/plancandidate/DialogUploadImage";
 import { OnClickHandler } from "src/view/types/handler";

--- a/src/view/plandetail/PlaceChipContextAction.tsx
+++ b/src/view/plandetail/PlaceChipContextAction.tsx
@@ -1,13 +1,13 @@
 import { Link } from "@chakra-ui/next-js";
-import { HStack, Icon, Text } from "@chakra-ui/react";
-import { useRef, useState } from "react";
+import { HStack,Icon,Text } from "@chakra-ui/react";
+import { useRef,useState } from "react";
 import { IconType } from "react-icons";
 import {
-    MdOutlineCameraAlt,
-    MdOutlineDeleteOutline,
-    MdOutlineFindReplace,
+MdOutlineCameraAlt,
+MdOutlineDeleteOutline,
+MdOutlineFindReplace
 } from "react-icons/md";
-import { SiGooglemaps, SiInstagram } from "react-icons/si";
+import { SiGooglemaps,SiInstagram } from "react-icons/si";
 import useUploadImage from "src/view/hooks/useUploadImage";
 import DialogUploadImage from "src/view/plancandidate/DialogUploadImage";
 import { OnClickHandler } from "src/view/types/handler";
@@ -146,6 +146,7 @@ export const PlaceChipActionCamera = () => {
                 ref={fileInputRef}
                 id="file-input"
                 type="file"
+                accept="image/*"
                 multiple
                 onChange={handleFileInputChange}
                 style={{ display: "none" }}


### PR DESCRIPTION
### 修正の概要
 #527のCSから取得した画像URLをDBに保存するためにURLをplannerに渡すの修正を行った。
 1. 環境変数の変更
 2. 画像のみを選択可能にした
<!--
|before| after |
|---|-------|
|||
-->

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [ ]

```shell
# poroto
export BRANCH_POROTO=feature/add_upload_button_to_card_2
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````