### PR TITLE
ダイアログがBottom Navigationよりも前に出るように修正

### DIFF
--- a/src/view/constants/zIndex.ts
+++ b/src/view/constants/zIndex.ts
@@ -1,5 +1,5 @@
 export const zIndex = {
     footer: 10,
-    bottomNavigation: 100,
+    bottomNavigation: 20,
     dialog: 100,
 };


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/9ba8c8b8-cdbb-43c1-af7e-c24b268d00c4)|![image](https://github.com/poroto-app/poroto/assets/55840281/ce718c4e-3f7b-44d3-bf05-81f48c9ca34b)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] 「いいね」した場所からプランを作成しようとしたときに、ダイアログがBottomNavigationよりも前に表示されることを確認

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````