### PR TITLE
sitemap.xmlがkomichi.appを指すように修正

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,8 @@
 APP_ENV=development
 
+APP_PROTOCOL=http
+APP_HOST=localhost:3000
+
 PLANNER_API_PROTOCOL=http
 PLANNER_API_HOST=localhost:8080
 CLOUD_STORAGE_POROTO_PLACE_IMAGES="gs://place-photos-development"

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,8 @@
 APP_ENV=production
 
+APP_PROTOCOL=https
+APP_HOST=komichi.app
+
 PLANNER_API_PROTOCOL=https
 PLANNER_API_HOST=planner.komichi.app
 CLOUD_STORAGE_POROTO_PLACE_IMAGES="gs://poroto-place-photos"

--- a/.env.staging
+++ b/.env.staging
@@ -1,5 +1,8 @@
 APP_ENV=staging
 
+APP_ENV=production
+APP_HOST=staging.komichi.app
+
 PLANNER_API_PROTOCOL=https
 PLANNER_API_HOST=staging.planner.komichi.app
 CLOUD_STORAGE_POROTO_PLACE_IMAGES="gs://place-photos-staging"

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -20,8 +20,8 @@ function generateSiteMap({ pages }: { pages: Page[] }): string {
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
-    const protocol = "https";
-    const host = "poroto.app";
+    const protocol = process.env.APP_PROTOCOL;
+    const host = process.env.APP_HOST;
     const baseUrl = `${protocol}://${host}`;
 
     const sitemap = generateSiteMap({

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -28,7 +28,11 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
         pages: [
             { url: `${baseUrl}/` },
             { url: `${baseUrl}${Routes.plans.interest()}` },
-            { url: `${baseUrl}${Routes.places.search}` },
+            {
+                url: `${baseUrl}${Routes.places.search({
+                    skipCurrentLocation: false,
+                })}`,
+            },
         ],
     });
 


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

環境変数に応じて、sitemapが作成されるように修正した。

|before| after |
|---|-------|
||<img width="423" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/4bddf177-8b93-4cfb-8e1a-316f57bcb67f">|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [ ] http://localhost:3000/sitemap.xml にアクセスして正しく表示されることを確認

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````