### PR TITLE
staging環境の環境変数の誤りを修正

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -1,6 +1,6 @@
 APP_ENV=staging
 
-APP_ENV=production
+APP_PROTOCOL=https
 APP_HOST=staging.komichi.app
 
 PLANNER_API_PROTOCOL=https

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,6 +33,9 @@ const nextConfig = {
     env: {
         APP_ENV: process.env.APP_ENV,
 
+        APP_PROTOCOL: process.env.APP_PROTOCOL,
+        APP_HOST: process.env.APP_HOST,
+
         PLANNER_API_PROTOCOL: process.env.PLANNER_API_PROTOCOL,
         PLANNER_API_HOST: process.env.PLANNER_API_HOST,
         PLANNER_API_ENDPOINT: `${process.env.PLANNER_API_PROTOCOL}://${process.env.PLANNER_API_HOST}`,


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- Stagingの環境変数について`APP_PROTOCOL`が存在せず、`APP_ENV`が上書きされてしまっている誤りを修正した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- Staging環境でBasic認証ができなくなってしまっている不具合を修正
- Staging環境で広告が表示されてしまっている不具合を修正

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] stagingビルドを行い、basic認証がされることを確認
- [x] http://localhost:3000/sitemap.xml にアクセスして、staging環境のURLが表示されることを確認 

```
ENV=staging yarn build-env
PORT=3000 yarn start
``` 

```shell
# poroto
export BRANCH_POROTO=feature/fix_staging_app_env
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````