### PR TITLE
好きな場所からプランを作るときに現在地取得を行わない

### DIFF
--- a/src/view/top/CreatePlanSection.tsx
+++ b/src/view/top/CreatePlanSection.tsx
@@ -56,7 +56,9 @@ export function CreatePlanSection() {
                         <CreatePlanButton
                             title="好きな場所から"
                             icon={MdOutlineMap}
-                            link={Routes.places.search({})}
+                            link={Routes.places.search({
+                                skipCurrentLocation: true,
+                            })}
                             onClick={() =>
                                 logEvent(
                                     getAnalytics(),


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
|before| after |
|---|-------|
|位置情報が許可されていると、「好きな場所から」プランを作るときに現在地取得を行う|位置情報の許可設定にかかわらず、現在地取得を行わない|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #641 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 現在地取得時間による離脱率を軽減するため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 位置情報取得の権限を与えた状態で「好きな場所から」プランを作成したときに、現在地取得が行われない

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````