### PR TITLE
保存済みプランを横並びで表示する

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import { Center, Spinner, VStack } from "@chakra-ui/react";
 import { GetStaticProps } from "next";
 import { useEffect } from "react";
-import {MdOutlineBookmark, MdOutlineBookmarkBorder, MdTrendingUp} from "react-icons/md";
+import { MdOutlineBookmarkBorder, MdTrendingUp } from "react-icons/md";
 import InfiniteScroll from "react-infinite-scroller";
 import { PlannerGraphQlApi } from "src/data/graphql/PlannerGraphQlApi";
 import { createPlanFromPlanEntity } from "src/domain/factory/Plan";
@@ -90,7 +90,7 @@ const IndexPage = (props: Props) => {
                     spacing="24px"
                 >
                     {plansByUser && plansByUser.length > 0 && (
-                        <PlanList plans={plansByUser}>
+                        <PlanList plans={plansByUser} grid={false}>
                             <PlanListSectionTitle
                                 title="保存したプラン"
                                 icon={MdOutlineBookmarkBorder}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -94,6 +94,7 @@ const IndexPage = (props: Props) => {
                             plans={plansByUser}
                             grid={false}
                             wrapTitle={false}
+                            showAuthor={false}
                         >
                             <PlanListSectionTitle
                                 title="保存したプラン"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -90,7 +90,11 @@ const IndexPage = (props: Props) => {
                     spacing="24px"
                 >
                     {plansByUser && plansByUser.length > 0 && (
-                        <PlanList plans={plansByUser} grid={false}>
+                        <PlanList
+                            plans={plansByUser}
+                            grid={false}
+                            wrapTitle={false}
+                        >
                             <PlanListSectionTitle
                                 title="保存したプラン"
                                 icon={MdOutlineBookmarkBorder}

--- a/src/stories/plan/PlanList.stories.tsx
+++ b/src/stories/plan/PlanList.stories.tsx
@@ -46,3 +46,13 @@ export const EmptyWithComponent: Story = {
         empty: <p>Empty</p>,
     },
 };
+
+export const Horizontal: Story = {
+    args: {
+        plans: createArrayWithSize(5).map((i) => ({
+            id: i,
+            ...mockPlan,
+        })),
+        grid: false,
+    },
+};

--- a/src/stories/plan/PlanPreview.stories.tsx
+++ b/src/stories/plan/PlanPreview.stories.tsx
@@ -81,3 +81,23 @@ export const PlaceHolder: Story = {
         plan: null,
     },
 };
+
+export const WrapTitle: Story = {
+    args: {
+        plan: {
+            id: "plan",
+            title: "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum.",
+            timeInMinutes: 30,
+            author: null,
+            transitions: [
+                {
+                    fromPlaceId: mockPlaces.bookStore.id,
+                    toPlaceId: mockPlaces.tokyo.id,
+                    durationInMinutes: 10,
+                },
+            ],
+            places: [mockPlaces.bookStore, mockPlaces.tokyo],
+        },
+        wrapTitle: false,
+    },
+};

--- a/src/stories/plan/PlanPreview.stories.tsx
+++ b/src/stories/plan/PlanPreview.stories.tsx
@@ -101,3 +101,27 @@ export const WrapTitle: Story = {
         wrapTitle: false,
     },
 };
+
+export const ShowAuthor: Story = {
+    args: {
+        plan: {
+            id: "plan",
+            title: "プランタイトル",
+            timeInMinutes: 30,
+            author: {
+                id: "author",
+                name: "Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum.",
+                avatarImage: "https://picsum.photos/450/600",
+            },
+            transitions: [
+                {
+                    fromPlaceId: mockPlaces.bookStore.id,
+                    toPlaceId: mockPlaces.tokyo.id,
+                    durationInMinutes: 10,
+                },
+            ],
+            places: [mockPlaces.bookStore, mockPlaces.tokyo],
+        },
+        showAuthor: false,
+    },
+};

--- a/src/view/common/HorizontaScrollablelList.tsx
+++ b/src/view/common/HorizontaScrollablelList.tsx
@@ -1,0 +1,94 @@
+import { Box, Center, HStack, Icon } from "@chakra-ui/react";
+import { ReactNode, useRef } from "react";
+import { MdArrowBackIos, MdArrowForwardIos } from "react-icons/md";
+import { isPC } from "src/view/constants/userAgent";
+
+type Props = {
+    scrollAmount?: number;
+    children?: ReactNode;
+};
+
+export const HorizontaScrollablelList = ({
+    scrollAmount = 400,
+    children,
+}: Props) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const scroll = (direction: "left" | "right") => {
+        if (!containerRef.current) {
+            return;
+        }
+        const container = containerRef.current;
+        const scrollLeft = container.scrollLeft;
+        const newScrollLeft =
+            scrollLeft + (direction === "left" ? -scrollAmount : scrollAmount);
+        container.scrollTo({ left: newScrollLeft, behavior: "smooth" });
+    };
+
+    return (
+        <Box position="relative" w="100%">
+            <HStack
+                ref={containerRef}
+                w="100%"
+                px={isPC ? "16px" : 0}
+                overflowX="auto"
+                overflowY="hidden"
+                scrollSnapType="x mandatory"
+                sx={{
+                    "::-webkit-scrollbar": {
+                        display: "none",
+                    },
+                }}
+            >
+                {children}
+            </HStack>
+            <Box>
+                <PageButton
+                    left={0}
+                    right="auto"
+                    onClick={() => scroll("left")}
+                >
+                    <Icon as={MdArrowBackIos} />
+                </PageButton>
+                <PageButton
+                    left="auto"
+                    right={0}
+                    onClick={() => scroll("right")}
+                >
+                    <Icon as={MdArrowForwardIos} />
+                </PageButton>
+            </Box>
+        </Box>
+    );
+};
+
+const PageButton = ({
+    left,
+    right,
+    onClick,
+    children,
+}: {
+    left: number | string;
+    right: number | string;
+    onClick?: () => void;
+    children: ReactNode;
+}) => {
+    return (
+        <Center
+            visibility={isPC ? "visible" : "hidden"}
+            position="absolute"
+            top="50%"
+            left={left}
+            right={right}
+            transform="translateY(-50%)"
+            w="40px"
+            h="40px"
+            backgroundColor="white"
+            borderRadius="100%"
+            boxShadow="0px 4px 8px rgba(0, 0, 0, 0.10)"
+            onClick={onClick}
+        >
+            {children}
+        </Center>
+    );
+};

--- a/src/view/common/HorizontalScrollablelList.tsx
+++ b/src/view/common/HorizontalScrollablelList.tsx
@@ -5,11 +5,13 @@ import { isPC } from "src/view/constants/userAgent";
 
 type Props = {
     scrollAmount?: number;
+    pageButtonOffsetY?: number;
     children?: ReactNode;
 };
 
-export const HorizontaScrollablelList = ({
+export const HorizontalScrollablelList = ({
     scrollAmount = 400,
+    pageButtonOffsetY = 0,
     children,
 }: Props) => {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -30,9 +32,10 @@ export const HorizontaScrollablelList = ({
             <HStack
                 ref={containerRef}
                 w="100%"
-                px={isPC ? "16px" : 0}
+                // px={isPC ? "16px" : 0}
                 overflowX="auto"
                 overflowY="hidden"
+                alignItems="flex-start"
                 scrollSnapType="x mandatory"
                 sx={{
                     "::-webkit-scrollbar": {
@@ -46,6 +49,7 @@ export const HorizontaScrollablelList = ({
                 <PageButton
                     left={0}
                     right="auto"
+                    offsetY={pageButtonOffsetY}
                     onClick={() => scroll("left")}
                 >
                     <Icon as={MdArrowBackIos} />
@@ -53,6 +57,7 @@ export const HorizontaScrollablelList = ({
                 <PageButton
                     left="auto"
                     right={0}
+                    offsetY={pageButtonOffsetY}
                     onClick={() => scroll("right")}
                 >
                     <Icon as={MdArrowForwardIos} />
@@ -65,11 +70,13 @@ export const HorizontaScrollablelList = ({
 const PageButton = ({
     left,
     right,
+    offsetY,
     onClick,
     children,
 }: {
     left: number | string;
     right: number | string;
+    offsetY: number;
     onClick?: () => void;
     children: ReactNode;
 }) => {
@@ -80,7 +87,7 @@ const PageButton = ({
             top="50%"
             left={left}
             right={right}
-            transform="translateY(-50%)"
+            transform={`translateY(calc(-50% + ${offsetY}px))`}
             w="40px"
             h="40px"
             backgroundColor="white"

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -21,7 +21,7 @@ export const Size = {
     },
     PlanList: {
         SavedPlan: {
-            ThumbnailHeight: "200px",
+            ThumbnailHeight: "250px",
         },
     },
 };

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -19,4 +19,9 @@ export const Size = {
             },
         },
     },
+    PlanList: {
+        SavedPlan: {
+            ThumbnailHeight: "200px",
+        },
+    },
 };

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -17,6 +17,7 @@ type Props = {
     empty?: ReactNode;
     grid?: boolean;
     wrapTitle?: boolean;
+    showAuthor?: boolean;
 };
 
 export function PlanList({
@@ -27,6 +28,7 @@ export function PlanList({
     numPlaceHolders = 6,
     grid = true,
     wrapTitle,
+    showAuthor,
 }: Props) {
     if (!plans || plans.length == 0 || isLoading) {
         if (empty && !isLoading) {
@@ -48,6 +50,7 @@ export function PlanList({
                             plan={null}
                             grid={grid}
                             wrapTitle={wrapTitle}
+                            showAuthor={showAuthor}
                         />
                     ))}
                 </Layout>
@@ -66,6 +69,7 @@ export function PlanList({
                             plan={plan}
                             grid={grid}
                             wrapTitle={wrapTitle}
+                            showAuthor={showAuthor}
                         />
                         {(index + 1) % 6 === 0 && <AdInPlanList />}
                     </>
@@ -87,10 +91,12 @@ function PlanListItem({
     plan,
     grid,
     wrapTitle,
+    showAuthor,
 }: {
     plan: Plan;
     grid: boolean;
     wrapTitle?: boolean;
+    showAuthor?: boolean;
 }) {
     return (
         <Box w={grid ? "100%" : "200px"}>
@@ -101,6 +107,7 @@ function PlanListItem({
                     grid ? undefined : Size.PlanList.SavedPlan.ThumbnailHeight
                 }
                 wrapTitle={wrapTitle}
+                showAuthor={showAuthor}
             />
         </Box>
     );

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -4,6 +4,7 @@ import { Plan } from "src/domain/models/Plan";
 import { createArrayWithSize } from "src/domain/util/array";
 import { HorizontalScrollablelList } from "src/view/common/HorizontalScrollablelList";
 import { Routes } from "src/view/constants/router";
+import { Size } from "src/view/constants/size";
 import { PlanPreview } from "src/view/plan/PlanPreview";
 import styled from "styled-components";
 import { AdInPlanList } from "../ad/AdInPlanList";
@@ -41,7 +42,13 @@ export function PlanList({
                 <Layout grid={grid}>
                     {createArrayWithSize(numPlaceHolders).map((i) => (
                         <PlanCardContainer key={i} grid={grid}>
-                            <PlanPreview plan={null} />
+                            <PlanPreview
+                                plan={null}
+                                planThumbnailHeight={
+                                    !grid &&
+                                    Size.PlanList.SavedPlan.ThumbnailHeight
+                                }
+                            />
                         </PlanCardContainer>
                     ))}
                 </Layout>
@@ -59,6 +66,12 @@ export function PlanList({
                             <PlanPreview
                                 link={Routes.plans.plan(plan.id)}
                                 plan={plan}
+                                planThumbnailHeight={
+                                    grid
+                                        ? undefined
+                                        : Size.PlanList.SavedPlan
+                                              .ThumbnailHeight
+                                }
                             />
                         </PlanCardContainer>
                         {(index + 1) % 6 === 0 && <AdInPlanList />}

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -1,7 +1,8 @@
-import { VStack } from "@chakra-ui/react";
+import { Box, VStack } from "@chakra-ui/react";
 import { ReactNode } from "react";
 import { Plan } from "src/domain/models/Plan";
 import { createArrayWithSize } from "src/domain/util/array";
+import { HorizontalScrollablelList } from "src/view/common/HorizontalScrollablelList";
 import { Routes } from "src/view/constants/router";
 import { PlanPreview } from "src/view/plan/PlanPreview";
 import styled from "styled-components";
@@ -13,6 +14,7 @@ type Props = {
     plans: Plan[] | null;
     numPlaceHolders?: number;
     empty?: ReactNode;
+    grid?: boolean;
 };
 
 export function PlanList({
@@ -21,6 +23,7 @@ export function PlanList({
     children,
     empty,
     numPlaceHolders = 6,
+    grid = true,
 }: Props) {
     if (!plans || plans.length == 0 || isLoading) {
         if (empty && !isLoading) {
@@ -35,11 +38,13 @@ export function PlanList({
         return (
             <Container>
                 {children}
-                <GridLayout>
+                <Layout grid={grid}>
                     {createArrayWithSize(numPlaceHolders).map((i) => (
-                        <PlanPreview key={i} plan={null} />
+                        <PlanCardContainer key={i} grid={grid}>
+                            <PlanPreview plan={null} />
+                        </PlanCardContainer>
                     ))}
-                </GridLayout>
+                </Layout>
             </Container>
         );
     }
@@ -47,18 +52,19 @@ export function PlanList({
     return (
         <Container>
             {children}
-            <GridLayout>
+            <Layout grid={grid}>
                 {plans.map((plan, index) => (
                     <>
-                        <PlanPreview
-                            key={index}
-                            link={Routes.plans.plan(plan.id)}
-                            plan={plan}
-                        />
+                        <PlanCardContainer key={index} grid={grid}>
+                            <PlanPreview
+                                link={Routes.plans.plan(plan.id)}
+                                plan={plan}
+                            />
+                        </PlanCardContainer>
                         {(index + 1) % 6 === 0 && <AdInPlanList />}
                     </>
                 ))}
-            </GridLayout>
+            </Layout>
         </Container>
     );
 }
@@ -70,6 +76,28 @@ function Container({ children }: { children: ReactNode }) {
         </VStack>
     );
 }
+
+function PlanCardContainer({
+    grid,
+    children,
+}: {
+    grid: boolean;
+    children: ReactNode;
+}) {
+    return <Box w={grid ? "100%" : "200px"}>{children}</Box>;
+}
+
+const Layout = ({ grid, children }: { grid: boolean; children: ReactNode }) => {
+    if (grid) {
+        return <GridLayout>{children}</GridLayout>;
+    }
+
+    return (
+        <HorizontalScrollablelList pageButtonOffsetY={-48}>
+            {children}
+        </HorizontalScrollablelList>
+    );
+};
 
 const GridLayout = styled.div`
     display: grid;

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -119,7 +119,7 @@ const Layout = ({ grid, children }: { grid: boolean; children: ReactNode }) => {
     }
 
     return (
-        <HorizontalScrollablelList pageButtonOffsetY={-48}>
+        <HorizontalScrollablelList pageButtonOffsetY={-8}>
             {children}
         </HorizontalScrollablelList>
     );

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -16,6 +16,7 @@ type Props = {
     numPlaceHolders?: number;
     empty?: ReactNode;
     grid?: boolean;
+    wrapTitle?: boolean;
 };
 
 export function PlanList({
@@ -25,6 +26,7 @@ export function PlanList({
     empty,
     numPlaceHolders = 6,
     grid = true,
+    wrapTitle,
 }: Props) {
     if (!plans || plans.length == 0 || isLoading) {
         if (empty && !isLoading) {
@@ -41,15 +43,12 @@ export function PlanList({
                 {children}
                 <Layout grid={grid}>
                     {createArrayWithSize(numPlaceHolders).map((i) => (
-                        <PlanCardContainer key={i} grid={grid}>
-                            <PlanPreview
-                                plan={null}
-                                planThumbnailHeight={
-                                    !grid &&
-                                    Size.PlanList.SavedPlan.ThumbnailHeight
-                                }
-                            />
-                        </PlanCardContainer>
+                        <PlanListItem
+                            key={i}
+                            plan={null}
+                            grid={grid}
+                            wrapTitle={wrapTitle}
+                        />
                     ))}
                 </Layout>
             </Container>
@@ -62,18 +61,12 @@ export function PlanList({
             <Layout grid={grid}>
                 {plans.map((plan, index) => (
                     <>
-                        <PlanCardContainer key={index} grid={grid}>
-                            <PlanPreview
-                                link={Routes.plans.plan(plan.id)}
-                                plan={plan}
-                                planThumbnailHeight={
-                                    grid
-                                        ? undefined
-                                        : Size.PlanList.SavedPlan
-                                              .ThumbnailHeight
-                                }
-                            />
-                        </PlanCardContainer>
+                        <PlanListItem
+                            key={plan.id}
+                            plan={plan}
+                            grid={grid}
+                            wrapTitle={wrapTitle}
+                        />
                         {(index + 1) % 6 === 0 && <AdInPlanList />}
                     </>
                 ))}
@@ -90,14 +83,27 @@ function Container({ children }: { children: ReactNode }) {
     );
 }
 
-function PlanCardContainer({
+function PlanListItem({
+    plan,
     grid,
-    children,
+    wrapTitle,
 }: {
+    plan: Plan;
     grid: boolean;
-    children: ReactNode;
+    wrapTitle?: boolean;
 }) {
-    return <Box w={grid ? "100%" : "200px"}>{children}</Box>;
+    return (
+        <Box w={grid ? "100%" : "200px"}>
+            <PlanPreview
+                link={plan && Routes.plans.plan(plan.id)}
+                plan={plan}
+                planThumbnailHeight={
+                    grid ? undefined : Size.PlanList.SavedPlan.ThumbnailHeight
+                }
+                wrapTitle={wrapTitle}
+            />
+        </Box>
+    );
 }
 
 const Layout = ({ grid, children }: { grid: boolean; children: ReactNode }) => {

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -8,6 +8,7 @@ import styled from "styled-components";
 type Props = {
     plan: Plan | null;
     link?: string;
+    planThumbnailHeight?: string | number;
 };
 
 export function PlaceHolder() {
@@ -19,7 +20,7 @@ export function PlaceHolder() {
     );
 }
 
-export function PlanPreview({ plan, link }: Props) {
+export function PlanPreview({ plan, link, planThumbnailHeight }: Props) {
     if (!plan) return <PlaceHolder />;
 
     const thumbnails = plan.places
@@ -31,7 +32,11 @@ export function PlanPreview({ plan, link }: Props) {
 
     return (
         <VStack w="100%" maxW="600px" alignItems="flex-start" overflow="hidden">
-            <PlanThumbnail images={thumbnails} link={link} />
+            <PlanThumbnail
+                images={thumbnails}
+                h={planThumbnailHeight}
+                link={link}
+            />
             <LinkWrapper href={link}>
                 <Text fontWeight="bold" fontSize="1.1rem" color="#222222">
                     {plan.title}

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -9,6 +9,7 @@ type Props = {
     plan: Plan | null;
     link?: string;
     planThumbnailHeight?: string | number;
+    wrapTitle?: boolean;
 };
 
 export function PlaceHolder() {
@@ -20,7 +21,12 @@ export function PlaceHolder() {
     );
 }
 
-export function PlanPreview({ plan, link, planThumbnailHeight }: Props) {
+export function PlanPreview({
+    plan,
+    link,
+    planThumbnailHeight,
+    wrapTitle = true,
+}: Props) {
     if (!plan) return <PlaceHolder />;
 
     const thumbnails = plan.places
@@ -38,7 +44,14 @@ export function PlanPreview({ plan, link, planThumbnailHeight }: Props) {
                 link={link}
             />
             <LinkWrapper href={link}>
-                <Text fontWeight="bold" fontSize="1.1rem" color="#222222">
+                <Text
+                    fontWeight="bold"
+                    fontSize="1.1rem"
+                    color="#222222"
+                    whiteSpace={wrapTitle ? "normal" : "nowrap"}
+                    overflow="hidden"
+                    textOverflow="ellipsis"
+                >
                     {plan.title}
                 </Text>
             </LinkWrapper>

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -10,6 +10,7 @@ type Props = {
     link?: string;
     planThumbnailHeight?: string | number;
     wrapTitle?: boolean;
+    showAuthor?: boolean;
 };
 
 export function PlaceHolder() {
@@ -26,6 +27,7 @@ export function PlanPreview({
     link,
     planThumbnailHeight,
     wrapTitle = true,
+    showAuthor = true,
 }: Props) {
     if (!plan) return <PlaceHolder />;
 
@@ -55,7 +57,7 @@ export function PlanPreview({
                     {plan.title}
                 </Text>
             </LinkWrapper>
-            {plan.author && (
+            {plan.author && showAuthor && (
                 <HStack w="100%">
                     <Avatar
                         name={plan.author.name}

--- a/src/view/plan/PlanThumbnail.tsx
+++ b/src/view/plan/PlanThumbnail.tsx
@@ -11,12 +11,14 @@ import { ImageSliderPreview } from "src/view/common/ImageSliderPreview";
 type Props = {
     images: Image[];
     imageSize?: ImageSize;
+    h?: string | number;
     link?: string;
 };
 
 export const PlanThumbnail = ({
     images,
     imageSize = ImageSizes.Small,
+    h = "300px",
     link,
 }: Props) => {
     if (images.length === 0) {
@@ -24,7 +26,7 @@ export const PlanThumbnail = ({
     }
 
     return (
-        <Box w="100%" h="300px">
+        <Box w="100%" h={h}>
             <ImageSliderPreview
                 images={images}
                 imageSize={imageSize}

--- a/src/view/plandetail/NearbyPlaceList.tsx
+++ b/src/view/plandetail/NearbyPlaceList.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from "@chakra-ui/react";
 import { Place } from "src/domain/models/Place";
 import { createArrayWithSize } from "src/domain/util/array";
-import { HorizontaScrollablelList } from "src/view/common/HorizontaScrollablelList";
+import { HorizontalScrollablelList } from "src/view/common/HorizontalScrollablelList";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
 import { Size } from "src/view/constants/size";
 
@@ -13,17 +13,17 @@ type Props = {
 export const NearbyPlaceList = ({ places, onSelectPlace }: Props) => {
     if (!places) {
         return (
-            <HorizontaScrollablelList>
+            <HorizontalScrollablelList>
                 {createArrayWithSize(5).map((_, index) => (
                     <NearbyPlaceCardSkeleton key={index} />
                 ))}
-            </HorizontaScrollablelList>
+            </HorizontalScrollablelList>
         );
     }
 
     // TODO: 要素が一つもないときの対応
     return (
-        <HorizontaScrollablelList>
+        <HorizontalScrollablelList>
             {places
                 .filter((p) => p.images.length > 0)
                 .map((place, index) => (
@@ -33,7 +33,7 @@ export const NearbyPlaceList = ({ places, onSelectPlace }: Props) => {
                         onClick={() => onSelectPlace?.(place)}
                     />
                 ))}
-        </HorizontaScrollablelList>
+        </HorizontalScrollablelList>
     );
 };
 

--- a/src/view/plandetail/NearbyPlaceList.tsx
+++ b/src/view/plandetail/NearbyPlaceList.tsx
@@ -1,11 +1,9 @@
-import { Box, Center, HStack, Icon, Text } from "@chakra-ui/react";
-import { ReactNode, useRef } from "react";
-import { MdArrowBackIos, MdArrowForwardIos } from "react-icons/md";
+import { Box, Text } from "@chakra-ui/react";
 import { Place } from "src/domain/models/Place";
 import { createArrayWithSize } from "src/domain/util/array";
+import { HorizontaScrollablelList } from "src/view/common/HorizontaScrollablelList";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
 import { Size } from "src/view/constants/size";
-import { isPC } from "src/view/constants/userAgent";
 
 type Props = {
     places: Place[] | null;
@@ -15,17 +13,17 @@ type Props = {
 export const NearbyPlaceList = ({ places, onSelectPlace }: Props) => {
     if (!places) {
         return (
-            <Container>
+            <HorizontaScrollablelList>
                 {createArrayWithSize(5).map((_, index) => (
                     <NearbyPlaceCardSkeleton key={index} />
                 ))}
-            </Container>
+            </HorizontaScrollablelList>
         );
     }
 
     // TODO: 要素が一つもないときの対応
     return (
-        <Container>
+        <HorizontaScrollablelList>
             {places
                 .filter((p) => p.images.length > 0)
                 .map((place, index) => (
@@ -35,90 +33,7 @@ export const NearbyPlaceList = ({ places, onSelectPlace }: Props) => {
                         onClick={() => onSelectPlace?.(place)}
                     />
                 ))}
-        </Container>
-    );
-};
-
-const Container = ({ children }: { children: ReactNode }) => {
-    const containerRef = useRef<HTMLDivElement>(null);
-
-    const scroll = (direction: "left" | "right") => {
-        if (!containerRef.current) {
-            return;
-        }
-        const container = containerRef.current;
-        const scrollLeft = container.scrollLeft;
-        const scrollAmount = 400;
-        const newScrollLeft =
-            scrollLeft + (direction === "left" ? -scrollAmount : scrollAmount);
-        container.scrollTo({ left: newScrollLeft, behavior: "smooth" });
-    };
-
-    return (
-        <Box position="relative" w="100%">
-            <HStack
-                ref={containerRef}
-                w="100%"
-                px={isPC ? "16px" : 0}
-                overflowX="auto"
-                overflowY="hidden"
-                scrollSnapType="x mandatory"
-                sx={{
-                    "::-webkit-scrollbar": {
-                        display: "none",
-                    },
-                }}
-            >
-                {children}
-            </HStack>
-            <Box>
-                <PageButton
-                    left={0}
-                    right="auto"
-                    onClick={() => scroll("left")}
-                >
-                    <Icon as={MdArrowBackIos} />
-                </PageButton>
-                <PageButton
-                    left="auto"
-                    right={0}
-                    onClick={() => scroll("right")}
-                >
-                    <Icon as={MdArrowForwardIos} />
-                </PageButton>
-            </Box>
-        </Box>
-    );
-};
-
-const PageButton = ({
-    left,
-    right,
-    onClick,
-    children,
-}: {
-    left: number | string;
-    right: number | string;
-    onClick?: () => void;
-    children: ReactNode;
-}) => {
-    return (
-        <Center
-            visibility={isPC ? "visible" : "hidden"}
-            position="absolute"
-            top="50%"
-            left={left}
-            right={right}
-            transform="translateY(-50%)"
-            w="40px"
-            h="40px"
-            backgroundColor="white"
-            borderRadius="100%"
-            boxShadow="0px 4px 8px rgba(0, 0, 0, 0.10)"
-            onClick={onClick}
-        >
-            {children}
-        </Center>
+        </HorizontaScrollablelList>
     );
 };
 


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/92fdb391-545f-45aa-b8ec-7f313124461d)|![image](https://github.com/poroto-app/poroto/assets/55840281/6d5af1e1-6f72-4e3a-8d7a-ede3e577af62)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #533 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] 横幅が溢れた状態でもプランが閲覧できることを確認（pc, sp） 

```shell
# poroto
export BRANCH_POROTO=feature/saved_plans_horizontal
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````