### PR TITLE
興味選択と時間選択でAnalyticsのログを取る

### DIFF
--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -1,4 +1,5 @@
 import { Box, Center, VStack } from "@chakra-ui/react";
+import { getAnalytics, logEvent } from "@firebase/analytics";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -24,6 +25,7 @@ import {
 import { useAppDispatch } from "src/redux/redux";
 import { NavBar } from "src/view/common/NavBar";
 import { RoundedIconButton } from "src/view/common/RoundedIconButton";
+import { AnalyticsEvents } from "src/view/constants/analytics";
 import { locationSinjukuStation } from "src/view/constants/location";
 import { PageMetaData } from "src/view/constants/meta";
 import { RouteParams, Routes } from "src/view/constants/router";
@@ -133,6 +135,10 @@ function PlaceSearchPage() {
 
     const handleOnCreatePlan = async () => {
         if (!placeSelected) return;
+        logEvent(
+            getAnalytics(),
+            AnalyticsEvents.CreatePlan.StartCreatePlanFromSelectedLocation
+        );
         dispatch(
             setSearchLocation({
                 searchLocation: placeSelected.location,

--- a/src/pages/plans/interest.tsx
+++ b/src/pages/plans/interest.tsx
@@ -1,3 +1,4 @@
+import { getAnalytics, logEvent } from "@firebase/analytics";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { ReactNode, useEffect, useState } from "react";
@@ -27,6 +28,7 @@ import { useAppDispatch } from "src/redux/redux";
 import { ErrorPage } from "src/view/common/ErrorPage";
 import { LoadingModal } from "src/view/common/LoadingModal";
 import { NavBar } from "src/view/common/NavBar";
+import { AnalyticsEvents } from "src/view/constants/analytics";
 import { LocalStorageKeys } from "src/view/constants/localStorageKey";
 import { PageMetaData } from "src/view/constants/meta";
 import { Routes } from "src/view/constants/router";
@@ -186,6 +188,7 @@ function PlanInterestPage() {
     ]);
 
     const handleAcceptCategory = (category: LocationCategory) => {
+        logEvent(getAnalytics(), AnalyticsEvents.Interests.SelectCategory);
         dispatch(pushAcceptedCategory({ category }));
     };
 
@@ -194,6 +197,14 @@ function PlanInterestPage() {
     };
 
     const handleSelectTime = (time: number | null) => {
+        if (time) {
+            logEvent(getAnalytics(), AnalyticsEvents.Interests.SelectDuration);
+        } else {
+            logEvent(
+                getAnalytics(),
+                AnalyticsEvents.Interests.SkipSelectDuration
+            );
+        }
         dispatch(setTimeForPlan({ time }));
     };
 

--- a/src/view/constants/analytics.ts
+++ b/src/view/constants/analytics.ts
@@ -5,6 +5,9 @@ export const AnalyticsEvents = {
         FromSelectedLocation: "create_plan_from_selected_location",
         FromPlaceNearbyPlan: "create_plan_from_place_nearby_plan",
 
+        StartCreatePlanFromSelectedLocation:
+            "start_create_plan_from_selected_location",
+
         // 実際に作成を行った
         Create: "create_plan",
     },

--- a/src/view/constants/analytics.ts
+++ b/src/view/constants/analytics.ts
@@ -8,6 +8,11 @@ export const AnalyticsEvents = {
         // 実際に作成を行った
         Create: "create_plan",
     },
+    Interests: {
+        SelectDuration: "interests_select_duration",
+        SkipSelectDuration: "interests_skip_select_duration",
+        SelectCategory: "interests_select_category",
+    },
     SavePlan: "save_plan",
     EditPlan: {
         Like: "edit_plan_like",


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- 興味選択画面において、「時間の指定」と「カテゴリの指定」でそれぞれGoogle Analyticsのログを取るように修正した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #640 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 場所の指定で離脱しているのか、興味選択画面で離脱しているかを区別できるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
```shell
# poroto
export BRANCH_POROTO=feature/analytics_interests
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````