### PR TITLE
プラン作成中の画面に画像として保存するボタンを配置

### DIFF
--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -28,6 +28,7 @@ import { usePlanPlaceReorder } from "src/view/hooks/usePlanPlaceReorder";
 import { usePlanPlaceReplace } from "src/view/hooks/usePlanPlaceReplace";
 import { PlaceMap } from "src/view/plan/PlaceMap";
 import { PlanFooter } from "src/view/plan/PlanFooter";
+import { SavePlanAsImageButton } from "src/view/plan/button/SavePlanAsImageButton";
 import { SearchRouteByGoogleMapButton } from "src/view/plan/button/SearchRouteByGoogleMapButton";
 import { AvailablePlaceSection } from "src/view/plan/candidate/AvailablePlaceSection";
 import { GeneratingPlanDialog } from "src/view/plan/candidate/GeneratingPlanDialog";
@@ -332,6 +333,7 @@ function PlanDetailPage({
                         <PlaceMap places={plan.places} />
                     </PlanPageSection>
                     <VStack w="100%" p="16px">
+                        <SavePlanAsImageButton plan={plan} />
                         <SearchRouteByGoogleMapButton
                             plan={plan}
                             currentLocation={currentLocation}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/80d2a641-5967-4244-a92e-11f08632b843)|![image](https://github.com/poroto-app/poroto/assets/55840281/2db3262d-7200-48f1-88c0-0b35c97ccd75)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #629
### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- プラン保存前に画像として保存できるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] プラン保存中に画像として保存できることを確認

```shell
# poroto
export BRANCH_POROTO=feature/save_as_image_in_creating
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````