### PR TITLE
プラン候補一覧ページでカードをタップすることで次のプランを表示できるようにする

### DIFF
--- a/src/view/constants/time.ts
+++ b/src/view/constants/time.ts
@@ -1,0 +1,6 @@
+export const Time = {
+    PlanCandidateGallery: {
+        // 最後の要素をタップしてから、次の要素に遷移するまでの遅延
+        lastItemTransitionDelay: 50,
+    },
+};

--- a/src/view/plancandidate/PlanCandidatesGallery.tsx
+++ b/src/view/plancandidate/PlanCandidatesGallery.tsx
@@ -29,10 +29,11 @@ export function PlanCandidatesGallery({
 
     const onClickFirstItem = (i: number) => {
         setTimeout(() => {
-            const prevActiveIndex = (i - 1 + planCandidates.length) % planCandidates.length;
+            const prevActiveIndex =
+                (i - 1 + planCandidates.length) % planCandidates.length;
             onClickCard(prevActiveIndex);
         }, 50);
-    }
+    };
 
     const onClickLastItem = (i: number) => {
         // カードタップによるこのカードへの移動処理と

--- a/src/view/plancandidate/PlanCandidatesGallery.tsx
+++ b/src/view/plancandidate/PlanCandidatesGallery.tsx
@@ -3,6 +3,7 @@ import { Splide, SplideSlide } from "@splidejs/react-splide";
 import "@splidejs/splide/css";
 import { useEffect, useRef, useState } from "react";
 import { Plan } from "src/domain/models/Plan";
+import { Time } from "src/view/constants/time";
 import { PlanCandidateGalleryCard } from "src/view/plancandidate/PlanCandidatesGalleryCard";
 import { styled } from "styled-components";
 
@@ -24,6 +25,23 @@ export function PlanCandidatesGallery({
 
     const onClickCard = (i: number) => {
         refSplide.current?.go(i);
+    };
+
+    const onClickFirstItem = (i: number) => {
+        setTimeout(() => {
+            const prevActiveIndex = (i - 1 + planCandidates.length) % planCandidates.length;
+            onClickCard(prevActiveIndex);
+        }, 50);
+    }
+
+    const onClickLastItem = (i: number) => {
+        // カードタップによるこのカードへの移動処理と
+        // カード中の最後の画像タップによる次のカードへの移動処理が重ならないように
+        // 次のカードへの移動処理を遅延させる
+        setTimeout(() => {
+            const nextActiveIndex = (i + 1) % planCandidates.length;
+            onClickCard(nextActiveIndex);
+        }, Time.PlanCandidateGallery.lastItemTransitionDelay);
     };
 
     useEffect(() => {
@@ -67,6 +85,8 @@ export function PlanCandidatesGallery({
                         <PlanCandidateGalleryCard
                             plan={plan}
                             isActive={i === activeIndex}
+                            onClickFirstItem={() => onClickFirstItem(i)}
+                            onClickLastItem={() => onClickLastItem(i)}
                         />
                     </SplideSlide>
                 ))}

--- a/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
+++ b/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
@@ -9,9 +9,18 @@ import { StoryImagePreview } from "src/view/plancandidate/StoryImagePreview";
 type Props = {
     plan: Plan;
     isActive: boolean;
+    // カード中の最初の画像をタップして、次の要素に移動しようとしている
+    onClickFirstItem?: () => void;
+    // カード中の最後の画像をタップして、次の要素に移動しようとしている
+    onClickLastItem?: () => void;
 };
 
-export function PlanCandidateGalleryCard({ plan, isActive }: Props) {
+export function PlanCandidateGalleryCard({
+    plan,
+    isActive,
+    onClickFirstItem,
+    onClickLastItem,
+}: Props) {
     const [currentPlaceIndex, setCurrentPlaceIndex] = useState<number>(0);
 
     const images: Image[] = plan.places.map((place) =>
@@ -36,6 +45,8 @@ export function PlanCandidateGalleryCard({ plan, isActive }: Props) {
                     images={images}
                     slideable={isActive}
                     onActiveIndexChange={setCurrentPlaceIndex}
+                    onClickFirstItem={onClickFirstItem}
+                    onClickLastItem={onClickLastItem}
                 />
                 <Box
                     position="absolute"

--- a/src/view/plancandidate/StoryImagePreview.tsx
+++ b/src/view/plancandidate/StoryImagePreview.tsx
@@ -9,6 +9,7 @@ import {
     getImageSizeOf,
 } from "src/domain/models/Image";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
+import { Time } from "src/view/constants/time";
 import { styled } from "styled-components";
 
 type Props = {
@@ -17,6 +18,8 @@ type Props = {
     tapControl?: boolean;
     slideable?: boolean;
     onActiveIndexChange?: (index: number) => void;
+    onClickLastItem?: () => void;
+    onClickFirstItem?: () => void;
 };
 
 export function StoryImagePreview({
@@ -25,6 +28,8 @@ export function StoryImagePreview({
     tapControl = true,
     slideable = true,
     onActiveIndexChange,
+    onClickFirstItem,
+    onClickLastItem,
 }: Props) {
     const refSplide = useRef<Splide | null>(null);
 
@@ -44,12 +49,27 @@ export function StoryImagePreview({
 
     const onClickNext = () => {
         if (!refSplide.current || !slideable) return;
-        refSplide.current.go(refSplide.current.splide.index + 1);
+
+        const isLastPage = refSplide.current.splide.index + 1 === images.length;
+        if (isLastPage && onClickLastItem) {
+            onClickLastItem();
+            setTimeout(() => {
+                refSplide.current.go(refSplide.current.splide.index + 1);
+            }, Time.PlanCandidateGallery.lastItemTransitionDelay);
+        } else {
+            refSplide.current.go(refSplide.current.splide.index + 1);
+        }
     };
 
     const onClickPrev = () => {
         if (!refSplide.current || !slideable) return;
-        refSplide.current.go(refSplide.current.splide.index - 1);
+
+        const isFirstPage = refSplide.current.splide.index === 0;
+        if (isFirstPage && onClickFirstItem) {
+            onClickFirstItem();
+        } else {
+            refSplide.current.go(refSplide.current.splide.index - 1);
+        }
     };
 
     return (


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
||![画面収録 2024-04-27 14 25 43](https://github.com/poroto-app/poroto/assets/55840281/a44a18a8-41f0-4bce-b263-fe640d959f1c)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #611 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 最後のページまで表示された状態で右側をタップすると、次のプランが表示される
- [x] 最初のページが表示された状態で左側をタップすると、前のプランが表示される
- [x] カードタップでプランを移動することができる  

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````