### PR TITLE
トップページの保存したプランをスワイプするときに、画像がスワイプれされないようにする

### DIFF
--- a/src/stories/common/ImageSliderPreview.stories.tsx
+++ b/src/stories/common/ImageSliderPreview.stories.tsx
@@ -22,3 +22,36 @@ export const Primary: Story = {
         </Box>
     ),
 };
+
+export const Smartphone: Story = {
+    args: {
+        images: mockPlaces["bookStore"].images,
+    },
+    parameters: {
+        viewport: {
+            defaultViewport: "iphonex",
+        },
+    },
+    render: (args) => (
+        <Box w="100%" maxW="400px" h="400px">
+            <ImageSliderPreview {...args} />
+        </Box>
+    ),
+};
+
+export const NotDraggable: Story = {
+    args: {
+        images: mockPlaces["bookStore"].images,
+        draggable: false,
+    },
+    parameters: {
+        viewport: {
+            defaultViewport: "iphonex",
+        },
+    },
+    render: (args) => (
+        <Box w="100%" maxW="400px" h="400px">
+            <ImageSliderPreview {...args} />
+        </Box>
+    ),
+};

--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -94,7 +94,7 @@ const SlideContainer = styled(Splide)<{ draggable: boolean }>`
     @media screen and (min-width: 700px) {
         & > .splide__arrows {
             opacity: 0;
-           
+
             &:hover {
                 opacity: 1;
             }

--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -79,7 +79,7 @@ const SlideContainer = styled(Splide)<{ draggable: boolean }>`
             }
 
             &:hover {
-                opacity: 1;
+                opacity: 0.7;
                 z-index: 99;
             }
 
@@ -94,9 +94,15 @@ const SlideContainer = styled(Splide)<{ draggable: boolean }>`
     @media screen and (min-width: 700px) {
         & > .splide__arrows {
             opacity: 0;
+        }
 
-            &:hover {
+        &:hover {
+            & > .splide__arrows {
                 opacity: 1;
+
+                & > .splide__arrow {
+                    opacity: 0.7;
+                }
             }
         }
     }

--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -14,6 +14,7 @@ type Props = {
     images: ImageType[];
     imageSize?: ImageSize;
     href?: string;
+    draggable?: boolean;
     borderRadius?: number | string;
     onClickImage?: (image: ImageType) => void;
 };
@@ -22,6 +23,7 @@ export function ImageSliderPreview({
     images,
     imageSize = ImageSizes.Large,
     href,
+    draggable = true,
     borderRadius,
     onClickImage,
 }: Props) {
@@ -29,10 +31,11 @@ export function ImageSliderPreview({
         <SlideContainer
             style={{ borderRadius: borderRadius }}
             options={{
-                drag: images.length > 1,
+                drag: images.length > 1 && draggable,
                 arrows: images.length > 1,
                 lazyLoad: "nearby",
             }}
+            draggable={images.length > 1 && draggable}
         >
             {images.map((image, i) => (
                 <SlideItem key={i}>
@@ -50,7 +53,7 @@ export function ImageSliderPreview({
     );
 }
 
-const SlideContainer = styled(Splide)`
+const SlideContainer = styled(Splide)<{ draggable: boolean }>`
     width: 100%;
     height: 100%;
     cursor: pointer;
@@ -61,7 +64,8 @@ const SlideContainer = styled(Splide)`
     }
 
     & > .splide__arrows {
-        opacity: 0;
+        // ドラッグによるスワイプが可能な場合はページングボタンを非表示
+        opacity: ${({ draggable }) => (draggable ? 0 : 1)};
 
         // 左右に表示される矢印
         & > .splide__arrow {
@@ -88,8 +92,10 @@ const SlideContainer = styled(Splide)`
 
     // pcでホバーをしたときだけ矢印を表示する
     @media screen and (min-width: 700px) {
-        &:hover {
-            & > .splide__arrows {
+        & > .splide__arrows {
+            opacity: 0;
+           
+            &:hover {
                 opacity: 1;
             }
         }

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -108,6 +108,7 @@ function PlanListItem({
                 }
                 wrapTitle={wrapTitle}
                 showAuthor={showAuthor}
+                draggableThumbnail={grid}
             />
         </Box>
     );

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -11,6 +11,7 @@ type Props = {
     planThumbnailHeight?: string | number;
     wrapTitle?: boolean;
     showAuthor?: boolean;
+    draggableThumbnail?: boolean;
 };
 
 export function PlaceHolder() {
@@ -28,6 +29,7 @@ export function PlanPreview({
     planThumbnailHeight,
     wrapTitle = true,
     showAuthor = true,
+    draggableThumbnail = true,
 }: Props) {
     if (!plan) return <PlaceHolder />;
 
@@ -44,6 +46,7 @@ export function PlanPreview({
                 images={thumbnails}
                 h={planThumbnailHeight}
                 link={link}
+                draggable={draggableThumbnail}
             />
             <LinkWrapper href={link}>
                 <Text

--- a/src/view/plan/PlanThumbnail.tsx
+++ b/src/view/plan/PlanThumbnail.tsx
@@ -13,6 +13,7 @@ type Props = {
     imageSize?: ImageSize;
     h?: string | number;
     link?: string;
+    draggable?: boolean;
 };
 
 export const PlanThumbnail = ({
@@ -20,6 +21,7 @@ export const PlanThumbnail = ({
     imageSize = ImageSizes.Small,
     h = "300px",
     link,
+    draggable,
 }: Props) => {
     if (images.length === 0) {
         images.push(getDefaultPlaceImage());
@@ -32,6 +34,7 @@ export const PlanThumbnail = ({
                 imageSize={imageSize}
                 borderRadius="10px"
                 href={link}
+                draggable={draggable}
             />
         </Box>
     );


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|スクショ|before| after |
|---|---|-------|
|<img width="384" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/56e7ba26-24d0-4cff-9fd7-4284a58a9b44">|スワイプすると、保存されたプランのカードの中がスワイプされる|スワイプされるとリスト全体がスワイプされる|
|<img width="197" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/246d7942-dd0a-44cd-aeb4-85351fa1b79b">|spだと常に表示されない|spだと常に表示する|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] スマホビューでスワイプするとリスト全体がスワイプすることを確認
- [x]  sp版で開くとカードに常に半透明のボタンが表示されていることを確認
- [x] pc版で開くとカードホバー時に半透明のボタンが出ることを確認 

```shell
# poroto
export BRANCH_POROTO=feature/swipe_saved_plans
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````