### PR TITLE
コラージュ画像のプレビュー

### DIFF
--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -222,18 +222,20 @@ export default function PlanPage() {
                     />
                 </PlanPageSection>
             </VStack>
-            <PlanFooter>
-                <Button
-                    variant="solid"
-                    flex={1}
-                    color="white"
-                    backgroundColor="#BF756E"
-                    borderRadius={20}
-                    onClick={savePlanAsCollageImage}
-                >
-                    コラージュ画像として保存
-                </Button>
-            </PlanFooter>
+            {process.env.APP_ENV !== "production" && (
+                <PlanFooter>
+                    <Button
+                        variant="solid"
+                        flex={1}
+                        color="white"
+                        backgroundColor="#BF756E"
+                        borderRadius={20}
+                        onClick={savePlanAsCollageImage}
+                    >
+                        コラージュ画像として保存
+                    </Button>
+                </PlanFooter>
+            )}
             <SavePlanCollageImageDialog
                 isOpen={isSaveCollageImageDialogOpen}
                 onClose={() => setIsSaveCollageImageDialogOpen(false)}

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -2,7 +2,7 @@ import { Box, Center, useToast, VStack, Button } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Place } from "src/domain/models/Place";
 import { getPlanPriceRange } from "src/domain/models/Plan";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
@@ -40,6 +40,7 @@ import { NearbyPlaceList } from "src/view/plandetail/NearbyPlaceList";
 import { PlanInfoSection } from "src/view/plandetail/PlanInfoSection";
 import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
 import { PlanFooter } from "src/view/plan/PlanFooter";
+import SavePlanCollageImageDialog from "src/view/plandetail/SavePlanCollageImageDialog";
 
 export default function PlanPage() {
     const { id } = useRouter().query;
@@ -51,6 +52,7 @@ export default function PlanPage() {
     const { userId, firebaseIdToken, likePlaceIds, updateLikePlace } =
         useUserPlan();
     const uploadImageProps = useUploadPlaceImage();
+    const [isSaveCollageImageDialogOpen, setIsSaveCollageImageDialogOpen] = useState(false);
 
     const {
         preview: plan,
@@ -95,6 +97,10 @@ export default function PlanPage() {
         // ダイアログの背景固定を解除するためにモーダルを閉じる
         dispatch(setPlaceIdToCreatePlan(null));
         await router.push(Routes.plans.interest(true));
+    };
+
+    const savePlanAsCollageImage = () => {
+        setIsSaveCollageImageDialogOpen(true);
     };
 
     useEffect(() => {
@@ -222,10 +228,12 @@ export default function PlanPage() {
                     color="white"
                     backgroundColor="#BF756E"
                     borderRadius={20}
+                    onClick={savePlanAsCollageImage}
                 >
                     コラージュ画像として保存
                 </Button>
             </PlanFooter>
+            <SavePlanCollageImageDialog isOpen={isSaveCollageImageDialogOpen} onClose={() => setIsSaveCollageImageDialogOpen(false)}/>
             {/*Dialogs*/}
             <PlanCreatedDialog
                 visible={showPlanCreatedModal}

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -1,4 +1,4 @@
-import { Box, Center, useToast, VStack, Button } from "@chakra-ui/react";
+import { Box, Button, Center, VStack, useToast } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import Head from "next/head";
 import { useRouter } from "next/router";
@@ -27,20 +27,20 @@ import { isPC } from "src/view/constants/userAgent";
 import { useAuth } from "src/view/hooks/useAuth";
 import useUploadPlaceImage from "src/view/hooks/useUploadPlaceImage";
 import { useUserPlan } from "src/view/hooks/useUserPlan";
-import { SavePlanAsImageButton } from "src/view/plan/button/SavePlanAsImageButton";
-import { SearchRouteByGoogleMapButton } from "src/view/plan/button/SearchRouteByGoogleMapButton";
 import { PlaceMap } from "src/view/plan/PlaceMap";
 import { PlanCreatedDialog } from "src/view/plan/PlanCreatedDialog";
+import { PlanFooter } from "src/view/plan/PlanFooter";
+import { SavePlanAsImageButton } from "src/view/plan/button/SavePlanAsImageButton";
+import { SearchRouteByGoogleMapButton } from "src/view/plan/button/SearchRouteByGoogleMapButton";
 import { PlanPageSection } from "src/view/plan/section/PlanPageSection";
 import DialogUploadImage from "src/view/plancandidate/DialogUploadImage";
 import { CreatePlanDialog } from "src/view/plandetail/CreatePlanDialog";
-import { PlanDetailPageHeader } from "src/view/plandetail/header/PlanDetailPageHeader";
 import { LoginCallMessage } from "src/view/plandetail/LoginCallMessage";
 import { NearbyPlaceList } from "src/view/plandetail/NearbyPlaceList";
 import { PlanInfoSection } from "src/view/plandetail/PlanInfoSection";
 import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
-import { PlanFooter } from "src/view/plan/PlanFooter";
 import SavePlanCollageImageDialog from "src/view/plandetail/SavePlanCollageImageDialog";
+import { PlanDetailPageHeader } from "src/view/plandetail/header/PlanDetailPageHeader";
 
 export default function PlanPage() {
     const { id } = useRouter().query;
@@ -52,7 +52,8 @@ export default function PlanPage() {
     const { userId, firebaseIdToken, likePlaceIds, updateLikePlace } =
         useUserPlan();
     const uploadImageProps = useUploadPlaceImage();
-    const [isSaveCollageImageDialogOpen, setIsSaveCollageImageDialogOpen] = useState(false);
+    const [isSaveCollageImageDialogOpen, setIsSaveCollageImageDialogOpen] =
+        useState(false);
 
     const {
         preview: plan,
@@ -233,7 +234,10 @@ export default function PlanPage() {
                     コラージュ画像として保存
                 </Button>
             </PlanFooter>
-            <SavePlanCollageImageDialog isOpen={isSaveCollageImageDialogOpen} onClose={() => setIsSaveCollageImageDialogOpen(false)}/>
+            <SavePlanCollageImageDialog
+                isOpen={isSaveCollageImageDialogOpen}
+                onClose={() => setIsSaveCollageImageDialogOpen(false)}
+            />
             {/*Dialogs*/}
             <PlanCreatedDialog
                 visible={showPlanCreatedModal}

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -1,4 +1,4 @@
-import { Box, Center, useToast, VStack } from "@chakra-ui/react";
+import { Box, Center, useToast, VStack, Button } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import Head from "next/head";
 import { useRouter } from "next/router";
@@ -39,6 +39,7 @@ import { LoginCallMessage } from "src/view/plandetail/LoginCallMessage";
 import { NearbyPlaceList } from "src/view/plandetail/NearbyPlaceList";
 import { PlanInfoSection } from "src/view/plandetail/PlanInfoSection";
 import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
+import { PlanFooter } from "src/view/plan/PlanFooter";
 
 export default function PlanPage() {
     const { id } = useRouter().query;
@@ -214,6 +215,17 @@ export default function PlanPage() {
                     />
                 </PlanPageSection>
             </VStack>
+            <PlanFooter>
+                <Button
+                    variant="solid"
+                    flex={1}
+                    color="white"
+                    backgroundColor="#BF756E"
+                    borderRadius={20}
+                >
+                    コラージュ画像として保存
+                </Button>
+            </PlanFooter>
             {/*Dialogs*/}
             <PlanCreatedDialog
                 visible={showPlanCreatedModal}

--- a/src/view/plandetail/SavePlanCollageImageDialog.tsx
+++ b/src/view/plandetail/SavePlanCollageImageDialog.tsx
@@ -1,12 +1,11 @@
 import {
+    Box,
     Button,
     Modal,
     ModalBody,
     ModalCloseButton,
     ModalContent,
-    ModalHeader,
     ModalOverlay,
-    Box,
 } from "@chakra-ui/react";
 import { CollageTemplate } from "src/view/plandetail/CollageTemplate";
 
@@ -47,7 +46,7 @@ const SavePlanCollageImageDialog: React.FC<SavePlanCollageImageDialogProps> = ({
             <ModalContent maxW="1300px">
                 <ModalCloseButton />
                 <ModalBody>
-                     <Box h="100%" overflow="auto">
+                    <Box h="100%" overflow="auto">
                         <CollageTemplate {...sampleCollageData} />
                     </Box>
                     <Button colorScheme="blue" mt={4} onClick={onClose}>

--- a/src/view/plandetail/SavePlanCollageImageDialog.tsx
+++ b/src/view/plandetail/SavePlanCollageImageDialog.tsx
@@ -1,0 +1,62 @@
+import {
+    Button,
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalHeader,
+    ModalOverlay,
+    Box,
+} from "@chakra-ui/react";
+import { CollageTemplate } from "src/view/plandetail/CollageTemplate";
+
+interface SavePlanCollageImageDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const sampleCollageData = {
+    title: "コラージュ画像のプレビュー",
+    places: [
+        {
+            name: "Place 1",
+            duration: 60,
+            imageUrl: "https://via.placeholder.com/400",
+        },
+        {
+            name: "Place 2",
+            duration: 45,
+            imageUrl: "https://via.placeholder.com/400",
+        },
+        {
+            name: "Place 3",
+            duration: 30,
+            imageUrl: "https://via.placeholder.com/400",
+        },
+    ],
+    introduction: "このコラージュ画像はプラン内の場所をまとめたものです",
+};
+
+const SavePlanCollageImageDialog: React.FC<SavePlanCollageImageDialogProps> = ({
+    isOpen,
+    onClose,
+}) => {
+    return (
+        <Modal isOpen={isOpen} onClose={onClose}>
+            <ModalOverlay />
+            <ModalContent maxW="1300px">
+                <ModalCloseButton />
+                <ModalBody>
+                     <Box h="100%" overflow="auto">
+                        <CollageTemplate {...sampleCollageData} />
+                    </Box>
+                    <Button colorScheme="blue" mt={4} onClick={onClose}>
+                        保存する
+                    </Button>
+                </ModalBody>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default SavePlanCollageImageDialog;


### PR DESCRIPTION
### 修正の概要
コラージュ画像のプレビューをダイアログで表示できる機能を作成した．
|before| after |
|---|-------|
||<img width="1680" alt="image" src="https://github.com/poroto-app/poroto/assets/90236945/bd9b1e87-d2da-42e0-aaa1-8d5f518c5d5d">|
||<img width="1676" alt="image" src="https://github.com/poroto-app/poroto/assets/90236945/888a432d-7647-47a0-81d5-2d22192c4318">|
### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
コラージュ画像を保存できるようにプレビュー画面の作成をした．

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] コラージュ画像がプレビュー可能か確認

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````