### PR TITLE
ダイアログを閉じたときに前の状態がリセットされるようにする

### DIFF
--- a/src/view/hooks/usePlanPlaceAdd.ts
+++ b/src/view/hooks/usePlanPlaceAdd.ts
@@ -39,6 +39,7 @@ export const usePlanPlaceAdd = ({
     };
 
     const onCloseDialog = () => {
+        setBasePlaceIdToAdd(null);
         setIsDialogVisible(false);
         dispatch(resetAddPlaceToPlanCandidateState());
     };

--- a/src/view/plancandidate/DialogRelatedPlaces.tsx
+++ b/src/view/plancandidate/DialogRelatedPlaces.tsx
@@ -62,7 +62,7 @@ export function DialogRelatedPlaces({
     onClickRelatedPlace,
 }: Props) {
     const [selectedPlaceToUpdate, setSelectedPlaceToUpdate] =
-        useState<Place | null>();
+        useState<Place | null>(null);
 
     const handleOnSelectPlaceToUpdate = (placeId: string) => {
         const places = [
@@ -82,7 +82,7 @@ export function DialogRelatedPlaces({
     };
 
     useEffect(() => {
-        if (placesRecommended === null) setSelectedPlaceToUpdate(null);
+        if (!placesRecommended) setSelectedPlaceToUpdate(null);
     }, [copyObject(placesRecommended)]);
 
     return (


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

1. プラン候補作成
2. 場所を追加ボタンをタップ
3. 場所を選択
4. ダイアログ範囲外をタップでダイアログを閉じる
5. 場所を追加ボタンを再びタップ

この手順を踏んだときに、前の選択の状態が残ってしまっているのを修正した。

|before| after |
|---|-------|
|<img width="385" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/e274b5e7-33e1-4145-bb56-cdaf11cc2436">|<img width="382" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/7dd8deb8-909f-4ef5-a240-1d2ac092c919">|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 新しい候補を表示できるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 一度ダイアログを閉じて、再び開いたときに前の状態を残っていないことを確認

```shell
# poroto
export BRANCH_POROTO=feature/add_place_prev_state
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````