### PR TITLE
Staging環境がインデックスされないようにする

### DIFF
--- a/src/pages/robots.txt.tsx
+++ b/src/pages/robots.txt.tsx
@@ -1,0 +1,32 @@
+import { GetServerSideProps } from "next";
+
+const robotsText = ({ sitemap }: { sitemap: string }) => `User-agent: *
+Allow: /
+SiteMap: ${sitemap}`;
+
+const robotsTextStaging = () => `User-agent: *
+Disallow: /`;
+
+const generateRobotsTxt = (): string => {
+    if (process.env.APP_ENV === "staging") {
+        return robotsTextStaging();
+    }
+
+    return robotsText({
+        sitemap: `${process.env.APP_PROTOCOL}://${process.env.APP_HOST}/sitemap.xml`,
+    });
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+    res.setHeader("Content-Type", "text/plain");
+    res.write(generateRobotsTxt());
+    res.end();
+
+    return {
+        props: {},
+    };
+};
+
+export default function RobotsTxt() {
+    return <></>;
+}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|development/production| staging |
|---|-------|
|<img width="623" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/f21442b3-eed4-422d-94a7-f5721cf74af0">|<img width="428" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/575a4d2c-907c-4f45-bf93-d875be83cf6b">|
|<img width="940" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/54eb1fc1-0e99-45b2-91dc-104243ac6ff0">|<img width="729" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/aa1280a8-aeef-479a-b6af-805ecfc7009a">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #625 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- Google のクローラが staging環境をindexしないようにする

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] developmentモードで起動したときに、全てのユーザーエージェントが許可されていることを確認
- [x] stagingモードで起動したときに、全てのユーザーエージェントが却下されることを確認

**developmentモードで確認**
1. yarn devで起動
2. ngrokでurl生成
3. [テストツール](https://technicalseo.com/tools/robots-txt/)を使って、許可されていることを確認

**stagingモードで確認**
1. `ENV="staging" yarn build-env` でstagingビルドする
2. `PORT=3000 yarn start`で起動
3. `http://localhost:3000/robots.txt`の結果がスクショと同じになっていることを確認

```shell
# poroto
export BRANCH_POROTO=feature/staging_index
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````