### PR TITLE
位置情報取得失敗時に、現在地を利用せずにプランを作るページに移動できるようにする

### DIFF
--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -89,16 +89,16 @@ function Failed({
 }) {
     return (
         <VStack w="100%">
+            <VStack spacing={0}>
+                <Text fontWeight="bold" fontSize="20px">位置情報の取得に失敗しました</Text>
+                <Text>設定をご確認ください</Text>
+            </VStack>
             <Box w="100%" position="relative" h="250px">
                 <LottiePlayer
                     animationData={animationDataFailedLocation}
                     loop={false}
                 />
             </Box>
-            <VStack spacing={0}>
-                <Text>位置情報の取得に失敗しました</Text>
-                <Text>設定をご確認ください</Text>
-            </VStack>
             <VStack w="100%" pt="8px">
                 <Button
                     w="100%"

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -111,7 +111,7 @@ function Failed({
                 <Link
                     href={Routes.places.search({ skipCurrentLocation: true })}
                     style={{ width: "100%" }}
-                    mt="16px"
+                    my="16px"
                 >
                     <Button w="100%" variant="link" colorScheme="blue">
                         {skipLocationLabel}

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -101,24 +101,23 @@ function Failed({
                     loop={false}
                 />
             </Box>
-            <VStack w="100%" pt="8px">
-                <Button
-                    w="100%"
-                    variant="outline"
-                    colorScheme="blue"
-                    onClick={onClickReFetch}
-                >
-                    再取得
-                </Button>
+            <VStack w="100%" py="16px">
                 <Link
                     href={Routes.places.search({ skipCurrentLocation: true })}
                     style={{ width: "100%" }}
-                    my="16px"
                 >
-                    <Button w="100%" variant="link" colorScheme="blue">
+                    <Button
+                        w="100%"
+                        variant="outline"
+                        colorScheme="blue"
+                        onClick={onClickReFetch}
+                    >
                         {skipLocationLabel}
                     </Button>
                 </Link>
+                <Button w="100%" variant="link" colorScheme="blue">
+                    再取得
+                </Button>
             </VStack>
         </VStack>
     );

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -90,7 +90,9 @@ function Failed({
     return (
         <VStack w="100%">
             <VStack spacing={0}>
-                <Text fontWeight="bold" fontSize="20px">位置情報の取得に失敗しました</Text>
+                <Text fontWeight="bold" fontSize="20px">
+                    位置情報の取得に失敗しました
+                </Text>
                 <Text>設定をご確認ください</Text>
             </VStack>
             <Box w="100%" position="relative" h="250px">

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -44,7 +44,10 @@ export function FetchLocationDialog({
                     )}
                     {fetchLocationRequestStatus ===
                         RequestStatuses.REJECTED && (
-                        <Failed onClickReFetch={onRetry} />
+                        <Failed
+                            skipLocationLabel={skipLocationLabel}
+                            onClickReFetch={onRetry}
+                        />
                     )}
                 </Box>
             </RoundedDialog>
@@ -77,7 +80,13 @@ function Fetching({
     );
 }
 
-function Failed({ onClickReFetch }: { onClickReFetch: () => void }) {
+function Failed({
+    skipLocationLabel,
+    onClickReFetch,
+}: {
+    skipLocationLabel: string;
+    onClickReFetch: () => void;
+}) {
     return (
         <VStack w="100%">
             <Box w="100%" position="relative" h="250px">
@@ -99,9 +108,13 @@ function Failed({ onClickReFetch }: { onClickReFetch: () => void }) {
                 >
                     再取得
                 </Button>
-                <Link href={Routes.home} style={{ width: "100%" }}>
+                <Link
+                    href={Routes.places.search({ skipCurrentLocation: true })}
+                    style={{ width: "100%" }}
+                    mt="16px"
+                >
                     <Button w="100%" variant="link" colorScheme="blue">
-                        ホームに戻る
+                        {skipLocationLabel}
                     </Button>
                 </Link>
             </VStack>


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|<img width="317" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/849f3712-55d2-420d-b5e1-7172f0d60b2e">|<img width="355" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/a01aab2a-b9ee-4509-9ae3-e2e8b19a5e3a">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- iPhoneユーザーは位置情報が拒否設定されていることが多く、ブラウザからの許可要求ダイアログも表示されない
- そのようなユーザーに対応するため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] 位置情報を拒否設定した状態で「好きな場所からプランを作成する」ボタンが表示される
- [x] ボタンを押して遷移すると、位置情報の取得が行われない 

```shell
# poroto
export BRANCH_POROTO=feature/location_unavailable
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````