### PR TITLE
2回目以降のプラン作成でプラン作成完了ダイアログが表示されない不具合を

### DIFF
--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -100,6 +100,13 @@ export default function PlanPage() {
         logEvent(getAnalytics(), AnalyticsEvents.Plan.View, {
             planId: id,
         });
+
+        return () => {
+            // 他のページに遷移するときにモーダルを閉じる
+            // (戻るボタンでトップページに遷移したときの対応)
+            dispatch(setShowPlanCreatedModal(false));
+            dispatch(setPlaceIdToCreatePlan(null));
+        }
     }, []);
 
     useEffect(() => {
@@ -112,13 +119,6 @@ export default function PlanPage() {
             })
         );
         dispatch(fetchPlacesNearbyPlanLocation({ planId: id, limit: 10 }));
-
-        return () => {
-            // 他のページに遷移するときにモーダルを閉じる
-            // (戻るボタンでトップページに遷移したときの対応)
-            dispatch(setShowPlanCreatedModal(false));
-            dispatch(setPlaceIdToCreatePlan(null));
-        };
     }, [id, userId, firebaseIdToken]);
 
     if (

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -106,7 +106,7 @@ export default function PlanPage() {
             // (戻るボタンでトップページに遷移したときの対応)
             dispatch(setShowPlanCreatedModal(false));
             dispatch(setPlaceIdToCreatePlan(null));
-        }
+        };
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
||![image](https://github.com/poroto-app/poroto/assets/55840281/dd527a01-93a4-4521-be5e-6168e2cd44bd)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #609 

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 複数回プランを保存しても適切にダイアログが表示されるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 2回目以降、プランを保存したときにダイアログが表示されることを確認
- [x] 2回目以降、プランを保存しNavigation Barのロゴからトップページに戻りプランを表示したときにダイアログが表示されないことを確認
- [x] 2回目以降、プランを保存しNavigation Barのロゴからトップページに戻り、戻るボタンでもとのページを表示したときにダイアログが表示されないことを確認
- [x] ダイアログ上でURLをコピーすると、保存したプランが表示できることを確認
 

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````