### PR TITLE
興味を選択する画面でエラー画面が表示されてしまう不具合を修正

### DIFF
--- a/src/pages/plans/interest.tsx
+++ b/src/pages/plans/interest.tsx
@@ -246,10 +246,11 @@ export function PlanInterestPageComponent({
             </MatchInterestPageTemplate>
         );
 
-    console.log("HELLOOOOOOOOOo", categoryCandidates?.length === 0)
-
     if (!currentCategory) {
-        if (matchInterestRequestStatus === RequestStatuses.FULFILLED && categoryCandidates?.length === 0)
+        if (
+            matchInterestRequestStatus === RequestStatuses.FULFILLED &&
+            categoryCandidates?.length === 0
+        )
             return <CouldNotFindAnyPlace />;
 
         if (matchInterestRequestStatus === RequestStatuses.REJECTED)

--- a/src/pages/plans/interest.tsx
+++ b/src/pages/plans/interest.tsx
@@ -190,6 +190,7 @@ function PlanInterestPage() {
 
     return (
         <PlanInterestPageComponent
+            categoryCandidates={categoryCandidates}
             currentCategory={
                 // 別のリクエスト結果が使われないようにする
                 matchInterestRequestId === fetchLocationCategoryRequestId &&
@@ -205,6 +206,7 @@ function PlanInterestPage() {
 }
 
 type Props = {
+    categoryCandidates: LocationCategoryWithPlace[] | null;
     currentCategory: LocationCategoryWithPlace | null;
     matchInterestRequestStatus: RequestStatus | null;
     handleAcceptCategory: (category: LocationCategory) => void;
@@ -214,6 +216,7 @@ type Props = {
 };
 
 export function PlanInterestPageComponent({
+    categoryCandidates,
     currentCategory,
     matchInterestRequestStatus,
     handleAcceptCategory,
@@ -243,17 +246,16 @@ export function PlanInterestPageComponent({
             </MatchInterestPageTemplate>
         );
 
+    console.log("HELLOOOOOOOOOo", categoryCandidates?.length === 0)
+
     if (!currentCategory) {
-        if (
-            !matchInterestRequestStatus ||
-            matchInterestRequestStatus === RequestStatuses.PENDING
-        )
-            return <LoadingModal title="近くに何があるかを探しています。" />;
+        if (matchInterestRequestStatus === RequestStatuses.FULFILLED && categoryCandidates?.length === 0)
+            return <CouldNotFindAnyPlace />;
 
         if (matchInterestRequestStatus === RequestStatuses.REJECTED)
             return <ErrorPage />;
 
-        return <CouldNotFindAnyPlace />;
+        return <LoadingModal title="近くに何があるかを探しています。" />;
     }
 
     return (

--- a/src/stories/pages/plan/interest.stories.tsx
+++ b/src/stories/pages/plan/interest.stories.tsx
@@ -7,7 +7,9 @@ export default {
     title: "interest/PlanInterestPageComponent",
     component: PlanInterestPageComponent,
     tags: ["autodocs"],
-    parameters: {},
+    parameters: {
+        layout: "fullscreen",
+    },
 } as Meta<typeof PlanInterestPageComponent>;
 
 type Story = StoryObj<typeof PlanInterestPageComponent>;
@@ -23,3 +25,30 @@ export const Primary: Story = {
         matchInterestRequestStatus: RequestStatuses.FULFILLED,
     },
 };
+
+export const CategorySelect: Story = {
+    args: {
+        currentCategory: {
+            name: "cafe",
+            displayName: "カフェ",
+            defaultThumbnailUrl: "https://picsum.photos/1280/720",
+            places: Object.values(mockPlaces),
+        },
+        matchInterestRequestStatus: RequestStatuses.FULFILLED,
+    },
+};
+
+export const CategorySelectSettingCategory: Story = {
+    args: {
+        categoryCandidates: [
+            {
+                name: "cafe",
+                displayName: "カフェ",
+                defaultThumbnailUrl: "https://picsum.photos/1280/720",
+                places: Object.values(mockPlaces),
+            },
+        ],
+        currentCategory: null,
+        matchInterestRequestStatus: RequestStatuses.FULFILLED,
+    },
+}

--- a/src/stories/pages/plan/interest.stories.tsx
+++ b/src/stories/pages/plan/interest.stories.tsx
@@ -51,4 +51,4 @@ export const CategorySelectSettingCategory: Story = {
         currentCategory: null,
         matchInterestRequestStatus: RequestStatuses.FULFILLED,
     },
-}
+};


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/28f7d3c7-cfe5-4053-a372-be100f34ecd0)|![image](https://github.com/poroto-app/poroto/assets/55840281/fdde9c1c-2162-40ef-ad2f-e17c7134ae33)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 不具合でない状況でエラーを出して、ユーザーに不快感を与えないため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] Storybookで状況を再現してテスト（http://localhost:6006/?path=/story/interest-planinterestpagecomponent--category-select-setting-category）

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````