### PR TITLE
プラン候補一覧ページの自動スクロールをscroll-snapで実装する

### DIFF
--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -48,8 +48,12 @@ const SelectPlanPage = () => {
     const { sessionId } = router.query;
     const [selectedPlanIndex, setSelectedPlanIndex] = useState(0);
     const refPlanCandidateGallery = useRef<HTMLDivElement>(null);
-    const { isPlanFooterVisible, planDetailPageRef, scrollToPlanDetailPage } =
-        usePlanCandidateGalleryPageAutoScroll();
+    const {
+        isPlanFooterVisible,
+        planDetailPageRef,
+        scrollContainerRef,
+        scrollToPlanDetailPage,
+    } = usePlanCandidateGalleryPageAutoScroll();
 
     const {
         plansCreated,
@@ -148,35 +152,48 @@ const SelectPlanPage = () => {
         );
 
     return (
-        <VStack w="100%" spacing={0}>
-            <NavBar />
-            <Center
-                w="100%"
-                h={`calc(100vh - ${Size.NavBar.height})`}
-                px="16px"
-                ref={refPlanCandidateGallery}
-                overflowX="hidden"
-            >
-                <VStack spacing="32px">
-                    <PlanCandidatesGallery
-                        planCandidates={plansCreated}
-                        activePlanIndex={selectedPlanIndex}
-                        onActiveIndexChange={setSelectedPlanIndex}
-                    />
-                    <ButtonWithBlur
-                        px="16px"
-                        py="16px"
-                        backgroundColor="#84A6FF"
-                        borderRadius="50px"
-                        onClick={scrollToPlanDetailPage}
-                    >
-                        <Text color="white" fontWeight="bold" fontSize="18px">
-                            プランをみてみる
-                        </Text>
-                    </ButtonWithBlur>
-                </VStack>
-            </Center>
-            <Box w="100%" overflowX="hidden" ref={planDetailPageRef}>
+        <VStack
+            w="100%"
+            h="100%"
+            overflowY="scroll"
+            spacing={0}
+            ref={scrollContainerRef}
+            scrollSnapType="y mandatory"
+        >
+            <VStack spacing={0} w="100%" scrollSnapAlign="start">
+                <NavBar />
+                <Center
+                    w="100%"
+                    h={`calc(100vh - ${Size.NavBar.height})`}
+                    px="16px"
+                    ref={refPlanCandidateGallery}
+                    overflowX="hidden"
+                >
+                    <VStack spacing="32px">
+                        <PlanCandidatesGallery
+                            planCandidates={plansCreated}
+                            activePlanIndex={selectedPlanIndex}
+                            onActiveIndexChange={setSelectedPlanIndex}
+                        />
+                        <ButtonWithBlur
+                            px="16px"
+                            py="16px"
+                            backgroundColor="#84A6FF"
+                            borderRadius="50px"
+                            onClick={scrollToPlanDetailPage}
+                        >
+                            <Text
+                                color="white"
+                                fontWeight="bold"
+                                fontSize="18px"
+                            >
+                                プランをみてみる
+                            </Text>
+                        </ButtonWithBlur>
+                    </VStack>
+                </Center>
+            </VStack>
+            <Box w="100%" ref={planDetailPageRef} scrollSnapAlign="start">
                 <PlanDetailPage
                     planId={
                         notEmpty(selectedPlanIndex) &&


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

||before| after |
|----|---|-------|
|少しだけスクロールしたときの挙動|一旦停止したあとで、自動スクロール開始|滑らかに自動スクロール開始|

before

https://github.com/poroto-app/poroto/assets/55840281/06808a06-1e22-40fe-acdf-f9d92a002014

after

https://github.com/poroto-app/poroto/assets/55840281/e4a4c91f-45e9-455b-9e0c-685cb37b5554



### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #618 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- より滑らかにスクロールできるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] 少しスクロールしたときに、滑らかに自動スクロールが始まるのを確認 

```shell
# poroto
export BRANCH_POROTO=feature/plan_list_scroll_snap
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````