### PR TITLE
PWAインストールボタンを表示

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,12 +21,14 @@ import { Size } from "src/view/constants/size";
 import { useAuth } from "src/view/hooks/useAuth";
 import { useLikePlaces } from "src/view/hooks/useLikePlaces";
 import { useNearbyPlans } from "src/view/hooks/useNearbyPlans";
+import { usePwaInstall } from "src/view/hooks/usePwaInstall";
 import { NearbyPlanList } from "src/view/plan/NearbyPlanList";
 import { PlanList } from "src/view/plan/PlanList";
 import { CreatePlanDialog } from "src/view/plandetail/CreatePlanDialog";
 import { CreatePlanSection } from "src/view/top/CreatePlanSection";
 import { LikePlacesList } from "src/view/top/LikePlacesList";
 import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
+import { PwaInstallDialog } from "src/view/top/PwaInstallDialog";
 import { UsersPlan } from "src/view/top/UsersPlan";
 
 type Props = {
@@ -55,6 +57,9 @@ const IndexPage = (props: Props) => {
         onSelectLikePlace,
         onCreatePlanFromLikePlace,
     } = useLikePlaces();
+
+    const { isPwaInstallVisible, installPwa, cancelInstallPwa } =
+        usePwaInstall();
 
     const { user, isLoggedInUser } = useAuth();
 
@@ -96,6 +101,11 @@ const IndexPage = (props: Props) => {
                     pb="48px"
                     spacing="24px"
                 >
+                    <PwaInstallDialog
+                        visible={isPwaInstallVisible}
+                        onClickInstall={() => installPwa()}
+                        onClickCancel={() => cancelInstallPwa()}
+                    />
                     <LikePlacesList
                         places={likePlaces}
                         onSelectLikePlace={onSelectLikePlace}

--- a/src/stories/top/PwaInstallDialog.stories.tsx
+++ b/src/stories/top/PwaInstallDialog.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { PwaInstallDialog } from "src/view/top/PwaInstallDialog";
+
+export default {
+    title: "top/PwaInstallDialog",
+    component: PwaInstallDialog,
+    tags: ["autodocs"],
+    parameters: {},
+} as Meta<typeof PwaInstallDialog>;
+
+type Story = StoryObj<typeof PwaInstallDialog>;
+
+export const Primary: Story = {
+    args: {
+        visible: true,
+    },
+};

--- a/src/view/constants/analytics.ts
+++ b/src/view/constants/analytics.ts
@@ -26,6 +26,11 @@ export const AnalyticsEvents = {
         Logout: "logout",
         BindPreLoginState: "bind_pre_login_state",
     },
+    Pwa: {
+        Install: "pwa_install",
+        CancelOnPrompt: "pwa_cancel_on_prompt",
+        Cancel: "pwa_cancel_install",
+    },
 };
 export type AnalyticsEvent =
     (typeof AnalyticsEvents)[keyof typeof AnalyticsEvents];

--- a/src/view/constants/localStorageKey.ts
+++ b/src/view/constants/localStorageKey.ts
@@ -1,6 +1,8 @@
 export const LocalStorageKeys = {
     PlanCandidate: "created_plan_candidates",
     LoggedIn: "logged_in",
+    pwaInstalled: "pwa_installed",
+    cancelInstallPwa: "cancel_pwa_install",
 };
 export type LocalStorageKey =
     (typeof LocalStorageKeys)[keyof typeof LocalStorageKeys];

--- a/src/view/hooks/usePwaInstall.ts
+++ b/src/view/hooks/usePwaInstall.ts
@@ -3,9 +3,11 @@ import { isSafari } from "react-device-detect";
 import { hasValue } from "src/domain/util/null";
 import { LocalStorageKeys } from "src/view/constants/localStorageKey";
 import { isPC } from "src/view/constants/userAgent";
+import {useToast} from "@chakra-ui/react";
 
 // TODO: iOSのインストール手順をダイアログで見せる（インストール手順をスクリーンショットで見せる）
 export const usePwaInstall = () => {
+    const toast = useToast();
     const [pwaInstallEvent, setPwaInstallEvent] = useState<Event | null>(null);
     const [isPwaSupported, setIsPwaSupported] = useState(false);
     const [isRunningOnPwa, setIsRunningOnPwa] = useState(false);
@@ -59,19 +61,31 @@ export const usePwaInstall = () => {
         setIsPwaInstallCanceled(true);
     };
 
+    const handlePwaInstall = (event: Event) => {
+        event.preventDefault();
+        setPwaInstallEvent(event);
+    };
+
+    const handleAppInstalled = () => {
+        toast({
+            title: "ホームに追加されました",
+            status: "success",
+            duration: 5000,
+            isClosable: true,
+        });
+    }
+
     useEffect(() => {
         setIsPwaSupported(checkIsPwaSupported());
         setIsRunningOnPwa(checkIsRunningOnPwa());
         setIsPwaInstalled(checkIsAlreadyInstalled());
         setIsPwaInstallCanceled(checkIsPwaInstallCanceled());
 
-        const handlePwaInstall = (event: Event) => {
-            event.preventDefault();
-            setPwaInstallEvent(event);
-        };
         window.addEventListener("beforeinstallprompt", handlePwaInstall);
+        window.addEventListener("appinstalled", handleAppInstalled);
         return () => {
             window.removeEventListener("beforeinstallprompt", handlePwaInstall);
+            window.removeEventListener("appinstalled", handleAppInstalled);
         };
     }, []);
 

--- a/src/view/hooks/usePwaInstall.ts
+++ b/src/view/hooks/usePwaInstall.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { hasValue } from "src/domain/util/null";
+import { LocalStorageKeys } from "src/view/constants/localStorageKey";
+import { isPC } from "src/view/constants/userAgent";
+
+export const usePwaInstall = () => {
+    const [pwaInstallEvent, setPwaInstallEvent] = useState<Event | null>(null);
+    const [isPwaSupported, setIsPwaSupported] = useState(false);
+    const [isRunningOnPwa, setIsRunningOnPwa] = useState(false);
+    const [isPwaInstalled, setIsPwaInstalled] = useState(false);
+    const [isPwaInstallCanceled, setIsPwaInstallCanceled] = useState(false);
+
+    const checkIsPwaSupported = () => {
+        return (
+            "serviceWorker" in navigator &&
+            "storage" in navigator &&
+            "permissions" in navigator
+        );
+    };
+
+    const checkIsRunningOnPwa = () => {
+        return window.matchMedia("(display-mode: standalone)").matches;
+    };
+
+    const checkIsPwaInstallCanceled = () => {
+        return (
+            localStorage.getItem(LocalStorageKeys.cancelInstallPwa) === "true"
+        );
+    };
+
+    const checkIsAlreadyInstalled = () => {
+        return localStorage.getItem(LocalStorageKeys.pwaInstalled) === "true";
+    };
+
+    const installPwa = async () => {
+        if (pwaInstallEvent) {
+            const promptEvent = pwaInstallEvent;
+            promptEvent["prompt"]();
+            const choiceResult = await promptEvent["userChoice"];
+            if (choiceResult.outcome === "accepted") {
+                setPwaInstallEvent(null);
+                setIsPwaInstalled(true);
+                localStorage.setItem(LocalStorageKeys.pwaInstalled, "true");
+            } else {
+                setIsPwaInstalled(false);
+            }
+        }
+    };
+
+    const cancelInstallPwa = () => {
+        localStorage.setItem(LocalStorageKeys.cancelInstallPwa, "true");
+        setIsPwaInstallCanceled(true);
+    };
+
+    useEffect(() => {
+        setIsPwaSupported(checkIsPwaSupported());
+        setIsRunningOnPwa(checkIsRunningOnPwa());
+        setIsPwaInstalled(checkIsAlreadyInstalled());
+        setIsPwaInstallCanceled(checkIsPwaInstallCanceled());
+
+        const handlePwaInstall = (event: Event) => {
+            event.preventDefault();
+            setPwaInstallEvent(event);
+        };
+        window.addEventListener("beforeinstallprompt", handlePwaInstall);
+        return () => {
+            window.removeEventListener("beforeinstallprompt", handlePwaInstall);
+        };
+    }, []);
+
+    return {
+        isPwaInstallVisible:
+            isPwaSupported &&
+            hasValue(pwaInstallEvent) &&
+            !isPC &&
+            !isRunningOnPwa &&
+            !isPwaInstalled &&
+            !isPwaInstallCanceled,
+        cancelInstallPwa,
+        installPwa,
+    };
+};

--- a/src/view/hooks/usePwaInstall.ts
+++ b/src/view/hooks/usePwaInstall.ts
@@ -62,6 +62,10 @@ export const usePwaInstall = () => {
     };
 
     const handlePwaInstall = (event: Event) => {
+        // アンインストールされたことをインストールイベントで検知
+        localStorage.setItem(LocalStorageKeys.pwaInstalled, "false");
+        setIsPwaInstalled(false);
+
         event.preventDefault();
         setPwaInstallEvent(event);
     };

--- a/src/view/hooks/usePwaInstall.ts
+++ b/src/view/hooks/usePwaInstall.ts
@@ -1,9 +1,11 @@
+import { useToast } from "@chakra-ui/react";
+import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useEffect, useState } from "react";
 import { isSafari } from "react-device-detect";
 import { hasValue } from "src/domain/util/null";
+import { AnalyticsEvents } from "src/view/constants/analytics";
 import { LocalStorageKeys } from "src/view/constants/localStorageKey";
 import { isPC } from "src/view/constants/userAgent";
-import {useToast} from "@chakra-ui/react";
 
 // TODO: iOSのインストール手順をダイアログで見せる（インストール手順をスクリーンショットで見せる）
 export const usePwaInstall = () => {
@@ -47,10 +49,12 @@ export const usePwaInstall = () => {
             promptEvent["prompt"]();
             const choiceResult = await promptEvent["userChoice"];
             if (choiceResult.outcome === "accepted") {
+                logEvent(getAnalytics(), AnalyticsEvents.Pwa.Install);
                 setPwaInstallEvent(null);
                 setIsPwaInstalled(true);
                 localStorage.setItem(LocalStorageKeys.pwaInstalled, "true");
             } else {
+                logEvent(getAnalytics(), AnalyticsEvents.Pwa.CancelOnPrompt);
                 setIsPwaInstalled(false);
             }
         }
@@ -59,6 +63,7 @@ export const usePwaInstall = () => {
     const cancelInstallPwa = () => {
         localStorage.setItem(LocalStorageKeys.cancelInstallPwa, "true");
         setIsPwaInstallCanceled(true);
+        logEvent(getAnalytics(), AnalyticsEvents.Pwa.Cancel);
     };
 
     const handlePwaInstall = (event: Event) => {
@@ -77,7 +82,7 @@ export const usePwaInstall = () => {
             duration: 5000,
             isClosable: true,
         });
-    }
+    };
 
     useEffect(() => {
         setIsPwaSupported(checkIsPwaSupported());

--- a/src/view/hooks/usePwaInstall.ts
+++ b/src/view/hooks/usePwaInstall.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
+import { isSafari } from "react-device-detect";
 import { hasValue } from "src/domain/util/null";
 import { LocalStorageKeys } from "src/view/constants/localStorageKey";
 import { isPC } from "src/view/constants/userAgent";
 
+// TODO: iOSのインストール手順をダイアログで見せる（インストール手順をスクリーンショットで見せる）
 export const usePwaInstall = () => {
     const [pwaInstallEvent, setPwaInstallEvent] = useState<Event | null>(null);
     const [isPwaSupported, setIsPwaSupported] = useState(false);
@@ -30,6 +32,11 @@ export const usePwaInstall = () => {
 
     const checkIsAlreadyInstalled = () => {
         return localStorage.getItem(LocalStorageKeys.pwaInstalled) === "true";
+    };
+
+    const checkIsIosSafari = () => {
+        // TODO: productionでも表示する
+        return isSafari && process.env.APP_ENV !== "production";
     };
 
     const installPwa = async () => {
@@ -71,10 +78,15 @@ export const usePwaInstall = () => {
     return {
         isPwaInstallVisible:
             isPwaSupported &&
-            hasValue(pwaInstallEvent) &&
+            // Android: PWAインストール可能の場合は表示
+            // iOS: Safariで表示しているときのみ表示
+            (hasValue(pwaInstallEvent) || checkIsIosSafari()) &&
+            // PCの場合は表示しない
             !isPC &&
+            // すでにPWAがインストールされている場合は表示しない
             !isRunningOnPwa &&
             !isPwaInstalled &&
+            // PWAインストールをキャンセルした場合は表示しない
             !isPwaInstallCanceled,
         cancelInstallPwa,
         installPwa,

--- a/src/view/top/PwaInstallDialog.tsx
+++ b/src/view/top/PwaInstallDialog.tsx
@@ -38,7 +38,7 @@ export function PwaInstallDialog({
         >
             {(state) =>
                 !["exited", "unmounted"].includes(state) && (
-                    <Center px={Size.top.px} w="100%" mt="32px">
+                    <Center px={Size.top.px} w="100%" mt="16px">
                         <VStack
                             backgroundColor="white"
                             borderRadius="20px"

--- a/src/view/top/PwaInstallDialog.tsx
+++ b/src/view/top/PwaInstallDialog.tsx
@@ -1,0 +1,104 @@
+import { Box, Button, Center, HStack, Text, VStack } from "@chakra-ui/react";
+import Image from "next/image";
+import { CSSProperties } from "react";
+import { Transition, TransitionStatus } from "react-transition-group";
+import { RoundedButton } from "src/view/common/RoundedButton";
+import { Size } from "src/view/constants/size";
+
+type Props = {
+    visible: boolean;
+    onClickInstall: () => void;
+    onClickCancel: () => void;
+};
+
+const dialogStyles: {
+    [key in TransitionStatus]: CSSProperties | undefined;
+} = {
+    entering: { opacity: 0, transform: "scale(0.9)" },
+    entered: { opacity: 1, boxShadow: "0 0 20px 0 #f0dfca" },
+    exiting: { opacity: 0, transform: "scale(0.9)" },
+    exited: { opacity: 0 },
+    unmounted: { opacity: 0 },
+};
+
+export function PwaInstallDialog({
+    visible,
+    onClickInstall,
+    onClickCancel,
+}: Props) {
+    return (
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        <Transition
+            in={visible}
+            timeout={{
+                enter: 200,
+                exit: 200,
+            }}
+        >
+            {(state) =>
+                !["exited", "unmounted"].includes(state) && (
+                    <Center px={Size.top.px} w="100%" mt="32px">
+                        <VStack
+                            backgroundColor="white"
+                            borderRadius="20px"
+                            spacing="8px"
+                            w="100%"
+                            px="16px"
+                            py="16px"
+                            style={{
+                                ...dialogStyles[state],
+                                transition:
+                                    "all 0.4s ease-in-out, box-shadow 0.4s 0.3s ease-in-out",
+                            }}
+                        >
+                            <HStack
+                                w="100%"
+                                spacing="8px"
+                                justifyContent="center"
+                            >
+                                <Image
+                                    src="/icons/icon-384x384.png"
+                                    alt="komichi"
+                                    width={64}
+                                    height={64}
+                                    style={{ borderRadius: "20px" }}
+                                />
+                                <Text
+                                    fontSize="1.1rem"
+                                    fontWeight="bold"
+                                    color="#45413E"
+                                >
+                                    komichiを
+                                    <br />
+                                    ホームに追加しますか?
+                                </Text>
+                            </HStack>
+                            <HStack
+                                w="100%"
+                                py="8px"
+                                justifyContent="space-between"
+                            >
+                                <Button
+                                    flex={1}
+                                    variant="link"
+                                    onClick={onClickCancel}
+                                >
+                                    キャンセル
+                                </Button>
+                                <Box flex={1}>
+                                    <RoundedButton
+                                        onClick={onClickInstall}
+                                        color="#BF756E"
+                                    >
+                                        ホームに追加
+                                    </RoundedButton>
+                                </Box>
+                            </HStack>
+                        </VStack>
+                    </Center>
+                )
+            }
+        </Transition>
+    );
+}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
|before| after |
|---|-------|
|<img width="401" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/8c164f0e-cda6-49fe-93f1-33209dbd1788">|<img width="344" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/083b5ce9-38f2-4400-8278-26bf3d52995e">|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #651

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- ホームにkomichiを追加してもらうことで、komichiの利用率を向上させるため

### どのようにテストされているか
<!--　単体テストを作成した -->
ngrokを用いて以下を確認

**端末別インストール可能確認**
- [x] Mac Chromeで表示されないことを確認 <- スマホでのみ表示されるようにする
- [x] Mac Safariで表示されないことを確認
- [x] Android Chromeで表示されることを確認
- [x] iOS Safariで表示されることを確認（開発環境のみ）
- [x] iOS Chromeで表示されないことを確認 <- SafariでのみPWAが利用できる

**インストール挙動確認**
- [x] インストールボタンを押すとインストールできることを確認 
- [x] インストールが完了するとトーストが表示されることを確認
- [x] インストールが完了するとダイアログが表示されなくなることを確認  
- [x] PWAで開くと、ダイアログが表示されないことを確認
- [x] PWAをインストールすると、再度ダイアログが表示されることを確認  
- [x] インストールキャンセルボタンを押すと、ダイアログが表示されなくなることを確認 

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````