### PR TITLE
並び替え成功時に通知を表示する

### DIFF
--- a/src/pages/plans/select/[sessionId]/[planId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/[planId]/index.tsx
@@ -5,7 +5,6 @@ import { getPlanPriceRange } from "src/domain/models/Plan";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { reduxAuthSelector } from "src/redux/auth";
 import {
-    autoReorderPlacesInPlanCandidate,
     fetchCachedCreatedPlans,
     reduxPlanCandidateSelector,
     updatePreviewPlanId,
@@ -25,6 +24,7 @@ import { usePlaceLikeInPlanCandidate } from "src/view/hooks/usePlaceLikeInPlanCa
 import { usePlanCreate } from "src/view/hooks/usePlanCreate";
 import { usePlanPlaceAdd } from "src/view/hooks/usePlanPlaceAdd";
 import { usePlanPlaceDelete } from "src/view/hooks/usePlanPlaceDelete";
+import { usePlanPlaceReorder } from "src/view/hooks/usePlanPlaceReorder";
 import { usePlanPlaceReplace } from "src/view/hooks/usePlanPlaceReplace";
 import { SearchRouteByGoogleMapButton } from "src/view/plan/button/SearchRouteByGoogleMapButton";
 import { PlaceMap } from "src/view/plan/PlaceMap";
@@ -48,6 +48,8 @@ const PlanDetail = () => {
         planCandidateSetId: sessionId as string,
         planId: planId as string,
     });
+
+    const { handleOptimizeRoute } = usePlanPlaceReorder();
 
     const {
         showRelatedPlaces,
@@ -140,16 +142,6 @@ const PlanDetail = () => {
             dispatch(updatePreviewPlanId({ planId }));
         }
     }, [planId, createPlanSession]);
-
-    const handleOptimizeRoute = ({
-        planCandidateId,
-        planId,
-    }: {
-        planCandidateId: string;
-        planId: string;
-    }): void => {
-        dispatch(autoReorderPlacesInPlanCandidate({ planId, planCandidateId }));
-    };
 
     if (savePlanFromCandidateRequestStatus === RequestStatuses.PENDING) {
         return <LoadingModal title="プランを作成しています" />;

--- a/src/redux/planCandidate.ts
+++ b/src/redux/planCandidate.ts
@@ -436,6 +436,10 @@ export const slice = createSlice({
             state.createPlanFromPlaceRequestStatus = null;
         },
 
+        resetAutoReorderPlacesInPlanCandidateRequestStatus: (state) => {
+            state.autoReorderPlacesInPlanCandidateRequestStatus = null;
+        },
+
         reorderPlacesInPreview: (
             state,
             { payload }: PayloadAction<{ placeIds: string[] }>
@@ -662,6 +666,7 @@ export const {
     resetPlanCandidates,
     resetCreatePlanFromLocationRequestStatus,
     resetCreatePlanFromPlaceRequestStatus,
+    resetAutoReorderPlacesInPlanCandidateRequestStatus,
 } = slice.actions;
 
 const { reorderPlacesInPreview } = slice.actions;

--- a/src/view/hooks/usePlanPlaceReorder.ts
+++ b/src/view/hooks/usePlanPlaceReorder.ts
@@ -1,0 +1,20 @@
+import { autoReorderPlacesInPlanCandidate } from "src/redux/planCandidate";
+import { useAppDispatch } from "src/redux/redux";
+
+export const usePlanPlaceReorder = () => {
+    const dispatch = useAppDispatch();
+
+    const handleOptimizeRoute = ({
+        planCandidateId,
+        planId,
+    }: {
+        planCandidateId: string;
+        planId: string;
+    }): void => {
+        dispatch(autoReorderPlacesInPlanCandidate({ planId, planCandidateId }));
+    };
+
+    return {
+        handleOptimizeRoute,
+    };
+};

--- a/src/view/hooks/usePlanPlaceReorder.ts
+++ b/src/view/hooks/usePlanPlaceReorder.ts
@@ -1,8 +1,53 @@
-import { autoReorderPlacesInPlanCandidate } from "src/redux/planCandidate";
+import { ToastId, useToast } from "@chakra-ui/react";
+import { useEffect } from "react";
+import { RequestStatuses } from "src/domain/models/RequestStatus";
+import {
+    autoReorderPlacesInPlanCandidate,
+    reduxPlanCandidateSelector,
+    resetAutoReorderPlacesInPlanCandidateRequestStatus,
+} from "src/redux/planCandidate";
 import { useAppDispatch } from "src/redux/redux";
 
 export const usePlanPlaceReorder = () => {
     const dispatch = useAppDispatch();
+    const toast = useToast();
+    const { autoReorderPlacesInPlanCandidateRequestStatus } =
+        reduxPlanCandidateSelector();
+
+    useEffect(() => {
+        let toastId: ToastId | null = null;
+        if (
+            autoReorderPlacesInPlanCandidateRequestStatus ===
+            RequestStatuses.FULFILLED
+        ) {
+            toastId = toast({
+                title: "並び替えが成功しました",
+                status: "success",
+                duration: 3000,
+                isClosable: true,
+            });
+        } else if (
+            autoReorderPlacesInPlanCandidateRequestStatus ===
+            RequestStatuses.REJECTED
+        ) {
+            toastId = toast({
+                title: "並び替えに失敗しました",
+                status: "error",
+                duration: 3000,
+                isClosable: true,
+            });
+        } else {
+            return;
+        }
+
+        return () => {
+            console.log(autoReorderPlacesInPlanCandidateRequestStatus);
+            dispatch(resetAutoReorderPlacesInPlanCandidateRequestStatus());
+            if (toastId) {
+                toast.close(toastId);
+            }
+        };
+    }, [autoReorderPlacesInPlanCandidateRequestStatus]);
 
     const handleOptimizeRoute = ({
         planCandidateId,


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
||![image](https://github.com/poroto-app/poroto/assets/55840281/5a3346c5-dffb-4bf1-b94f-4faab4e989b3)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 並び替えが行われたことをわかりやすくするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 並び替えが成功するとトーストが表示されることを確認
- [x] 戻るボタンでプラン一覧ページに戻ると、トーストが消えることを確認
- [x] 別のプラン候補を表示しても、トーストが表示されないことを確認（うまく処理がかけていないと、ページを更新するたびに表示される）   

```shell
# poroto
export BRANCH_POROTO=feature/notify_reordering
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````