### PR TITLE
場所に2枚目の画像をアップロードすると画面がバグる不具合を修正

### DIFF
--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -65,7 +65,7 @@ const SlideContainer = styled(Splide)<{ $draggable: boolean }>`
 
     & > .splide__arrows {
         // ドラッグによるスワイプが可能な場合はページングボタンを非表示
-        // opacity: ${({ draggable }) => (draggable ? 0 : 1)};
+        // opacity: ${({ $draggable }) => ($draggable ? 0 : 1)};
 
         // 左右に表示される矢印
         & > .splide__arrow {

--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -35,7 +35,7 @@ export function ImageSliderPreview({
                 arrows: images.length > 1,
                 lazyLoad: "nearby",
             }}
-            draggable={images.length > 1 && draggable}
+            $draggable={images.length > 1 && draggable}
         >
             {images.map((image, i) => (
                 <SlideItem key={i}>
@@ -53,7 +53,7 @@ export function ImageSliderPreview({
     );
 }
 
-const SlideContainer = styled(Splide)<{ draggable: boolean }>`
+const SlideContainer = styled(Splide)<{ $draggable: boolean }>`
     width: 100%;
     height: 100%;
     cursor: pointer;
@@ -65,7 +65,7 @@ const SlideContainer = styled(Splide)<{ draggable: boolean }>`
 
     & > .splide__arrows {
         // ドラッグによるスワイプが可能な場合はページングボタンを非表示
-        opacity: ${({ draggable }) => (draggable ? 0 : 1)};
+        // opacity: ${({ draggable }) => (draggable ? 0 : 1)};
 
         // 左右に表示される矢印
         & > .splide__arrow {


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- styled-componentでパラメータを渡すときに、パラメータ名がHTMLの属性と一致しているため不具合を起こしたのだと考えられる

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] まだ画像がアップロードされていない場所に対して画像をアップロードし、画面が適切に更新される

```shell
# poroto
export BRANCH_POROTO=feature/fix_upload_image_splide
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````