### PR TITLE
Staging環境ではrobots.txtにだけアクセスできるようにする

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,6 +19,11 @@ export function middleware(req: NextRequest) {
     const basicAuth = req.headers.get("authorization");
     const url = req.nextUrl;
 
+    // robots.txtはBasic認証をスキップ
+    if (["/robots.txt"].includes(url.pathname)) {
+        return NextResponse.next();
+    }
+
     if (basicAuth) {
         const authValue = basicAuth.split(" ")[1];
         const [user, pwd] = atob(authValue).split(":");


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- Staging環境ではrobots.txtでクローラにインデックスを禁止している。
- しかし、staging環境ではBasic認証が動作するため、このファイルにアクセスできなくなっていた。
- そこでrobots.txtだけはBasic認証なしでアクセスできるように修正を行った。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- Staging環境をインデックスさせないため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] `http://localhost:3000/robots.txt` にはアクセスできることを確認
- [x] その他のパスにはアクセスできないことを確認 

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````