### PR TITLE
トップページのセクションタイトルのスタイルを統一

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import { Center, Spinner, VStack } from "@chakra-ui/react";
 import { GetStaticProps } from "next";
 import { useEffect } from "react";
-import {MdOutlineBookmark, MdOutlineBookmarkBorder, MdTrendingUp} from "react-icons/md";
+import { MdOutlineBookmarkBorder, MdTrendingUp } from "react-icons/md";
 import InfiniteScroll from "react-infinite-scroller";
 import { PlannerGraphQlApi } from "src/data/graphql/PlannerGraphQlApi";
 import { createPlanFromPlanEntity } from "src/domain/factory/Plan";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
-import { Center, Spinner, Text, VStack } from "@chakra-ui/react";
+import { Center, Spinner, VStack } from "@chakra-ui/react";
 import { GetStaticProps } from "next";
 import { useEffect } from "react";
-import { MdTrendingUp } from "react-icons/md";
+import {MdOutlineBookmark, MdOutlineBookmarkBorder, MdTrendingUp} from "react-icons/md";
 import InfiniteScroll from "react-infinite-scroller";
 import { PlannerGraphQlApi } from "src/data/graphql/PlannerGraphQlApi";
 import { createPlanFromPlanEntity } from "src/domain/factory/Plan";
@@ -91,17 +91,10 @@ const IndexPage = (props: Props) => {
                 >
                     {plansByUser && plansByUser.length > 0 && (
                         <PlanList plans={plansByUser}>
-                            <Text
-                                as="h2"
-                                fontSize="20px"
-                                fontWeight="bold"
-                                w="100%"
-                                maxW="600px"
-                                textAlign="center"
-                                py="16x"
-                            >
-                                保存したプラン
-                            </Text>
+                            <PlanListSectionTitle
+                                title="保存したプラン"
+                                icon={MdOutlineBookmarkBorder}
+                            />
                         </PlanList>
                     )}
                     {/* TODO: 拒否設定されている場合の対処をする */}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { Center, Spinner, Text, VStack } from "@chakra-ui/react";
 import { GetStaticProps } from "next";
 import { useEffect } from "react";
+import { MdTrendingUp } from "react-icons/md";
 import InfiniteScroll from "react-infinite-scroller";
 import { PlannerGraphQlApi } from "src/data/graphql/PlannerGraphQlApi";
 import { createPlanFromPlanEntity } from "src/domain/factory/Plan";
@@ -22,10 +23,7 @@ import { useNearbyPlans } from "src/view/hooks/useNearbyPlans";
 import { NearbyPlanList } from "src/view/plan/NearbyPlanList";
 import { PlanList } from "src/view/plan/PlanList";
 import { CreatePlanSection } from "src/view/top/CreatePlanSection";
-import {
-    PlanListSectionTitle,
-    PlanSections,
-} from "src/view/top/PlanListSectionTitle";
+import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
 
 type Props = {
     plansRecentlyCreated: Plan[] | null;
@@ -124,7 +122,8 @@ const IndexPage = (props: Props) => {
                     >
                         <PlanList plans={plansRecentlyCreated}>
                             <PlanListSectionTitle
-                                section={PlanSections.Recent}
+                                title="最近作成されたプラン"
+                                icon={MdTrendingUp}
                             />
                         </PlanList>
                         {fetchPlansRecentlyCreatedRequestStatus ===

--- a/src/stories/top/PlanListSectionTitle.stories.tsx
+++ b/src/stories/top/PlanListSectionTitle.stories.tsx
@@ -1,8 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
-import {
-    PlanListSectionTitle,
-    PlanSections,
-} from "src/view/top/PlanListSectionTitle";
+import { MdTrendingUp } from "react-icons/md";
+import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
 
 export default {
     title: "top/PlanListSectionTitle",
@@ -13,14 +11,9 @@ export default {
 
 type Story = StoryObj<typeof PlanListSectionTitle>;
 
-export const NearBy: Story = {
+export const Primary: Story = {
     args: {
-        section: PlanSections.NearBy,
-    },
-};
-
-export const Recent: Story = {
-    args: {
-        section: PlanSections.Recent,
+        title: "おすすめのプラン",
+        icon: MdTrendingUp,
     },
 };

--- a/src/view/plan/NearbyPlanList.tsx
+++ b/src/view/plan/NearbyPlanList.tsx
@@ -1,3 +1,4 @@
+import { MdOutlineExplore } from "react-icons/md";
 import { Plan } from "src/domain/models/Plan";
 import { isPC } from "src/view/constants/userAgent";
 import {
@@ -7,10 +8,7 @@ import {
 import { PlanList } from "src/view/plan/PlanList";
 import { LocationUnavailable } from "src/view/top/LocationUnavailable";
 import { NearbyPlansNotFound } from "src/view/top/NearbyPlansNotFound";
-import {
-    PlanListSectionTitle,
-    PlanSections,
-} from "src/view/top/PlanListSectionTitle";
+import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
 
 type Props = {
     plans: Plan[] | null;
@@ -41,7 +39,10 @@ export function NearbyPlanList({
             isLoading={isFetchingNearbyPlans}
             numPlaceHolders={isPC ? 3 : 1}
         >
-            <PlanListSectionTitle section={PlanSections.NearBy} />
+            <PlanListSectionTitle
+                title="近くのプラン"
+                icon={MdOutlineExplore}
+            />
         </PlanList>
     );
 }

--- a/src/view/top/PlanListSectionTitle.tsx
+++ b/src/view/top/PlanListSectionTitle.tsx
@@ -9,7 +9,7 @@ type Props = {
 export function PlanListSectionTitle({ title, icon }: Props) {
     return (
         <VStack w="100%" alignItems="flex-start">
-            <VStack py="48px" px="8px" alignItems="flex-start" spacing={4}>
+            <VStack py="32px" px="8px" alignItems="flex-start" spacing={4}>
                 <HStack color="#3E3E3E">
                     <Icon w="32px" h="32px" as={icon} />
                     <Text

--- a/src/view/top/PlanListSectionTitle.tsx
+++ b/src/view/top/PlanListSectionTitle.tsx
@@ -1,77 +1,33 @@
-import { Box, Center, HStack, Text, VStack } from "@chakra-ui/react";
-import Link from "next/link";
+import { Box, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { IconType } from "react-icons";
 
 type Props = {
-    section: PlanSection;
-};
-
-export const PlanSections = {
-    NearBy: "nearby",
-    Recent: "recent",
-};
-export type PlanSection = (typeof PlanSections)[keyof typeof PlanSections];
-
-export function PlanListSectionTitle({ section }: Props) {
-    return (
-        <HStack
-            id={`${section}`}
-            py="48px"
-            px="16px"
-            w="100%"
-            justifyContent="center"
-            spacing={4}
-        >
-            <Title
-                prefix="あなたの近くの"
-                title="おすすめのプラン"
-                section={PlanSections.NearBy}
-                currentSection={section}
-            />
-            <Title
-                prefix="全国各地の"
-                title="注目のプラン"
-                section={PlanSections.Recent}
-                currentSection={section}
-            />
-        </HStack>
-    );
-}
-
-function Title({
-    title,
-    prefix,
-    section,
-    currentSection,
-}: {
     title: string;
-    prefix: string;
-    section: PlanSection;
-    currentSection?: PlanSection;
-}) {
+    icon: IconType;
+};
+
+export function PlanListSectionTitle({ title, icon }: Props) {
     return (
-        <Link href={`#${section}`}>
-            <VStack
-                alignItems="flex-start"
-                color={section !== currentSection && "gray"}
-                userSelect="none"
-            >
-                <Text lineHeight={1}>{prefix}</Text>
-                <Text fontSize="20px" fontWeight="bold" lineHeight={1} as="h1">
-                    {title}
-                </Text>
-                <Center
+        <VStack w="100%" alignItems="flex-start">
+            <VStack py="48px" px="8px" alignItems="flex-start" spacing={4}>
+                <HStack color="#3E3E3E">
+                    <Icon w="32px" h="32px" as={icon} />
+                    <Text
+                        fontSize="20px"
+                        fontWeight="bold"
+                        lineHeight={1}
+                        as="h1"
+                    >
+                        {title}
+                    </Text>
+                </HStack>
+                <Box
                     w="100%"
-                    px="16px"
-                    mt="8px"
-                    opacity={section === currentSection ? 1 : 0}
-                >
-                    <Box
-                        w="90px"
-                        border="2px solid #222222"
-                        borderRadius="20px"
-                    />
-                </Center>
+                    h="4px"
+                    backgroundColor="#3E3E3E"
+                    borderRadius="10px"
+                />
             </VStack>
-        </Link>
+        </VStack>
     );
 }


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/4ef3353e-437d-492a-810a-b8f168d2446f)|![image](https://github.com/poroto-app/poroto/assets/55840281/22fd0346-6dce-4d31-91a8-8aa207c84956)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 複数のセクションを作成したときにも、統一感を出せるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
```shell
# poroto
export BRANCH_POROTO=feature/top_page_title
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````