### PR TITLE
ファイル名が日本語だと写真を登録できない不具合を修正

### DIFF
--- a/src/domain/util/file.test.ts
+++ b/src/domain/util/file.test.ts
@@ -1,0 +1,37 @@
+import { getFileExtension } from "src/domain/util/file";
+
+describe("getFileExtension", () => {
+    const cases: {
+        name: string;
+        fileName: string;
+        expected: string | null;
+    }[] = [
+        {
+            name: "no extension",
+            fileName: "file",
+            expected: null,
+        },
+        {
+            name: "one extension",
+            fileName: "file.txt",
+            expected: "txt",
+        },
+        {
+            name: "two extensions",
+            fileName: "file.tar.gz",
+            expected: "gz",
+        },
+        {
+            name: "with file path",
+            fileName: "path/to/file.txt",
+            expected: "txt",
+        },
+    ];
+
+    cases.forEach((c) =>
+        test(c.name, () => {
+            const actual = getFileExtension(c.fileName);
+            expect(actual).toEqual(c.expected);
+        })
+    );
+});

--- a/src/domain/util/file.ts
+++ b/src/domain/util/file.ts
@@ -1,0 +1,7 @@
+export function getFileExtension(filename: string): string | null {
+    const parts = filename.split(".");
+    if (parts.length === 1) {
+        return null;
+    }
+    return parts.pop();
+}

--- a/src/view/hooks/useUploadPlaceImage.ts
+++ b/src/view/hooks/useUploadPlaceImage.ts
@@ -8,6 +8,7 @@ import {
     uploadBytesResumable,
 } from "firebase/storage";
 import { useState } from "react";
+import { getFileExtension } from "src/domain/util/file";
 import { reduxAuthSelector } from "src/redux/auth";
 import { reduxPlanSelector, uploadPlacePhotosInPlan } from "src/redux/plan";
 import { useAppDispatch } from "src/redux/redux";
@@ -86,7 +87,14 @@ const useUploadPlaceImage = () => {
 
             const uploadTasks = localFilesWithSize.map(
                 async ({ file, size, placeId }) => {
-                    const uniqueFileName = `${uuidv4()}_${file.name}`;
+                    let uniqueFileName = uuidv4();
+
+                    // ファイル名が日本語の場合は downloadUrl が長くなってしまうため、拡張子だけ取得する
+                    const fileExtension = getFileExtension(file.name);
+                    if (fileExtension) {
+                        uniqueFileName += `.${fileExtension}`;
+                    }
+
                     const storageRef = ref(storage, `images/${uniqueFileName}`);
                     const { downloadUrl } = await uploadFile(file, storageRef);
                     return { downloadUrl, size, placeId };


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
<!--
|before| after |
|---|-------|
|||
-->
- ファイル名が日本語の場合、Cloud Storageのアップロードまでは成功するが、URLを取得するときにURL EncodingされURLが長くなるため、plannnerに登録できない不具合が生じていた。
- そこで、アップロードされたファイルから取得するのは拡張子のみとし、ファイル名は利用しないようにした。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] アップロードされる画像のファイル名が、`{{ uuid }}.{{ 拡張子 }}`のフォーマットになっていることを確認

画像アップロードリクエストに含まれる画像のファイル名を確認
<img width="761" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/b55c19cb-4bf3-4809-b39f-24a921e4bc53">

```shell
# poroto
export BRANCH_POROTO=feature/fix_long_file_name
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````