### PR TITLE
位置情報取得中ダイアログのLottieの背景色が浮いている

### DIFF
--- a/docs/tools/lottie.md
+++ b/docs/tools/lottie.md
@@ -1,0 +1,5 @@
+# Lottie
+
+| ファイル名                 | オリジナルURL                                               |
+|-----------------------|--------------------------------------------------------|
+| location-loading.json | https://lottiefiles.com/animations/location-Plib9UEgQJ |

--- a/src/stories/plan/candidate/GeneratingPlanDialog.stories.tsx
+++ b/src/stories/plan/candidate/GeneratingPlanDialog.stories.tsx
@@ -11,11 +11,15 @@ export default {
 type Story = StoryObj<typeof GeneratingPlanDialog>;
 
 export const Primary: Story = {
-    args: {},
+    args: {
+        visible: true,
+        failed: false,
+    },
 };
 
 export const Failed: Story = {
     args: {
+        visible: true,
         failed: true,
     },
 };

--- a/src/view/common/RoundedDialog.tsx
+++ b/src/view/common/RoundedDialog.tsx
@@ -1,5 +1,6 @@
 import { Box } from "@chakra-ui/react";
 import { ReactNode } from "react";
+import { Colors } from "src/view/constants/color";
 
 type Props = {
     children?: ReactNode;
@@ -8,7 +9,7 @@ type Props = {
 export function RoundedDialog({ children }: Props) {
     return (
         <Box
-            backgroundColor="#FFF8F3"
+            backgroundColor={Colors.dialog.backgroundColor}
             w="500px"
             maxW="100%"
             borderRadius="20px"

--- a/src/view/common/RoundedDialog.tsx
+++ b/src/view/common/RoundedDialog.tsx
@@ -3,15 +3,17 @@ import { ReactNode } from "react";
 import { Colors } from "src/view/constants/color";
 
 type Props = {
+    h?: string | number;
     children?: ReactNode;
 };
 
-export function RoundedDialog({ children }: Props) {
+export function RoundedDialog({ h, children }: Props) {
     return (
         <Box
             backgroundColor={Colors.dialog.backgroundColor}
             w="500px"
             maxW="100%"
+            h={h}
             borderRadius="20px"
             overflow="hidden"
         >

--- a/src/view/common/RoundedDialog.tsx
+++ b/src/view/common/RoundedDialog.tsx
@@ -4,13 +4,18 @@ import { Colors } from "src/view/constants/color";
 
 type Props = {
     h?: string | number;
+    backgroundColor?: string;
     children?: ReactNode;
 };
 
-export function RoundedDialog({ h, children }: Props) {
+export function RoundedDialog({
+    h,
+    backgroundColor = Colors.dialog.backgroundColor,
+    children,
+}: Props) {
     return (
         <Box
-            backgroundColor={Colors.dialog.backgroundColor}
+            backgroundColor={backgroundColor}
             w="500px"
             maxW="100%"
             h={h}

--- a/src/view/constants/color.ts
+++ b/src/view/constants/color.ts
@@ -22,4 +22,8 @@ export const Colors = {
         700: "var(--color-primary-700)",
         800: "var(--color-primary-800)",
     },
+
+    dialog: {
+        backgroundColor: "#FFF8F3",
+    },
 };

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -7,6 +7,7 @@ import {
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 import { LottiePlayer } from "src/view/common/LottiePlayer";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
+import { Colors } from "src/view/constants/color";
 import { Routes } from "src/view/constants/router";
 import animationDataFailedLocation from "src/view/lottie/location-failed.json";
 import animationDataLoadingLocation from "src/view/lottie/location-loading.json";
@@ -62,7 +63,10 @@ function Fetching({
     return (
         <VStack w="100%">
             <Box w="100%" position="relative" h="250px">
-                <LottiePlayer animationData={animationDataLoadingLocation} />
+                <LottiePlayer
+                    animationData={animationDataLoadingLocation}
+                    style={{ fill: Colors.dialog.backgroundColor }}
+                />
             </Box>
             <Text>位置情報を取得しています...</Text>
             {isSkipCurrentLocationVisible && (
@@ -84,6 +88,7 @@ function Failed({ onClickReFetch }: { onClickReFetch: () => void }) {
                 <LottiePlayer
                     animationData={animationDataFailedLocation}
                     loop={false}
+                    style={{ fill: Colors.dialog.backgroundColor }}
                 />
             </Box>
             <VStack spacing={0}>

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -7,7 +7,6 @@ import {
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 import { LottiePlayer } from "src/view/common/LottiePlayer";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
-import { Colors } from "src/view/constants/color";
 import { Routes } from "src/view/constants/router";
 import animationDataFailedLocation from "src/view/lottie/location-failed.json";
 import animationDataLoadingLocation from "src/view/lottie/location-loading.json";
@@ -33,7 +32,7 @@ export function FetchLocationDialog({
             ].includes(fetchLocationRequestStatus)}
             padding="16px"
         >
-            <RoundedDialog>
+            <RoundedDialog backgroundColor="white">
                 <Box p="16px" w="100%">
                     {fetchLocationRequestStatus === RequestStatuses.PENDING && (
                         <Fetching
@@ -63,10 +62,7 @@ function Fetching({
     return (
         <VStack w="100%">
             <Box w="100%" position="relative" h="250px">
-                <LottiePlayer
-                    animationData={animationDataLoadingLocation}
-                    style={{ fill: Colors.dialog.backgroundColor }}
-                />
+                <LottiePlayer animationData={animationDataLoadingLocation} />
             </Box>
             <Text>位置情報を取得しています...</Text>
             {isSkipCurrentLocationVisible && (
@@ -88,7 +84,6 @@ function Failed({ onClickReFetch }: { onClickReFetch: () => void }) {
                 <LottiePlayer
                     animationData={animationDataFailedLocation}
                     loop={false}
-                    style={{ fill: Colors.dialog.backgroundColor }}
                 />
             </Box>
             <VStack spacing={0}>

--- a/src/view/plan/candidate/GeneratingPlanDialog.tsx
+++ b/src/view/plan/candidate/GeneratingPlanDialog.tsx
@@ -1,8 +1,8 @@
 import { Box, Center, Text, VStack } from "@chakra-ui/react";
-import { ReactNode } from "react";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 import { LottiePlayer } from "src/view/common/LottiePlayer";
 import { RoundedButton } from "src/view/common/RoundedButton";
+import { RoundedDialog } from "src/view/common/RoundedDialog";
 import animationDataCreating from "src/view/lottie/creating_map.json";
 import animationDataFailed from "src/view/lottie/fail.json";
 
@@ -27,10 +27,14 @@ export function GeneratingPlanDialog({ visible, failed, onClose }: Props) {
             height="500px"
             maxWidth="500px"
             maxHeight="100%"
+            paddingX="16px"
+            paddingY="32px"
         >
-            <Dialog>
-                {failed ? <Failed onClose={onClose} /> : <Generating />}
-            </Dialog>
+            <RoundedDialog h="100%">
+                <Center w="100%" h="100%" px="16px" py="32px">
+                    {failed ? <Failed onClose={onClose} /> : <Generating />}
+                </Center>
+            </RoundedDialog>
         </FullscreenDialog>
     );
 }
@@ -68,22 +72,5 @@ function Failed({ onClose }: { onClose: () => void }) {
             </VStack>
             <RoundedButton onClick={onClose}>閉じる</RoundedButton>
         </VStack>
-    );
-}
-
-function Dialog({ children }: { children?: ReactNode }) {
-    return (
-        <Center w="100%" h="100%" py="32px" px="16px">
-            <Center
-                w="100%"
-                h="100%"
-                px="16px"
-                py="32px"
-                backgroundColor="#FFF8F3"
-                borderRadius="30px"
-            >
-                {children}
-            </Center>
-        </Center>
     );
 }


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after | storybook URL |
|---|-------|---|
|![image](https://github.com/poroto-app/poroto/assets/55840281/58e2430c-e0a5-416a-b8bb-6aaeefcce8aa)|![image](https://github.com/poroto-app/poroto/assets/55840281/ed506b8c-35f6-4c53-8813-d3f27d0eb548)|[storybook](http://localhost:6006/?path=/story/location-fetchlocationdialog--fetching&globals=viewport:responsive)|
|![image](https://github.com/poroto-app/poroto/assets/55840281/09aff28d-aa46-4692-9e2a-27664ada3f8b)|![image](https://github.com/poroto-app/poroto/assets/55840281/85a7e85b-cf4b-4c09-8a25-7b8c8f5b7fdc)|[storybook](http://localhost:6006/?path=/story/location-fetchlocationdialog--failed&globals=viewport:responsive)|

- ダイアログの背景色とLottieの背景色とがあっていない不具合を修正
- Lottieを使う場合は、背景色を変更してしまうと、アニメーションのイメージも変わってしまうので白を使うことにした。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] storybookで確認

```shell
# poroto
export BRANCH_POROTO=feature/lottie_dialog_color
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````