### PR TITLE
スマホのスクロール挙動の不具合を修正

### DIFF
--- a/.github/workflows/build_deploy_staging.yml
+++ b/.github/workflows/build_deploy_staging.yml
@@ -2,8 +2,8 @@ name: deploy-staging
 run-name: Deploy Staging by @${{ github.actor }}
 on:
   push:
-#    branches:
-#      - develop
+    branches:
+      - develop 
 
 jobs:
   deploy-staging:

--- a/.github/workflows/build_deploy_staging.yml
+++ b/.github/workflows/build_deploy_staging.yml
@@ -2,8 +2,8 @@ name: deploy-staging
 run-name: Deploy Staging by @${{ github.actor }}
 on:
   push:
-    branches:
-      - develop 
+#    branches:
+#      - develop
 
 jobs:
   deploy-staging:

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -49,12 +49,8 @@ const SelectPlanPage = () => {
     const { sessionId } = router.query;
     const [selectedPlanIndex, setSelectedPlanIndex] = useState(0);
     const refPlanCandidateGallery = useRef<HTMLDivElement>(null);
-    const {
-        isPlanFooterVisible,
-        planDetailPageRef,
-        scrollContainerRef,
-        scrollToPlanDetailPage,
-    } = usePlanCandidateGalleryPageAutoScroll();
+    const { isPlanFooterVisible, planDetailPageRef, scrollToPlanDetailPage } =
+        usePlanCandidateGalleryPageAutoScroll();
 
     const {
         plansCreated,
@@ -153,48 +149,35 @@ const SelectPlanPage = () => {
         );
 
     return (
-        <VStack
-            w="100%"
-            h="100%"
-            overflowY="scroll"
-            spacing={0}
-            ref={scrollContainerRef}
-            scrollSnapType="y mandatory"
-        >
-            <VStack spacing={0} w="100%" scrollSnapAlign="start">
-                <NavBar />
-                <Center
-                    w="100%"
-                    h={`calc(100vh - ${Size.NavBar.height})`}
-                    px="16px"
-                    ref={refPlanCandidateGallery}
-                    overflowX="hidden"
-                >
-                    <VStack spacing="32px">
-                        <PlanCandidatesGallery
-                            planCandidates={plansCreated}
-                            activePlanIndex={selectedPlanIndex}
-                            onActiveIndexChange={setSelectedPlanIndex}
-                        />
-                        <ButtonWithBlur
-                            px="16px"
-                            py="16px"
-                            backgroundColor="#84A6FF"
-                            borderRadius="50px"
-                            onClick={scrollToPlanDetailPage}
-                        >
-                            <Text
-                                color="white"
-                                fontWeight="bold"
-                                fontSize="18px"
-                            >
-                                プランをみてみる
-                            </Text>
-                        </ButtonWithBlur>
-                    </VStack>
-                </Center>
-            </VStack>
-            <Box w="100%" ref={planDetailPageRef} scrollSnapAlign="start">
+        <VStack w="100%" spacing={0}>
+            <NavBar />
+            <Center
+                w="100%"
+                h={`calc(100vh - ${Size.NavBar.height})`}
+                px="16px"
+                ref={refPlanCandidateGallery}
+                overflowX="hidden"
+            >
+                <VStack spacing="32px">
+                    <PlanCandidatesGallery
+                        planCandidates={plansCreated}
+                        activePlanIndex={selectedPlanIndex}
+                        onActiveIndexChange={setSelectedPlanIndex}
+                    />
+                    <ButtonWithBlur
+                        px="16px"
+                        py="16px"
+                        backgroundColor="#84A6FF"
+                        borderRadius="50px"
+                        onClick={scrollToPlanDetailPage}
+                    >
+                        <Text color="white" fontWeight="bold" fontSize="18px">
+                            プランをみてみる
+                        </Text>
+                    </ButtonWithBlur>
+                </VStack>
+            </Center>
+            <Box w="100%" overflowX="hidden" ref={planDetailPageRef}>
                 <PlanDetailPage
                     planId={
                         hasValue(selectedPlanIndex) &&

--- a/src/view/hooks/usePlanCandidateGalleryPageAutoScroll.ts
+++ b/src/view/hooks/usePlanCandidateGalleryPageAutoScroll.ts
@@ -3,28 +3,27 @@ import { useEffect, useRef, useState } from "react";
 export const usePlanCandidateGalleryPageAutoScroll = () => {
     const isAutoScrollingRef = useRef(false);
     const prevScrollYRef = useRef(0);
-    const scrollContainerRef = useRef<HTMLDivElement>(null);
     const planDetailPageRef = useRef<HTMLDivElement>(null);
     const [isUpperOfPlanDetailPage, setIsUpperOfPlanDetailPage] =
         useState(true);
     const [isAutoScrolling, setIsAutoScrolling] = useState(false);
 
     const scrollToPlanDetailPage = () => {
-        if (!planDetailPageRef.current || !scrollContainerRef.current) return;
-        scrollContainerRef.current.scrollTo({
+        if (!planDetailPageRef.current) return;
+        window.scrollTo({
             top: planDetailPageRef.current.offsetTop,
             behavior: "smooth",
         });
     };
 
     let scrollTimeout: NodeJS.Timeout | null = null;
-    const scrollListener = (e: Event) => {
+    const scrollListener = () => {
         if (scrollTimeout) clearTimeout(scrollTimeout);
 
-        if (!planDetailPageRef.current || !scrollContainerRef) return;
+        if (!planDetailPageRef.current) return;
 
         const isAutoScrolling = isAutoScrollingRef.current;
-        const currentScroll = scrollContainerRef.current.scrollTop;
+        const currentScroll = window.scrollY;
         const offsetTopPlanDetailPage = planDetailPageRef.current.offsetTop;
 
         // Safariだとページ上部までいきおいよくスクロールすると、スクロール量がマイナスになり
@@ -40,6 +39,10 @@ export const usePlanCandidateGalleryPageAutoScroll = () => {
             currentScroll < offsetTopPlanDetailPage &&
             isScrollingDown
         ) {
+            window.scrollTo({
+                top: offsetTopPlanDetailPage,
+                behavior: "smooth",
+            });
             isAutoScrollingRef.current = true;
             setIsAutoScrolling(true);
         }
@@ -60,13 +63,17 @@ export const usePlanCandidateGalleryPageAutoScroll = () => {
     };
 
     const scrollEndListener = () => {
-        if (!planDetailPageRef.current || !scrollContainerRef) return;
+        if (!planDetailPageRef.current) return;
 
         // スクロールが停止したときも、自動スクロール中は継続する
         const isAutoScrolling = isAutoScrollingRef.current;
-        const currentScroll = scrollContainerRef.current.scrollTop;
+        const currentScroll = window.scrollY;
         const offsetTopPlanDetailPage = planDetailPageRef.current.offsetTop;
         if (isAutoScrolling && currentScroll < offsetTopPlanDetailPage) {
+            window.scrollTo({
+                top: offsetTopPlanDetailPage,
+                behavior: "smooth",
+            });
             isAutoScrollingRef.current = true;
             setIsAutoScrolling(true);
         } else {
@@ -79,21 +86,15 @@ export const usePlanCandidateGalleryPageAutoScroll = () => {
     };
 
     useEffect(() => {
-        scrollContainerRef.current?.addEventListener("scroll", scrollListener, {
-            passive: false,
-        });
+        window.addEventListener("scroll", scrollListener);
 
         return () => {
-            scrollContainerRef.current?.removeEventListener(
-                "scroll",
-                scrollListener
-            );
+            window.removeEventListener("scroll", scrollListener);
             clearTimeout(scrollTimeout);
         };
-    }, [scrollContainerRef?.current, isAutoScrollingRef]);
+    }, [isAutoScrollingRef]);
 
     return {
-        scrollContainerRef,
         planDetailPageRef,
         scrollToPlanDetailPage,
         isPlanFooterVisible: !isUpperOfPlanDetailPage || isAutoScrolling,


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
#617 でscroll-snapでプラン候補一覧ページのスクロールを実装行った。 
スマホで見るとプラン詳細画面の下部までスクロールしても上に戻るような挙動をしてしまったため、これを修正

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #617 

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] スマホビューのときに、プラン詳細画面の下部までスクロールしても上に戻るような挙動をしない

```shell
# poroto
export BRANCH_POROTO=fix/scroll_snap
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````