### PR TITLE
コラージュ画像をプラン詳細画面で見られるようにする

### DIFF
--- a/src/stories/plandetail/header/PlanHeaderPlaceCard.stories.tsx
+++ b/src/stories/plandetail/header/PlanHeaderPlaceCard.stories.tsx
@@ -24,7 +24,7 @@ export const Primary: Story = {
             (Story: any) => (
                 <Box
                     w={Size.PlanDetailHeader.maxW}
-                    h={Size.PlanDetailHeader.imageH}
+                    h={Size.PlanDetailHeader.imageH + "px"}
                 >
                     <Story />
                 </Box>
@@ -48,7 +48,7 @@ export const LongName: Story = {
             (Story: any) => (
                 <Box
                     w={Size.PlanDetailHeader.maxW}
-                    h={Size.PlanDetailHeader.imageH}
+                    h={Size.PlanDetailHeader.imageH + "px"}
                 >
                     <Story />
                 </Box>

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -1,4 +1,5 @@
 import { Padding } from "src/view/constants/padding";
+import { isPC } from "src/view/constants/userAgent";
 
 export const Size = {
     mainContentWidth: "var(--size-main-content-width)",
@@ -16,7 +17,14 @@ export const Size = {
         maxH: "900px",
         maxW: "500px",
         px: Padding.p16,
-        imageH: "300px",
+        imageH: 300,
+        PlaceList: {
+            height: 160,
+            scrollBarHeight: isPC ? 8 : 0,
+        },
+        Info: {
+            spacingY: 16,
+        },
     },
     PlanDetail: {
         px: "16px",

--- a/src/view/plandetail/CollageContainer.tsx
+++ b/src/view/plandetail/CollageContainer.tsx
@@ -13,11 +13,20 @@ export function CollageContainer({ children }: Props) {
 
     useEffect(() => {
         const handleResize = () => {
+            // console.log({
+            //     collageContainerRef: collageContainerRef.current,
+            //     collageRef: collageRef.current,
+            // })
             if (collageContainerRef.current && collageRef.current) {
                 const containerHeight =
                     collageContainerRef.current.clientHeight;
                 const collageHeight = collageRef.current.clientHeight;
                 const scaleValue = containerHeight / collageHeight;
+                console.log({
+                    containerHeight,
+                    collageHeight,
+                    scaleValue,
+                });
                 setScale(scaleValue);
             }
         };
@@ -42,7 +51,7 @@ export function CollageContainer({ children }: Props) {
                 bottom={0}
                 transform={`scale(${scale})`}
             >
-                {children}
+                <Box ref={collageRef}>{children}</Box>
             </Center>
         </Box>
     );

--- a/src/view/plandetail/CollageContainer.tsx
+++ b/src/view/plandetail/CollageContainer.tsx
@@ -1,0 +1,49 @@
+import { Box, Center } from "@chakra-ui/react";
+import { ReactNode, useEffect, useRef, useState } from "react";
+
+type Props = {
+    children?: ReactNode;
+};
+
+// 親要素の高さにあわせて、自動的にコラージュ画像をスケールする
+export function CollageContainer({ children }: Props) {
+    const collageContainerRef = useRef<HTMLDivElement>(null);
+    const collageRef = useRef<HTMLDivElement>(null);
+    const [scale, setScale] = useState(0);
+
+    useEffect(() => {
+        const handleResize = () => {
+            if (collageContainerRef.current && collageRef.current) {
+                const containerHeight =
+                    collageContainerRef.current.clientHeight;
+                const collageHeight = collageRef.current.clientHeight;
+                const scaleValue = containerHeight / collageHeight;
+                setScale(scaleValue);
+            }
+        };
+        const resizeObserver = new ResizeObserver(handleResize);
+
+        if (collageContainerRef.current) {
+            resizeObserver.observe(collageContainerRef.current);
+        }
+
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, []);
+
+    return (
+        <Box w="100%" position="relative" ref={collageContainerRef}>
+            <Center
+                position="absolute"
+                top={0}
+                left={0}
+                right={0}
+                bottom={0}
+                transform={`scale(${scale})`}
+            >
+                {children}
+            </Center>
+        </Box>
+    );
+}

--- a/src/view/plandetail/CollageTemplate.tsx
+++ b/src/view/plandetail/CollageTemplate.tsx
@@ -1,4 +1,5 @@
 import { Box, Divider, HStack, Image, Text, VStack } from "@chakra-ui/react";
+import { forwardRef } from "react";
 import Logo from "src/view/assets/svg/logo.svg";
 
 type CollagePlace = {
@@ -13,76 +14,107 @@ type CollageProps = {
     introduction: string;
 };
 
-export function CollageTemplate({ title, places, introduction }: CollageProps) {
-    return (
-        <Box padding={16} position="relative" background="white">
-            <Box textAlign="center" mb={4}>
-                <Text
-                    color="rgba(130, 141, 205, 1)"
-                    fontFamily="Inter"
-                    fontWeight="bold"
-                    fontSize="80px"
-                >
-                    {title}
-                </Text>
-            </Box>
-            <Divider borderColor="#A4ABD4" my={4} />
-            {places.map((place, index) => (
-                <Box key={index}>
-                    <HStack
-                        justifyContent="space-between"
-                        alignItems="flex-start"
-                        flexDirection={index % 2 === 0 ? "row" : "row-reverse"}
+export const CollageTemplate = forwardRef<HTMLDivElement, CollageProps>(
+    function CollageTemplateComponent({ title, places, introduction }, ref) {
+        return (
+            <VStack
+                ref={ref}
+                w="1080px"
+                h="1920px"
+                padding={16}
+                position="relative"
+                background="white"
+            >
+                <Box textAlign="center" mb={4}>
+                    <Text
+                        color="rgba(130, 141, 205, 1)"
+                        fontFamily="Inter"
+                        fontWeight="bold"
+                        fontSize="80px"
                     >
-                        <Image
-                            src={place.imageUrl}
-                            alt={`Collage Image ${index}`}
-                            borderRadius="lg"
-                            boxSize="400px"
-                        />
-                        <VStack alignItems="flex-start" spacing={0}>
-                            <Text
-                                color="rgba(130, 141, 205, 1)"
-                                fontFamily="Inter"
-                                fontWeight="bold"
-                                fontSize="56px"
-                            >
-                                {place.name}
-                            </Text>
-                            <Text
-                                color="rgba(164, 168, 212, 1)"
-                                fontFamily="Inter"
-                                fontWeight="bold"
-                                fontSize="32px"
-                            >
-                                滞在時間：{place.duration}分
-                            </Text>
-                        </VStack>
-                    </HStack>
-                    {index !== places.length - 1 && (
-                        <Divider borderColor="#A4ABD4" my={4} />
-                    )}
+                        {title}
+                    </Text>
                 </Box>
-            ))}
-            <Divider borderColor="#A4ABD4" my={4} />
-            <HStack spacing={8} alignItems="center">
-                <Text
-                    color="rgba(164, 168, 212, 1)"
-                    fontFamily="Inter"
-                    fontWeight="bold"
-                    fontSize="32px"
-                >
-                    {introduction}
-                </Text>
-                <Logo
-                    viewBox="0 0 315 75"
-                    style={{
-                        bottom: 0,
-                        right: 0,
-                        position: "absolute",
-                    }}
-                />
-            </HStack>
-        </Box>
-    );
-}
+                <Divider borderColor="#A4ABD4" my={4} />
+                <VStack w="100%" flex={1} spacing="32px" divider={<Divider />}>
+                    {places.map((place, index) => (
+                        <HStack
+                            spacing="32px"
+                            key={index}
+                            flex={1}
+                            w="100%"
+                            justifyContent="space-between"
+                            alignItems="flex-start"
+                            flexDirection={
+                                index % 2 === 0 ? "row" : "row-reverse"
+                            }
+                        >
+                            <Box
+                                h="100%"
+                                w="100%"
+                                overflow="hidden"
+                                position="relative"
+                                flex={1}
+                            >
+                                <Image
+                                    position="absolute"
+                                    top={0}
+                                    left={0}
+                                    right={0}
+                                    bottom={0}
+                                    h="100%"
+                                    w="100%"
+                                    objectFit="cover"
+                                    src={place.imageUrl}
+                                    alt={`Collage Image ${index}`}
+                                    borderRadius="lg"
+                                />
+                            </Box>
+                            <VStack
+                                alignItems="flex-start"
+                                spacing={0}
+                                flex={1}
+                            >
+                                <Text
+                                    color="rgba(130, 141, 205, 1)"
+                                    fontFamily="Inter"
+                                    fontWeight="bold"
+                                    fontSize="56px"
+                                >
+                                    {place.name}
+                                </Text>
+                                <Text
+                                    color="rgba(164, 168, 212, 1)"
+                                    fontFamily="Inter"
+                                    fontWeight="bold"
+                                    fontSize="32px"
+                                >
+                                    滞在時間：{place.duration}分
+                                </Text>
+                            </VStack>
+                        </HStack>
+                    ))}
+                </VStack>
+                <Divider borderColor="#A4ABD4" my={4} />
+                <HStack spacing={8} alignItems="center">
+                    <Text
+                        color="rgba(164, 168, 212, 1)"
+                        fontFamily="Inter"
+                        fontWeight="bold"
+                        fontSize="32px"
+                    >
+                        {introduction}
+                    </Text>
+                    <Logo
+                        viewBox="0 0 315 75"
+                        style={{
+                            bottom: 0,
+                            right: 0,
+                            position: "absolute",
+                        }}
+                    />
+                </HStack>
+            </VStack>
+        );
+    }
+);

--- a/src/view/plandetail/CollageTemplate.tsx
+++ b/src/view/plandetail/CollageTemplate.tsx
@@ -15,7 +15,7 @@ type CollageProps = {
 
 export function CollageTemplate({ title, places, introduction }: CollageProps) {
     return (
-        <Box padding={16} position="relative">
+        <Box padding={16} position="relative" background="white">
             <Box textAlign="center" mb={4}>
                 <Text
                     color="rgba(130, 141, 205, 1)"

--- a/src/view/plandetail/CollageTemplate.tsx
+++ b/src/view/plandetail/CollageTemplate.tsx
@@ -21,6 +21,7 @@ export const CollageTemplate = forwardRef<HTMLDivElement, CollageProps>(
                 ref={ref}
                 w="1080px"
                 h="1920px"
+                minW="1080px"
                 padding={16}
                 position="relative"
                 background="white"

--- a/src/view/plandetail/header/PlaceImageGallery.tsx
+++ b/src/view/plandetail/header/PlaceImageGallery.tsx
@@ -46,7 +46,7 @@ export const PlaceImageGallery = ({
                 borderRadius="20px"
                 overflow="hidden"
                 w="100%"
-                h={Size.PlanDetailHeader.imageH}
+                h={Size.PlanDetailHeader.imageH + "px"}
                 maxW={Size.PlanDetailHeader.maxW}
             >
                 <Splide
@@ -59,7 +59,7 @@ export const PlaceImageGallery = ({
                         pagination: false,
                         perPage: 1,
                         type: "slide",
-                        height: Size.PlanDetailHeader.imageH,
+                        height: Size.PlanDetailHeader.imageH + "px",
                     }}
                 >
                     {places.map((place, i) => (
@@ -133,7 +133,7 @@ function AmbientBackgroundImage({
             bottom={0}
             left={0}
             w="100%"
-            h={`calc(${Size.PlanDetailHeader.imageH})`}
+            h={`calc(${Size.PlanDetailHeader.imageH + "px"})`}
         >
             <Image
                 w={`calc(${100 / scale}% + ${margin / scale}px)`}

--- a/src/view/plandetail/header/PlaceList.tsx
+++ b/src/view/plandetail/header/PlaceList.tsx
@@ -20,7 +20,7 @@ export function PlaceList({ places, onClickPlace }: Props) {
             /*親要素で余白をつけると、スクロール時に範囲外が切れてしまう*/
             px={Size.PlanDetailHeader.px}
             /*スクロールバーと要素間の余白*/
-            pb={isPC && "8px"}
+            pb={isPC && Size.PlanDetailHeader.PlaceList.scrollBarHeight + "px"}
             sx={{
                 scrollbarColor: "rgba(255,255,255,0.6) rgba(0,0,0,.2)",
                 scrollbarWidth: "thin",
@@ -72,10 +72,11 @@ function PlaceCard({ place, onClick }: { place: Place; onClick: () => void }) {
             backgroundColor="rgba(0, 0, 0, 0.3)"
             overflow="hidden"
             w="200px"
+            h={Size.PlanDetailHeader.PlaceList.height + "px"}
             userSelect="none"
             onClick={onClick}
         >
-            <Box w="100%" h="130px">
+            <Box w="100%" flex={1} overflowY="hidden">
                 <ImageWithSkeleton src={image} />
             </Box>
             <Text

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -55,7 +55,7 @@ export function PlanDetailPageHeader({
         if (collageRef.current) {
             const item = collageRef.current;
             const matrix = window.getComputedStyle(item).transform;
-            if (matrix !== 'none') {
+            if (matrix !== "none") {
                 const matrixArray = matrix.replace("matrix(", "").split(",");
                 const scale = parseFloat(matrixArray[0]);
                 item.style.height = item.clientHeight * scale + "px";
@@ -74,7 +74,7 @@ export function PlanDetailPageHeader({
             overflow="hidden"
         >
             {activeTab === "info" ? (
-                <VStack >
+                <VStack>
                     <VStack w="100%" flex={1}>
                         <Center
                             px={Size.PlanDetailHeader.px}
@@ -106,69 +106,6 @@ export function PlanDetailPageHeader({
                                 }
                             />
                         </Box>
-                    </VStack>
-                    <VStack
-                        w="100%"
-                        spacing="16px"
-                        alignItems="flex-start"
-                        justifyContent="flex-end"
-                        zIndex={1}
-                    >
-                        <VStack
-                            alignSelf="center"
-                            w="100%"
-                            mb="16px"
-                            px={Size.PlanDetailHeader.px}
-                            maxW={Size.PlanDetailHeader.maxW}
-                            alignItems="flex-start"
-                            justifyContent="center"
-                        >
-                            <Text
-                                color="white"
-                                fontWeight="bold"
-                                fontSize="20px"
-                            >
-                                {plan.title}
-                            </Text>
-                            {plan.author && (
-                                <HStack>
-                                    <Avatar
-                                        name={plan.author.name}
-                                        src={plan.author.avatarImage}
-                                    />
-                                    <Text color="white">
-                                        {plan.author.name}
-                                    </Text>
-                                </HStack>
-                            )}
-                        </VStack>
-                        <HStack
-                            w="100%"
-                            maxW={Size.PlanDetailHeader.maxW}
-                            px={Size.PlanDetailHeader.px}
-                            alignSelf="center"
-                        >
-                            {onCopyPlanUrl && (
-                                <HStack
-                                    as="button"
-                                    px="4px"
-                                    py="2px"
-                                    backgroundColor="rgba(255,255,255,.8)"
-                                    color="#282828"
-                                    borderRadius="8px"
-                                    onClick={onCopyPlanUrl}
-                                    spacing="4px"
-                                >
-                                    <Icon
-                                        w="32px"
-                                        h="32px"
-                                        color="#5E6382"
-                                        as={MdLink}
-                                    />
-                                    <Text>リンクをコピー</Text>
-                                </HStack>
-                            )}
-                        </HStack>
                     </VStack>
                 </VStack>
             ) : (
@@ -214,6 +151,63 @@ export function PlanDetailPageHeader({
                 >
                     アルバム
                 </Button>
+            </HStack>
+            <HStack
+                w="100%"
+                spacing="16px"
+                alignItems="flex-start"
+                justifyContent="flex-end"
+                zIndex={1}
+            >
+                <VStack
+                    alignSelf="center"
+                    w="100%"
+                    mb="16px"
+                    px={Size.PlanDetailHeader.px}
+                    maxW={Size.PlanDetailHeader.maxW}
+                    alignItems="flex-start"
+                    justifyContent="center"
+                >
+                    {plan.author && (
+                        <HStack>
+                            <Avatar
+                                name={plan.author.name}
+                                src={plan.author.avatarImage}
+                            />
+                            <Text color="white">{plan.author.name}</Text>
+                        </HStack>
+                    )}
+                    <Text color="white" fontWeight="bold" fontSize="20px">
+                        {plan.title}
+                    </Text>
+                </VStack>
+                <HStack
+                    w="100%"
+                    maxW={Size.PlanDetailHeader.maxW}
+                    px={Size.PlanDetailHeader.px}
+                    alignSelf="center"
+                >
+                    {onCopyPlanUrl && (
+                        <HStack
+                            as="button"
+                            px="4px"
+                            py="2px"
+                            backgroundColor="rgba(255,255,255,.8)"
+                            color="#282828"
+                            borderRadius="8px"
+                            onClick={onCopyPlanUrl}
+                            spacing="4px"
+                        >
+                            <Icon
+                                w="32px"
+                                h="32px"
+                                color="#5E6382"
+                                as={MdLink}
+                            />
+                            <Text>リンクをコピー</Text>
+                        </HStack>
+                    )}
+                </HStack>
             </HStack>
         </VStack>
     );

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -57,24 +57,24 @@ export function PlanDetailPageHeader({
 
     const mockIntroduction = "これは紹介文のモックです。";
 
+    const collageContainerRef = useRef<HTMLDivElement>(null);
     const collageRef = useRef<HTMLDivElement>(null);
     const infoRef = useRef<HTMLDivElement>(null);
-    const [infoHeight, setInfoHeight] = useState(0);
     const [scale, setScale] = useState(1);
 
     useEffect(() => {
-        if (infoRef.current) {
-            setInfoHeight(infoRef.current.clientHeight);
-        }
-    }, [activeTab]);
-
-    useEffect(() => {
-        if (collageRef.current) {
+        if (collageContainerRef.current && collageRef.current) {
+            const containerHeight = collageContainerRef.current.clientHeight;
             const collageHeight = collageRef.current.clientHeight;
-            const scaleValue = infoHeight / collageHeight;
+            const scaleValue = containerHeight / collageHeight;
+            console.log({
+                containerHeight,
+                collageHeight,
+                scaleValue,
+            });
             setScale(scaleValue);
         }
-    }, [infoHeight, activeTab]);
+    }, [activeTab]);
 
     return (
         <VStack
@@ -115,16 +115,27 @@ export function PlanDetailPageHeader({
                 </VStack>
             ) : (
                 <Box
-                    transform={`scale(${scale})`}
-                    transformOrigin="center top"
-                    h={infoHeight}
+                    position="relative"
+                    ref={collageContainerRef}
+                    flex={1}
+                    w="100%"
                 >
-                    <CollageTemplate
-                        ref={collageRef}
-                        title={plan.title}
-                        places={mockPlaces}
-                        introduction={mockIntroduction}
-                    />
+                    <Box
+                        position="absolute"
+                        // top={0}
+                        // left={0}
+                        // right={0}
+                        // bottom={0}
+                        transform={`scale(${scale})`}
+                        transformOrigin="center top"
+                    >
+                        <CollageTemplate
+                            ref={collageRef}
+                            title={plan.title}
+                            places={mockPlaces}
+                            introduction={mockIntroduction}
+                        />
+                    </Box>
                 </Box>
             )}
             <HStack>

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -45,7 +45,7 @@ export function PlanDetailPageHeader({
     const mockPlaces = plan.places.map((place, index) => ({
         name: place.name,
         duration: index * 30 + 30,
-        imageUrl: place.images[0]?.url || "https://via.placeholder.com/400",
+        imageUrl: "https://via.placeholder.com/400",
     }));
 
     const mockIntroduction = "これは紹介文のモックです。";
@@ -140,6 +140,7 @@ export function PlanDetailPageHeader({
                     backgroundSize="200% auto"
                     opacity={activeTab === "album" ? 1 : 0.3}
                     leftIcon={<Icon as={MdOutlineCameraAlt} />}
+
                 >
                     アルバム
                 </Button>

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -27,6 +27,12 @@ type Props = {
     onCopyPlanUrl?: () => void;
 };
 
+export const PlanHeaderTabs = {
+    Info: "Info",
+    Collage: "Collage",
+}
+export type PlanHeaderTab = typeof PlanHeaderTabs[keyof typeof PlanHeaderTabs];
+
 export function PlanDetailPageHeader({
     plan,
     likedPlaceIds,
@@ -40,7 +46,7 @@ export function PlanDetailPageHeader({
     const placesWithImages = plan.places.filter(
         (place) => place.images.length > 0
     );
-    const [activeTab, setActiveTab] = useState("info");
+    const [activeTab, setActiveTab] = useState(PlanHeaderTabs..Info);
 
     const mockPlaces = plan.places.map((place, index) => ({
         name: place.name,
@@ -75,7 +81,6 @@ export function PlanDetailPageHeader({
             overflow="hidden"
         >
             {activeTab === "info" ? (
-                <VStack>
                     <VStack w="100%" flex={1}>
                         <Center
                             px={Size.PlanDetailHeader.px}
@@ -108,7 +113,6 @@ export function PlanDetailPageHeader({
                             />
                         </Box>
                     </VStack>
-                </VStack>
             ) : (
                 <Box
                     ref={collageRef}

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -10,7 +10,7 @@ import {
     VStack,
 } from "@chakra-ui/react";
 import { useState } from "react";
-import { MdLink } from "react-icons/md";
+import { MdLink, MdOutlineInfo, MdOutlineCameraAlt  } from "react-icons/md";
 import { ImageSize } from "src/domain/models/Image";
 import { Plan } from "src/domain/models/Plan";
 import { Size } from "src/view/constants/size";
@@ -173,6 +173,7 @@ export function PlanDetailPageHeader({
                     background={activeTab === "info" ? "#AC8E6C" : "#F3ECE1"}
                     _hover={{ background: "#AC8E6C" }}
                     opacity={activeTab === "info" ? 1 : 0.6}
+                    leftIcon={<Icon as={MdOutlineInfo} />}
                 >
                     情報
                 </Button>
@@ -182,7 +183,8 @@ export function PlanDetailPageHeader({
                     background={activeTab === "album" ? "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)" : "#F3ECE1"}
                     backgroundSize="200% auto"
                     _hover={{ backgroundPosition: "right center", background: "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)" }}
-                    opacity={activeTab === "album" ? 1 : 0.6} // アクティブなタブの場合は不透明度を1に、そうでない場合は0.6にする
+                    opacity={activeTab === "album" ? 1 : 0.6}
+                    leftIcon={<Icon as={MdOutlineCameraAlt} />}
                 >
                     アルバム
                 </Button>

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -9,7 +9,7 @@ import {
     useMediaQuery,
     VStack,
 } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { MdLink, MdOutlineCameraAlt, MdOutlineInfo } from "react-icons/md";
 import { ImageSize } from "src/domain/models/Image";
 import { Plan } from "src/domain/models/Plan";
@@ -49,6 +49,20 @@ export function PlanDetailPageHeader({
 
     const mockIntroduction = "これは紹介文のモックです。";
 
+    const collageRef = useRef(null);
+
+    useEffect(() => {
+        if (collageRef.current) {
+            const item = collageRef.current;
+            const matrix = window.getComputedStyle(item).transform;
+            if (matrix !== 'none') {
+                const matrixArray = matrix.replace("matrix(", "").split(",");
+                const scale = parseFloat(matrixArray[0]);
+                item.style.height = item.clientHeight * scale + "px";
+            }
+        }
+    }, [activeTab]);
+
     return (
         <VStack
             flex={1}
@@ -60,7 +74,7 @@ export function PlanDetailPageHeader({
             overflow="hidden"
         >
             {activeTab === "info" ? (
-                <VStack>
+                <VStack >
                     <VStack w="100%" flex={1}>
                         <Center
                             px={Size.PlanDetailHeader.px}
@@ -158,7 +172,11 @@ export function PlanDetailPageHeader({
                     </VStack>
                 </VStack>
             ) : (
-                <Box background="white">
+                <Box
+                    ref={collageRef}
+                    transform="scale(0.3)"
+                    transformOrigin="center top"
+                >
                     <CollageTemplate
                         title={plan.title}
                         places={mockPlaces}

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -4,17 +4,19 @@ import {
     Button,
     Center,
     Circle,
+    Flex,
     HStack,
     Icon,
     Text,
     useMediaQuery,
     VStack,
 } from "@chakra-ui/react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { MdLink, MdOutlineCameraAlt, MdOutlineInfo } from "react-icons/md";
 import { ImageSize } from "src/domain/models/Image";
 import { Plan } from "src/domain/models/Plan";
 import { Size } from "src/view/constants/size";
+import { CollageContainer } from "src/view/plandetail/CollageContainer";
 import { CollageTemplate } from "src/view/plandetail/CollageTemplate";
 import { PlaceImageGallery } from "src/view/plandetail/header/PlaceImageGallery";
 import { PlaceList } from "src/view/plandetail/header/PlaceList";
@@ -56,33 +58,7 @@ export function PlanDetailPageHeader({
     }));
 
     const mockIntroduction = "これは紹介文のモックです。";
-
-    const collageContainerRef = useRef<HTMLDivElement>(null);
-    const collageRef = useRef<HTMLDivElement>(null);
     const infoRef = useRef<HTMLDivElement>(null);
-    const [scale, setScale] = useState(0);
-
-    useEffect(() => {
-        // モードが切り替わると、collageContainerRef等に参照が追加される
-        const handleResize = () => {
-            if (collageContainerRef.current && collageRef.current) {
-                const containerHeight =
-                    collageContainerRef.current.clientHeight;
-                const collageHeight = collageRef.current.clientHeight;
-                const scaleValue = containerHeight / collageHeight;
-                setScale(scaleValue);
-            }
-        };
-        const resizeObserver = new ResizeObserver(handleResize);
-
-        if (collageContainerRef.current) {
-            resizeObserver.observe(collageContainerRef.current);
-        }
-
-        return () => {
-            resizeObserver.disconnect();
-        };
-    }, [activeTab]);
 
     return (
         <VStack
@@ -122,28 +98,15 @@ export function PlanDetailPageHeader({
                     </Box>
                 </VStack>
             ) : (
-                <Box
-                    position="relative"
-                    ref={collageContainerRef}
-                    flex={1}
-                    w="100%"
-                >
-                    <Center
-                        position="absolute"
-                        top={0}
-                        left={0}
-                        right={0}
-                        bottom={0}
-                        transform={`scale(${scale})`}
-                    >
+                <Flex flex={1} w="100%">
+                    <CollageContainer>
                         <CollageTemplate
-                            ref={collageRef}
                             title={plan.title}
                             places={mockPlaces}
                             introduction={mockIntroduction}
                         />
-                    </Center>
-                </Box>
+                    </CollageContainer>
+                </Flex>
             )}
             <HStack>
                 <Button

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -16,6 +16,7 @@ import { MdLink, MdOutlineCameraAlt, MdOutlineInfo } from "react-icons/md";
 import { ImageSize } from "src/domain/models/Image";
 import { Plan } from "src/domain/models/Plan";
 import { Size } from "src/view/constants/size";
+import { isPC } from "src/view/constants/userAgent";
 import { CollageContainer } from "src/view/plandetail/CollageContainer";
 import { CollageTemplate } from "src/view/plandetail/CollageTemplate";
 import { PlaceImageGallery } from "src/view/plandetail/header/PlaceImageGallery";
@@ -71,7 +72,12 @@ export function PlanDetailPageHeader({
             overflow="hidden"
         >
             {activeTab === PlanHeaderTabs.Info ? (
-                <VStack w="100%" flex={1} ref={infoRef}>
+                <VStack
+                    w="100%"
+                    flex={1}
+                    ref={infoRef}
+                    spacing={Size.PlanDetailHeader.Info.spacingY + "px"}
+                >
                     <Center px={Size.PlanDetailHeader.px} flex={1} zIndex={0}>
                         <PlaceImageGallery
                             places={placesWithImages}
@@ -98,7 +104,18 @@ export function PlanDetailPageHeader({
                     </Box>
                 </VStack>
             ) : (
-                <Flex flex={1} w="100%">
+                <Flex
+                    flex={!isPC && 1}
+                    w="100%"
+                    h={
+                        isPC &&
+                        Size.PlanDetailHeader.imageH +
+                            Size.PlanDetailHeader.Info.spacingY +
+                            Size.PlanDetailHeader.PlaceList.height +
+                            Size.PlanDetailHeader.PlaceList.scrollBarHeight +
+                            "px"
+                    }
+                >
                     <CollageContainer>
                         <CollageTemplate
                             title={plan.title}

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -120,14 +120,13 @@ export function PlanDetailPageHeader({
                     flex={1}
                     w="100%"
                 >
-                    <Box
+                    <Center
                         position="absolute"
-                        // top={0}
-                        // left={0}
-                        // right={0}
-                        // bottom={0}
+                        top={0}
+                        left={0}
+                        right={0}
+                        bottom={0}
                         transform={`scale(${scale})`}
-                        transformOrigin="center top"
                     >
                         <CollageTemplate
                             ref={collageRef}
@@ -135,7 +134,7 @@ export function PlanDetailPageHeader({
                             places={mockPlaces}
                             introduction={mockIntroduction}
                         />
-                    </Box>
+                    </Center>
                 </Box>
             )}
             <HStack>

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -147,16 +147,15 @@ export function PlanDetailPageHeader({
             <HStack
                 w="100%"
                 spacing="16px"
-                alignItems="flex-start"
                 justifyContent="flex-end"
                 zIndex={1}
+                px={Size.PlanDetailHeader.px}
+                maxW={Size.PlanDetailHeader.maxW}
             >
                 <VStack
                     alignSelf="center"
                     w="100%"
                     mb="16px"
-                    px={Size.PlanDetailHeader.px}
-                    maxW={Size.PlanDetailHeader.maxW}
                     alignItems="flex-start"
                     justifyContent="center"
                 >
@@ -174,9 +173,6 @@ export function PlanDetailPageHeader({
                     </Text>
                 </VStack>
                 <HStack
-                    w="100%"
-                    maxW={Size.PlanDetailHeader.maxW}
-                    px={Size.PlanDetailHeader.px}
                     alignSelf="center"
                 >
                     {onCopyPlanUrl && (

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -140,7 +140,6 @@ export function PlanDetailPageHeader({
                     backgroundSize="200% auto"
                     opacity={activeTab === "album" ? 1 : 0.3}
                     leftIcon={<Icon as={MdOutlineCameraAlt} />}
-
                 >
                     アルバム
                 </Button>

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -14,6 +14,7 @@ import { MdLink } from "react-icons/md";
 import { ImageSize } from "src/domain/models/Image";
 import { Plan } from "src/domain/models/Plan";
 import { Size } from "src/view/constants/size";
+import { CollageTemplate } from "src/view/plandetail/CollageTemplate";
 import { PlaceImageGallery } from "src/view/plandetail/header/PlaceImageGallery";
 import { PlaceList } from "src/view/plandetail/header/PlaceList";
 
@@ -39,6 +40,14 @@ export function PlanDetailPageHeader({
         (place) => place.images.length > 0
     );
     const [activeTab, setActiveTab] = useState("info");
+
+    const mockPlaces = plan.places.map((place, index) => ({
+        name: place.name,
+        duration: index * 30 + 30,
+        imageUrl: place.images[0]?.url || "https://via.placeholder.com/400",
+    }));
+
+    const mockIntroduction = "これは紹介文のモックです。";
 
     return (
         <VStack
@@ -149,18 +158,31 @@ export function PlanDetailPageHeader({
                     </VStack>
                 </VStack>
             ) : (
-                <></>
+            <Box background="white">
+                <CollageTemplate
+                    title={plan.title}
+                    places={mockPlaces}
+                    introduction={mockIntroduction}
+                />
+            </Box>
             )}
             <HStack>
-                <Button onClick={() => setActiveTab("info")} color="#AC8E6C">
+                <Button
+                    onClick={() => setActiveTab("info")}
+                    color="white"
+                    background={activeTab === "info" ? "#AC8E6C" : "#F3ECE1"}
+                    _hover={{ background: "#AC8E6C" }}
+                    opacity={activeTab === "info" ? 1 : 0.6}
+                >
                     情報
                 </Button>
                 <Button
                     onClick={() => setActiveTab("album")}
-                    background="linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)"
-                    backgroundSize="200% auto"
-                    _hover={{ backgroundPosition: "right center" }}
                     color="white"
+                    background={activeTab === "album" ? "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)" : "#F3ECE1"}
+                    backgroundSize="200% auto"
+                    _hover={{ backgroundPosition: "right center", background: "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)" }}
+                    opacity={activeTab === "album" ? 1 : 0.6} // アクティブなタブの場合は不透明度を1に、そうでない場合は0.6にする
                 >
                     アルバム
                 </Button>

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -1,6 +1,7 @@
 import {
     Avatar,
     Box,
+    Button,
     Center,
     HStack,
     Icon,
@@ -37,6 +38,8 @@ export function PlanDetailPageHeader({
     const placesWithImages = plan.places.filter(
         (place) => place.images.length > 0
     );
+    const [activeTab, setActiveTab] = useState("info");
+
     return (
         <VStack
             flex={1}
@@ -47,89 +50,99 @@ export function PlanDetailPageHeader({
             spacing="16px"
             overflow="hidden"
         >
-            <VStack w="100%" flex={1}>
-                <Center px={Size.PlanDetailHeader.px} flex={1} zIndex={0}>
-                    <PlaceImageGallery
-                        places={placesWithImages}
-                        currentPage={currentPage}
-                        likedPlaceIds={likedPlaceIds}
-                        onUpdateLikePlace={onUpdateLikePlace}
-                        onPageChange={(page) => setCurrentPage(page)}
-                    />
-                </Center>
-                <Box
-                    zIndex={1}
-                    alignSelf="center"
-                    w={!isLargerThanHeaderWidth && "100%"}
-                    maxW={
-                        isLargerThanHeaderWidth
-                            ? "100%"
-                            : Size.PlanDetailHeader.maxW
-                    }
-                >
-                    <PlaceList
-                        places={plan.places}
-                        onClickPlace={({ index }) => setCurrentPage(index)}
-                    />
-                </Box>
-            </VStack>
-            <VStack
-                w="100%"
-                spacing="16px"
-                alignItems="flex-start"
-                justifyContent="flex-end"
-                zIndex={1}
-            >
-                <VStack
-                    alignSelf="center"
-                    w="100%"
-                    mb="16px"
-                    px={Size.PlanDetailHeader.px}
-                    maxW={Size.PlanDetailHeader.maxW}
-                    alignItems="flex-start"
-                    justifyContent="center"
-                >
-                    <Text color="white" fontWeight="bold" fontSize="20px">
-                        {plan.title}
-                    </Text>
-                    {plan.author && (
-                        <HStack>
-                            <Avatar
-                                name={plan.author.name}
-                                src={plan.author.avatarImage}
+            {activeTab === "info" ? (
+                <VStack>
+                    <VStack w="100%" flex={1}>
+                        <Center px={Size.PlanDetailHeader.px} flex={1} zIndex={0}>
+                            <PlaceImageGallery
+                                places={placesWithImages}
+                                currentPage={currentPage}
+                                likedPlaceIds={likedPlaceIds}
+                                onUpdateLikePlace={onUpdateLikePlace}
+                                onPageChange={(page) => setCurrentPage(page)}
                             />
-                            <Text color="white">{plan.author.name}</Text>
-                        </HStack>
-                    )}
-                </VStack>
-                <HStack
-                    w="100%"
-                    maxW={Size.PlanDetailHeader.maxW}
-                    px={Size.PlanDetailHeader.px}
-                    alignSelf="center"
-                >
-                    {onCopyPlanUrl && (
-                        <HStack
-                            as="button"
-                            px="4px"
-                            py="2px"
-                            backgroundColor="rgba(255,255,255,.8)"
-                            color="#282828"
-                            borderRadius="8px"
-                            onClick={onCopyPlanUrl}
-                            spacing="4px"
+                        </Center>
+                        <Box
+                            zIndex={1}
+                            alignSelf="center"
+                            w={!isLargerThanHeaderWidth && "100%"}
+                            maxW={
+                                isLargerThanHeaderWidth
+                                    ? "100%"
+                                    : Size.PlanDetailHeader.maxW
+                            }
                         >
-                            <Icon
-                                w="32px"
-                                h="32px"
-                                color="#5E6382"
-                                as={MdLink}
+                            <PlaceList
+                                places={plan.places}
+                                onClickPlace={({ index }) => setCurrentPage(index)}
                             />
-                            <Text>リンクをコピー</Text>
+                        </Box>
+                    </VStack>
+                    <VStack
+                        w="100%"
+                        spacing="16px"
+                        alignItems="flex-start"
+                        justifyContent="flex-end"
+                        zIndex={1}
+                    >
+                        <VStack
+                            alignSelf="center"
+                            w="100%"
+                            mb="16px"
+                            px={Size.PlanDetailHeader.px}
+                            maxW={Size.PlanDetailHeader.maxW}
+                            alignItems="flex-start"
+                            justifyContent="center"
+                        >
+                            <Text color="white" fontWeight="bold" fontSize="20px">
+                                {plan.title}
+                            </Text>
+                            {plan.author && (
+                                <HStack>
+                                    <Avatar
+                                        name={plan.author.name}
+                                        src={plan.author.avatarImage}
+                                    />
+                                    <Text color="white">{plan.author.name}</Text>
+                                </HStack>
+                            )}
+                        </VStack>
+                        <HStack
+                            w="100%"
+                            maxW={Size.PlanDetailHeader.maxW}
+                            px={Size.PlanDetailHeader.px}
+                            alignSelf="center"
+                        >
+                            {onCopyPlanUrl && (
+                                <HStack
+                                    as="button"
+                                    px="4px"
+                                    py="2px"
+                                    backgroundColor="rgba(255,255,255,.8)"
+                                    color="#282828"
+                                    borderRadius="8px"
+                                    onClick={onCopyPlanUrl}
+                                    spacing="4px"
+                                >
+                                    <Icon
+                                        w="32px"
+                                        h="32px"
+                                        color="#5E6382"
+                                        as={MdLink}
+                                    />
+                                    <Text>リンクをコピー</Text>
+                                </HStack>
+                            )}
                         </HStack>
-                    )}
-                </HStack>
-            </VStack>
+                    </VStack>
+                </VStack>
+            ) : (
+                <></>
+            )}
+            <HStack>
+                <Button onClick={() => setActiveTab("info")}>情報</Button>
+                <Button onClick={() => setActiveTab("album")}>アルバム</Button>
+            </HStack>
         </VStack>
     );
 }

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -10,7 +10,7 @@ import {
     VStack,
 } from "@chakra-ui/react";
 import { useState } from "react";
-import { MdLink, MdOutlineInfo, MdOutlineCameraAlt  } from "react-icons/md";
+import { MdLink, MdOutlineCameraAlt, MdOutlineInfo } from "react-icons/md";
 import { ImageSize } from "src/domain/models/Image";
 import { Plan } from "src/domain/models/Plan";
 import { Size } from "src/view/constants/size";
@@ -158,13 +158,13 @@ export function PlanDetailPageHeader({
                     </VStack>
                 </VStack>
             ) : (
-            <Box background="white">
-                <CollageTemplate
-                    title={plan.title}
-                    places={mockPlaces}
-                    introduction={mockIntroduction}
-                />
-            </Box>
+                <Box background="white">
+                    <CollageTemplate
+                        title={plan.title}
+                        places={mockPlaces}
+                        introduction={mockIntroduction}
+                    />
+                </Box>
             )}
             <HStack>
                 <Button
@@ -180,9 +180,17 @@ export function PlanDetailPageHeader({
                 <Button
                     onClick={() => setActiveTab("album")}
                     color="white"
-                    background={activeTab === "album" ? "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)" : "#F3ECE1"}
+                    background={
+                        activeTab === "album"
+                            ? "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)"
+                            : "#F3ECE1"
+                    }
                     backgroundSize="200% auto"
-                    _hover={{ backgroundPosition: "right center", background: "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)" }}
+                    _hover={{
+                        backgroundPosition: "right center",
+                        background:
+                            "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)",
+                    }}
                     opacity={activeTab === "album" ? 1 : 0.6}
                     leftIcon={<Icon as={MdOutlineCameraAlt} />}
                 >

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -57,24 +57,24 @@ export function PlanDetailPageHeader({
 
     const mockIntroduction = "これは紹介文のモックです。";
 
-    const collageRef = useRef(null);
-    const infoRef = useRef(null);
-    const [infoHeight, setInfoHeight] = useState("auto");
+    const collageRef = useRef<HTMLDivElement>(null);
+    const infoRef = useRef<HTMLDivElement>(null);
+    const [infoHeight, setInfoHeight] = useState(0);
     const [scale, setScale] = useState(1);
 
     useEffect(() => {
         if (infoRef.current) {
-            setInfoHeight(infoRef.current.clientHeight + "px");
+            setInfoHeight(infoRef.current.clientHeight);
         }
     }, [activeTab]);
 
     useEffect(() => {
-        if (infoRef.current && collageRef.current) {
+        if (collageRef.current) {
             const collageHeight = collageRef.current.clientHeight;
-            const scaleValue = infoRef.current.clientHeight / collageHeight;
+            const scaleValue = infoHeight / collageHeight;
             setScale(scaleValue);
         }
-    }, [infoHeight]);
+    }, [infoHeight, activeTab]);
 
     return (
         <VStack
@@ -115,12 +115,12 @@ export function PlanDetailPageHeader({
                 </VStack>
             ) : (
                 <Box
-                    ref={collageRef}
                     transform={`scale(${scale})`}
                     transformOrigin="center top"
-                    h={infoHeight} // 情報タブの高さを反映
+                    h={infoHeight}
                 >
                     <CollageTemplate
+                        ref={collageRef}
                         title={plan.title}
                         places={mockPlaces}
                         introduction={mockIntroduction}

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -3,6 +3,7 @@ import {
     Box,
     Button,
     Center,
+    Circle,
     HStack,
     Icon,
     Text,
@@ -111,7 +112,7 @@ export function PlanDetailPageHeader({
             ) : (
                 <Box
                     ref={collageRef}
-                    transform="scale(0.3)"
+                    transform="scale(0.25)"
                     transformOrigin="center top"
                 >
                     <CollageTemplate
@@ -125,9 +126,9 @@ export function PlanDetailPageHeader({
                 <Button
                     onClick={() => setActiveTab("info")}
                     color="white"
-                    background={activeTab === "info" ? "#AC8E6C" : "#F3ECE1"}
-                    _hover={{ background: "#AC8E6C" }}
-                    opacity={activeTab === "info" ? 1 : 0.6}
+                    background="#AC8E6C"
+                    _hover={{ background: "#b8a998" }}
+                    opacity={activeTab === "info" ? 1 : 0.3}
                     leftIcon={<Icon as={MdOutlineInfo} />}
                 >
                     情報
@@ -135,18 +136,9 @@ export function PlanDetailPageHeader({
                 <Button
                     onClick={() => setActiveTab("album")}
                     color="white"
-                    background={
-                        activeTab === "album"
-                            ? "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)"
-                            : "#F3ECE1"
-                    }
+                    background="linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)"
                     backgroundSize="200% auto"
-                    _hover={{
-                        backgroundPosition: "right center",
-                        background:
-                            "linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)",
-                    }}
-                    opacity={activeTab === "album" ? 1 : 0.6}
+                    opacity={activeTab === "album" ? 1 : 0.3}
                     leftIcon={<Icon as={MdOutlineCameraAlt} />}
                 >
                     アルバム
@@ -188,24 +180,22 @@ export function PlanDetailPageHeader({
                     alignSelf="center"
                 >
                     {onCopyPlanUrl && (
-                        <HStack
+                        <Circle
                             as="button"
-                            px="4px"
-                            py="2px"
-                            backgroundColor="rgba(255,255,255,.8)"
+                            px="6px"
+                            py="4px"
+                            backgroundColor="#875643"
                             color="#282828"
-                            borderRadius="8px"
                             onClick={onCopyPlanUrl}
-                            spacing="4px"
                         >
                             <Icon
                                 w="32px"
                                 h="32px"
-                                color="#5E6382"
+                                color="#FFFFFF"
                                 as={MdLink}
+                                transform="rotate(-45deg)"
                             />
-                            <Text>リンクをコピー</Text>
-                        </HStack>
+                        </Circle>
                     )}
                 </HStack>
             </HStack>

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -53,7 +53,11 @@ export function PlanDetailPageHeader({
             {activeTab === "info" ? (
                 <VStack>
                     <VStack w="100%" flex={1}>
-                        <Center px={Size.PlanDetailHeader.px} flex={1} zIndex={0}>
+                        <Center
+                            px={Size.PlanDetailHeader.px}
+                            flex={1}
+                            zIndex={0}
+                        >
                             <PlaceImageGallery
                                 places={placesWithImages}
                                 currentPage={currentPage}
@@ -74,7 +78,9 @@ export function PlanDetailPageHeader({
                         >
                             <PlaceList
                                 places={plan.places}
-                                onClickPlace={({ index }) => setCurrentPage(index)}
+                                onClickPlace={({ index }) =>
+                                    setCurrentPage(index)
+                                }
                             />
                         </Box>
                     </VStack>
@@ -94,7 +100,11 @@ export function PlanDetailPageHeader({
                             alignItems="flex-start"
                             justifyContent="center"
                         >
-                            <Text color="white" fontWeight="bold" fontSize="20px">
+                            <Text
+                                color="white"
+                                fontWeight="bold"
+                                fontSize="20px"
+                            >
                                 {plan.title}
                             </Text>
                             {plan.author && (
@@ -103,7 +113,9 @@ export function PlanDetailPageHeader({
                                         name={plan.author.name}
                                         src={plan.author.avatarImage}
                                     />
-                                    <Text color="white">{plan.author.name}</Text>
+                                    <Text color="white">
+                                        {plan.author.name}
+                                    </Text>
                                 </HStack>
                             )}
                         </VStack>
@@ -140,8 +152,18 @@ export function PlanDetailPageHeader({
                 <></>
             )}
             <HStack>
-                <Button onClick={() => setActiveTab("info")}>情報</Button>
-                <Button onClick={() => setActiveTab("album")}>アルバム</Button>
+                <Button onClick={() => setActiveTab("info")} color="#AC8E6C">
+                    情報
+                </Button>
+                <Button
+                    onClick={() => setActiveTab("album")}
+                    background="linear-gradient(90deg, #505FD0 0%, #7B45B9 23%, #DA2E79 62%, #FDC769 100%)"
+                    backgroundSize="200% auto"
+                    _hover={{ backgroundPosition: "right center" }}
+                    color="white"
+                >
+                    アルバム
+                </Button>
             </HStack>
         </VStack>
     );

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -60,20 +60,28 @@ export function PlanDetailPageHeader({
     const collageContainerRef = useRef<HTMLDivElement>(null);
     const collageRef = useRef<HTMLDivElement>(null);
     const infoRef = useRef<HTMLDivElement>(null);
-    const [scale, setScale] = useState(1);
+    const [scale, setScale] = useState(0);
 
     useEffect(() => {
-        if (collageContainerRef.current && collageRef.current) {
-            const containerHeight = collageContainerRef.current.clientHeight;
-            const collageHeight = collageRef.current.clientHeight;
-            const scaleValue = containerHeight / collageHeight;
-            console.log({
-                containerHeight,
-                collageHeight,
-                scaleValue,
-            });
-            setScale(scaleValue);
+        // モードが切り替わると、collageContainerRef等に参照が追加される
+        const handleResize = () => {
+            if (collageContainerRef.current && collageRef.current) {
+                const containerHeight =
+                    collageContainerRef.current.clientHeight;
+                const collageHeight = collageRef.current.clientHeight;
+                const scaleValue = containerHeight / collageHeight;
+                setScale(scaleValue);
+            }
+        };
+        const resizeObserver = new ResizeObserver(handleResize);
+
+        if (collageContainerRef.current) {
+            resizeObserver.observe(collageContainerRef.current);
         }
+
+        return () => {
+            resizeObserver.disconnect();
+        };
     }, [activeTab]);
 
     return (


### PR DESCRIPTION
### 修正の概要
コラージュ画像をプラン詳細画面切り替えて表示できるようにした．

|before| after |
|---|-------|
|情報タブ|![image](https://github.com/poroto-app/poroto/assets/90236945/0cd62099-d372-487b-a19b-610151e2eda4)|
|アルバムタブ|![image](https://github.com/poroto-app/poroto/assets/90236945/d0473c28-6d51-49d4-b3fa-0cdcd8e9e3f2))|

### 関連する Issue・PR
- #665
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
コラージュ画像を作成・レビューできるようにするため．

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] ボタンで情報画面とコラージュ画像プレビュー画面が切り替え可能かを確認
- [x] コラージュ画像が正しく表示されていることを確認 

```shell
# poroto
export BRANCH_POROTO=feature/collage_image_preview_switch
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````