### PR TITLE
Safariでプラン候補一覧ページをスクロールしたときの不具合を修正

### DIFF
--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -148,17 +148,16 @@ const SelectPlanPage = () => {
         );
 
     return (
-        <VStack w="100%">
+        <VStack w="100%" spacing={0}>
             <NavBar />
             <Center
                 w="100%"
                 h={`calc(100vh - ${Size.NavBar.height})`}
                 px="16px"
-                py="16px"
                 ref={refPlanCandidateGallery}
                 overflowX="hidden"
             >
-                <VStack spacing="32px" my="32px">
+                <VStack spacing="32px">
                     <PlanCandidatesGallery
                         planCandidates={plansCreated}
                         activePlanIndex={selectedPlanIndex}

--- a/src/view/hooks/usePlanCandidateGalleryPageAutoScroll.ts
+++ b/src/view/hooks/usePlanCandidateGalleryPageAutoScroll.ts
@@ -29,7 +29,8 @@ export const usePlanCandidateGalleryPageAutoScroll = () => {
         // Safariだとページ上部までいきおいよくスクロールすると、スクロール量がマイナスになり
         // スクロール方向も下方向になることがあるため、その場合はスクロール量を0として扱う
         const isBounded = prevScrollYRef.current < 0;
-        const isScrollingDown = currentScroll > prevScrollYRef.current && !isBounded;
+        const isScrollingDown =
+            currentScroll > prevScrollYRef.current && !isBounded;
 
         // PlanDetailのトップより上で下方向にスクロールした場合は
         // プラン詳細セクションのトップまで自動スクロールを開始


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- プラン候補一覧ページでSafariで勢いよく上向きにスクロールすると、自動スクロールが発生する不具合を修正
- バウンドが発生し、下向きスクロール判定されることが原因

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #600 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] Safariで下向きにスクロールしたときに適切に自動スクロールが発生することを確認
- [x] Safariでプラン詳細部から上向きに勢いよくスクロールしたときに 、一覧部で停止することを確認
- [x] Chromeで下向きにスクロールしたときに適切に自動スクロールが発生することを確認
- [x] Chromeでプラン詳細部から上向きに勢いよくスクロールしたときに 、一覧部で停止することを確認

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````