### PR TITLE
トップページの水平スクロール部分の余白を修正

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -124,7 +124,7 @@ const IndexPage = (props: Props) => {
                                 title="お気に入りの場所"
                                 icon={MdOutlineFavoriteBorder}
                             />
-                            <HorizontalScrollableList>
+                            <HorizontalScrollableList px={Padding.p16}>
                                 {likePlaces.map((place, index) => (
                                     <PlaceCard
                                         key={index}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,6 +24,7 @@ import {
 import { useAppDispatch } from "src/redux/redux";
 import { HorizontalScrollableList } from "src/view/common/HorizontalScrollableList";
 import { NavBar } from "src/view/common/NavBar";
+import { Padding } from "src/view/constants/padding";
 import { Size } from "src/view/constants/size";
 import { useLikePlaces } from "src/view/hooks/useLikePlaces";
 import { useNearbyPlans } from "src/view/hooks/useNearbyPlans";
@@ -33,7 +34,6 @@ import { PlanList } from "src/view/plan/PlanList";
 import { CreatePlanDialog } from "src/view/plandetail/CreatePlanDialog";
 import { CreatePlanSection } from "src/view/top/CreatePlanSection";
 import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
-import {Padding} from "src/view/constants/padding";
 
 type Props = {
     plansRecentlyCreated: Plan[] | null;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,7 @@ import {
     setPlaceIdToCreatePlan,
 } from "src/redux/plan";
 import { useAppDispatch } from "src/redux/redux";
-import { HorizontalScrollablelList } from "src/view/common/HorizontalScrollablelList";
+import { HorizontalScrollableList } from "src/view/common/HorizontalScrollableList";
 import { NavBar } from "src/view/common/NavBar";
 import { Size } from "src/view/constants/size";
 import { useLikePlaces } from "src/view/hooks/useLikePlaces";
@@ -33,6 +33,7 @@ import { PlanList } from "src/view/plan/PlanList";
 import { CreatePlanDialog } from "src/view/plandetail/CreatePlanDialog";
 import { CreatePlanSection } from "src/view/top/CreatePlanSection";
 import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
+import {Padding} from "src/view/constants/padding";
 
 type Props = {
     plansRecentlyCreated: Plan[] | null;
@@ -99,7 +100,6 @@ const IndexPage = (props: Props) => {
                 <VStack
                     w="100%"
                     maxW={Size.mainContentWidth}
-                    px="16px"
                     pt="16px"
                     pb="48px"
                     spacing="24px"
@@ -110,6 +110,7 @@ const IndexPage = (props: Props) => {
                             grid={false}
                             wrapTitle={false}
                             showAuthor={false}
+                            px={Padding.p16}
                         >
                             <PlanListSectionTitle
                                 title="保存したプラン"
@@ -123,7 +124,7 @@ const IndexPage = (props: Props) => {
                                 title="お気に入りの場所"
                                 icon={MdOutlineFavoriteBorder}
                             />
-                            <HorizontalScrollablelList>
+                            <HorizontalScrollableList>
                                 {likePlaces.map((place, index) => (
                                     <PlaceCard
                                         key={index}
@@ -135,7 +136,7 @@ const IndexPage = (props: Props) => {
                                         }
                                     />
                                 ))}
-                            </HorizontalScrollablelList>
+                            </HorizontalScrollableList>
                         </VStack>
                     )}
                     {/* TODO: 拒否設定されている場合の対処をする */}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -143,6 +143,7 @@ const IndexPage = (props: Props) => {
                     <NearbyPlanList
                         plans={plansNearby}
                         locationPermission={locationPermission}
+                        px={Size.top.px}
                         isFetchingCurrentLocation={isFetchingCurrentLocation}
                         isFetchingNearbyPlans={isFetchingNearbyPlans}
                         onRequestFetchNearByPlans={fetchNearbyPlans}
@@ -155,7 +156,7 @@ const IndexPage = (props: Props) => {
                         hasMore={nextPageTokenPlansRecentlyCreated !== null}
                         style={{ width: "100%" }}
                     >
-                        <PlanList plans={plansRecentlyCreated}>
+                        <PlanList plans={plansRecentlyCreated} px={Size.top.px}>
                             <PlanListSectionTitle
                                 title="最近作成されたプラン"
                                 icon={MdTrendingUp}

--- a/src/stories/common/ImageSliderPreview.stories.tsx
+++ b/src/stories/common/ImageSliderPreview.stories.tsx
@@ -22,3 +22,36 @@ export const Primary: Story = {
         </Box>
     ),
 };
+
+export const Smartphone: Story = {
+    args: {
+        images: mockPlaces["bookStore"].images,
+    },
+    parameters: {
+        viewport: {
+            defaultViewport: "iphonex",
+        },
+    },
+    render: (args) => (
+        <Box w="100%" maxW="400px" h="400px">
+            <ImageSliderPreview {...args} />
+        </Box>
+    ),
+};
+
+export const NotDraggable: Story = {
+    args: {
+        images: mockPlaces["bookStore"].images,
+        draggable: false,
+    },
+    parameters: {
+        viewport: {
+            defaultViewport: "iphonex",
+        },
+    },
+    render: (args) => (
+        <Box w="100%" maxW="400px" h="400px">
+            <ImageSliderPreview {...args} />
+        </Box>
+    ),
+};

--- a/src/view/common/HorizontalScrollableList.tsx
+++ b/src/view/common/HorizontalScrollableList.tsx
@@ -6,12 +6,14 @@ import { isPC } from "src/view/constants/userAgent";
 type Props = {
     scrollAmount?: number;
     pageButtonOffsetY?: number;
+    px?: number | string;
     children?: ReactNode;
 };
 
-export const HorizontalScrollablelList = ({
+export const HorizontalScrollableList = ({
     scrollAmount = 400,
     pageButtonOffsetY = 0,
+    px = 0,
     children,
 }: Props) => {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -32,7 +34,7 @@ export const HorizontalScrollablelList = ({
             <HStack
                 ref={containerRef}
                 w="100%"
-                // px={isPC ? "16px" : 0}
+                px={px}
                 overflowX="auto"
                 overflowY="hidden"
                 alignItems="flex-start"

--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -94,7 +94,7 @@ const SlideContainer = styled(Splide)<{ draggable: boolean }>`
     @media screen and (min-width: 700px) {
         & > .splide__arrows {
             opacity: 0;
-           
+
             &:hover {
                 opacity: 1;
             }

--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -79,7 +79,7 @@ const SlideContainer = styled(Splide)<{ draggable: boolean }>`
             }
 
             &:hover {
-                opacity: 1;
+                opacity: 0.7;
                 z-index: 99;
             }
 
@@ -94,9 +94,15 @@ const SlideContainer = styled(Splide)<{ draggable: boolean }>`
     @media screen and (min-width: 700px) {
         & > .splide__arrows {
             opacity: 0;
+        }
 
-            &:hover {
+        &:hover {
+            & > .splide__arrows {
                 opacity: 1;
+
+                & > .splide__arrow {
+                    opacity: 0.7;
+                }
             }
         }
     }

--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -14,6 +14,7 @@ type Props = {
     images: ImageType[];
     imageSize?: ImageSize;
     href?: string;
+    draggable?: boolean;
     borderRadius?: number | string;
     onClickImage?: (image: ImageType) => void;
 };
@@ -22,6 +23,7 @@ export function ImageSliderPreview({
     images,
     imageSize = ImageSizes.Large,
     href,
+    draggable = true,
     borderRadius,
     onClickImage,
 }: Props) {
@@ -29,10 +31,11 @@ export function ImageSliderPreview({
         <SlideContainer
             style={{ borderRadius: borderRadius }}
             options={{
-                drag: images.length > 1,
+                drag: images.length > 1 && draggable,
                 arrows: images.length > 1,
                 lazyLoad: "nearby",
             }}
+            draggable={images.length > 1 && draggable}
         >
             {images.map((image, i) => (
                 <SlideItem key={i}>
@@ -50,7 +53,7 @@ export function ImageSliderPreview({
     );
 }
 
-const SlideContainer = styled(Splide)`
+const SlideContainer = styled(Splide)<{ draggable: boolean }>`
     width: 100%;
     height: 100%;
     cursor: pointer;
@@ -61,7 +64,8 @@ const SlideContainer = styled(Splide)`
     }
 
     & > .splide__arrows {
-        opacity: 0;
+        // ドラッグによるスワイプが可能な場合はページングボタンを非表示
+        opacity: ${({ draggable }) => (draggable ? 0 : 1)};
 
         // 左右に表示される矢印
         & > .splide__arrow {
@@ -88,8 +92,10 @@ const SlideContainer = styled(Splide)`
 
     // pcでホバーをしたときだけ矢印を表示する
     @media screen and (min-width: 700px) {
-        &:hover {
-            & > .splide__arrows {
+        & > .splide__arrows {
+            opacity: 0;
+           
+            &:hover {
                 opacity: 1;
             }
         }

--- a/src/view/constants/padding.ts
+++ b/src/view/constants/padding.ts
@@ -2,4 +2,5 @@
 export const Padding = {
     p8: "8px",
     p16: "16px",
+    p24: "24px",
 };

--- a/src/view/constants/padding.ts
+++ b/src/view/constants/padding.ts
@@ -1,0 +1,5 @@
+// TODO: この定数を用いて統一する
+export const Padding = {
+    p8: "8px",
+    p16: "16px",
+};

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -4,6 +4,9 @@ export const Size = {
     mainContentWidth: "var(--size-main-content-width)",
     top: {
         px: Padding.p16,
+        SectionTitle: {
+            px: Padding.p24,
+        }
     },
     PlaceCardPaddingH: Padding.p16,
     NavBar: {

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -2,6 +2,9 @@ import {Padding} from "src/view/constants/padding";
 
 export const Size = {
     mainContentWidth: "var(--size-main-content-width)",
+    top: {
+        px: Padding.p16,
+    },
     PlaceCardPaddingH: Padding.p16,
     NavBar: {
         height: "50px",

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -1,13 +1,19 @@
+// TODO: この定数を用いて統一する
+const Padding = {
+    p8: "8px",
+    p16: "16px",
+}
+
 export const Size = {
     mainContentWidth: "var(--size-main-content-width)",
-    PlaceCardPaddingH: "16px",
+    PlaceCardPaddingH: Padding.p16,
     NavBar: {
         height: "50px",
     },
     PlanDetailHeader: {
         maxH: "900px",
         maxW: "500px",
-        px: "16px",
+        px: Padding.p16,
         imageH: "300px",
     },
     PlanList: {

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -1,4 +1,4 @@
-import {Padding} from "src/view/constants/padding";
+import { Padding } from "src/view/constants/padding";
 
 export const Size = {
     mainContentWidth: "var(--size-main-content-width)",
@@ -6,7 +6,7 @@ export const Size = {
         px: Padding.p16,
         SectionTitle: {
             px: Padding.p24,
-        }
+        },
     },
     PlaceCardPaddingH: Padding.p16,
     NavBar: {

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -1,8 +1,4 @@
-// TODO: この定数を用いて統一する
-const Padding = {
-    p8: "8px",
-    p16: "16px",
-}
+import {Padding} from "src/view/constants/padding";
 
 export const Size = {
     mainContentWidth: "var(--size-main-content-width)",

--- a/src/view/plan/NearbyPlanList.tsx
+++ b/src/view/plan/NearbyPlanList.tsx
@@ -13,6 +13,7 @@ import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
 type Props = {
     plans: Plan[] | null;
     locationPermission: LocationPermission | null;
+    px?: string | number;
     isFetchingNearbyPlans: boolean;
     isFetchingCurrentLocation: boolean;
     onRequestFetchNearByPlans: () => void;
@@ -21,6 +22,7 @@ type Props = {
 export function NearbyPlanList({
     plans,
     locationPermission,
+    px,
     isFetchingNearbyPlans,
     isFetchingCurrentLocation,
     onRequestFetchNearByPlans,
@@ -38,6 +40,7 @@ export function NearbyPlanList({
             }
             isLoading={isFetchingNearbyPlans}
             numPlaceHolders={isPC ? 3 : 1}
+            px={px}
         >
             <PlanListSectionTitle
                 title="近くのプラン"

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -2,7 +2,7 @@ import { Box, VStack } from "@chakra-ui/react";
 import { ReactNode } from "react";
 import { Plan } from "src/domain/models/Plan";
 import { createArrayWithSize } from "src/domain/util/array";
-import { HorizontalScrollablelList } from "src/view/common/HorizontalScrollablelList";
+import { HorizontalScrollableList } from "src/view/common/HorizontalScrollableList";
 import { Routes } from "src/view/constants/router";
 import { Size } from "src/view/constants/size";
 import { PlanPreview } from "src/view/plan/PlanPreview";
@@ -18,6 +18,7 @@ type Props = {
     grid?: boolean;
     wrapTitle?: boolean;
     showAuthor?: boolean;
+    px?: string | number;
 };
 
 export function PlanList({
@@ -29,6 +30,7 @@ export function PlanList({
     grid = true,
     wrapTitle,
     showAuthor,
+    px = 0,
 }: Props) {
     if (!plans || plans.length == 0 || isLoading) {
         if (empty && !isLoading) {
@@ -43,7 +45,7 @@ export function PlanList({
         return (
             <Container>
                 {children}
-                <Layout grid={grid}>
+                <Layout grid={grid} px={px}>
                     {createArrayWithSize(numPlaceHolders).map((i) => (
                         <PlanListItem
                             key={i}
@@ -61,7 +63,7 @@ export function PlanList({
     return (
         <Container>
             {children}
-            <Layout grid={grid}>
+            <Layout grid={grid} px={px}>
                 {plans.map((plan, index) => (
                     <>
                         <PlanListItem
@@ -114,23 +116,32 @@ function PlanListItem({
     );
 }
 
-const Layout = ({ grid, children }: { grid: boolean; children: ReactNode }) => {
+const Layout = ({
+    grid,
+    px,
+    children,
+}: {
+    grid: boolean;
+    px: string | number;
+    children: ReactNode;
+}) => {
     if (grid) {
-        return <GridLayout>{children}</GridLayout>;
+        return <GridLayout px={px}>{children}</GridLayout>;
     }
 
     return (
-        <HorizontalScrollablelList pageButtonOffsetY={-8}>
+        <HorizontalScrollableList pageButtonOffsetY={-8} px={px}>
             {children}
-        </HorizontalScrollablelList>
+        </HorizontalScrollableList>
     );
 };
 
-const GridLayout = styled.div`
+const GridLayout = styled.div<{ px?: string | number }>`
     display: grid;
     width: 100%;
     column-gap: 24px;
     row-gap: 48px;
+    padding: ${({ px }) => px};
 
     grid-template-columns: 1fr;
 

--- a/src/view/plan/PlanList.tsx
+++ b/src/view/plan/PlanList.tsx
@@ -108,6 +108,7 @@ function PlanListItem({
                 }
                 wrapTitle={wrapTitle}
                 showAuthor={showAuthor}
+                draggableThumbnail={grid}
             />
         </Box>
     );

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -11,6 +11,7 @@ type Props = {
     planThumbnailHeight?: string | number;
     wrapTitle?: boolean;
     showAuthor?: boolean;
+    draggableThumbnail?: boolean;
 };
 
 export function PlaceHolder() {
@@ -28,6 +29,7 @@ export function PlanPreview({
     planThumbnailHeight,
     wrapTitle = true,
     showAuthor = true,
+    draggableThumbnail = true,
 }: Props) {
     if (!plan) return <PlaceHolder />;
 
@@ -44,6 +46,7 @@ export function PlanPreview({
                 images={thumbnails}
                 h={planThumbnailHeight}
                 link={link}
+                draggable={draggableThumbnail}
             />
             <LinkWrapper href={link}>
                 <Text

--- a/src/view/plan/PlanThumbnail.tsx
+++ b/src/view/plan/PlanThumbnail.tsx
@@ -13,6 +13,7 @@ type Props = {
     imageSize?: ImageSize;
     h?: string | number;
     link?: string;
+    draggable?: boolean;
 };
 
 export const PlanThumbnail = ({
@@ -20,6 +21,7 @@ export const PlanThumbnail = ({
     imageSize = ImageSizes.Small,
     h = "300px",
     link,
+    draggable,
 }: Props) => {
     if (images.length === 0) {
         images.push(getDefaultPlaceImage());
@@ -32,6 +34,7 @@ export const PlanThumbnail = ({
                 imageSize={imageSize}
                 borderRadius="10px"
                 href={link}
+                draggable={draggable}
             />
         </Box>
     );

--- a/src/view/plandetail/NearbyPlaceList.tsx
+++ b/src/view/plandetail/NearbyPlaceList.tsx
@@ -1,6 +1,6 @@
 import { Place } from "src/domain/models/Place";
 import { createArrayWithSize } from "src/domain/util/array";
-import { HorizontalScrollablelList } from "src/view/common/HorizontalScrollablelList";
+import { HorizontalScrollableList } from "src/view/common/HorizontalScrollableList";
 import { PlaceCard } from "src/view/place/PlaceCard";
 
 type Props = {
@@ -11,17 +11,17 @@ type Props = {
 export const NearbyPlaceList = ({ places, onSelectPlace }: Props) => {
     if (!places) {
         return (
-            <HorizontalScrollablelList>
+            <HorizontalScrollableList>
                 {createArrayWithSize(5).map((_, index) => (
                     <PlaceCard place={null} key={index} />
                 ))}
-            </HorizontalScrollablelList>
+            </HorizontalScrollableList>
         );
     }
 
     // TODO: 要素が一つもないときの対応
     return (
-        <HorizontalScrollablelList>
+        <HorizontalScrollableList>
             {places
                 .filter((p) => p.images.length > 0)
                 .map((place, index) => (
@@ -31,6 +31,6 @@ export const NearbyPlaceList = ({ places, onSelectPlace }: Props) => {
                         onClick={() => onSelectPlace?.(place)}
                     />
                 ))}
-        </HorizontalScrollablelList>
+        </HorizontalScrollableList>
     );
 };

--- a/src/view/top/PlanListSectionTitle.tsx
+++ b/src/view/top/PlanListSectionTitle.tsx
@@ -1,5 +1,6 @@
 import { Box, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { IconType } from "react-icons";
+import {Size} from "src/view/constants/size";
 
 type Props = {
     title: string;
@@ -9,7 +10,7 @@ type Props = {
 export function PlanListSectionTitle({ title, icon }: Props) {
     return (
         <VStack w="100%" alignItems="flex-start">
-            <VStack py="32px" px="8px" alignItems="flex-start" spacing={4}>
+            <VStack py="32px" px={Size.top.SectionTitle.px} alignItems="flex-start" spacing={4}>
                 <HStack color="#3E3E3E">
                     <Icon w="32px" h="32px" as={icon} />
                     <Text

--- a/src/view/top/PlanListSectionTitle.tsx
+++ b/src/view/top/PlanListSectionTitle.tsx
@@ -1,6 +1,6 @@
 import { Box, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { IconType } from "react-icons";
-import {Size} from "src/view/constants/size";
+import { Size } from "src/view/constants/size";
 
 type Props = {
     title: string;
@@ -10,7 +10,12 @@ type Props = {
 export function PlanListSectionTitle({ title, icon }: Props) {
     return (
         <VStack w="100%" alignItems="flex-start">
-            <VStack py="32px" px={Size.top.SectionTitle.px} alignItems="flex-start" spacing={4}>
+            <VStack
+                py="32px"
+                px={Size.top.SectionTitle.px}
+                alignItems="flex-start"
+                spacing={4}
+            >
                 <HStack color="#3E3E3E">
                     <Icon w="32px" h="32px" as={icon} />
                     <Text


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|<img width="381" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/f72b6a85-20b3-4045-b9b0-500858e69f4c">|<img width="385" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/19d0c8c7-538d-4738-8674-ce8f9f0ee62d">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 水平スクロールをしたときに見きれないようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] sp版でスクロールしたときに、リストの左右に余白が入らないことを確認

```shell
# poroto
export BRANCH_POROTO=feature/top_page_h_padding
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````