### PR TITLE
ホバーされたときだけページボタンを表示する

### DIFF
--- a/src/view/common/HorizontalScrollableList.tsx
+++ b/src/view/common/HorizontalScrollableList.tsx
@@ -1,5 +1,5 @@
 import { Box, Center, HStack, Icon } from "@chakra-ui/react";
-import { ReactNode, useRef } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { MdArrowBackIos, MdArrowForwardIos } from "react-icons/md";
 import { isPC } from "src/view/constants/userAgent";
 
@@ -17,6 +17,7 @@ export const HorizontalScrollableList = ({
     children,
 }: Props) => {
     const containerRef = useRef<HTMLDivElement>(null);
+    const [isHovered, setIsHovered] = useState(false);
 
     const scroll = (direction: "left" | "right") => {
         if (!containerRef.current) {
@@ -28,6 +29,26 @@ export const HorizontalScrollableList = ({
             scrollLeft + (direction === "left" ? -scrollAmount : scrollAmount);
         container.scrollTo({ left: newScrollLeft, behavior: "smooth" });
     };
+
+    useEffect(() => {
+        const handleMouseMove = (event) => {
+            if (containerRef.current) {
+                const rect = containerRef.current.getBoundingClientRect();
+                const isInside =
+                    event.clientX >= rect.left &&
+                    event.clientX <= rect.right &&
+                    event.clientY >= rect.top &&
+                    event.clientY <= rect.bottom;
+                setIsHovered(isInside);
+            }
+        };
+
+        window.addEventListener("mousemove", handleMouseMove);
+
+        return () => {
+            window.removeEventListener("mousemove", handleMouseMove);
+        };
+    }, []);
 
     return (
         <Box position="relative" w="100%">
@@ -47,7 +68,7 @@ export const HorizontalScrollableList = ({
             >
                 {children}
             </HStack>
-            <Box>
+            <Box opacity={isHovered ? 1 : 0} transition="all 0.2s ease-in-out">
                 <PageButton
                     left={0}
                     right="auto"


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/08b9af41-758e-4314-a86e-df0eb48e49fb)|![image](https://github.com/poroto-app/poroto/assets/55840281/00411266-bdea-4ee0-9a02-d1178195acec)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- pc版でページ送りのボタンが大量に表示されないようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] ホバーしたときだけページボタンが表示されることを確認
- [x] ページボタンでスクロールできることを確認
- [x] リスト内の要素を選択できることを確認  

```shell
# poroto
export BRANCH_POROTO=feature/show_page_button_on_hover
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````