### PR TITLE
プランを保存中のとき、遷移が完了するまでモーダルが表示されるようにする

### DIFF
--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -253,12 +253,12 @@ function PlanDetailPage({
     const { likedPlaceIdsInPlanCandidate, updateLikeAtPlace } =
         usePlaceLikeInPlanCandidate();
 
-    const { createPlan, savePlanFromCandidateRequestStatus } = usePlanCreate({
+    const { createPlan, isCreatingPlan } = usePlanCreate({
         planCandidateSetId: planCandidateSetId,
         planId: planId,
     });
 
-    if (savePlanFromCandidateRequestStatus === RequestStatuses.PENDING) {
+    if (isCreatingPlan) {
         return <LoadingModal title="プランを作成しています" />;
     }
 

--- a/src/view/hooks/usePlanCreate.ts
+++ b/src/view/hooks/usePlanCreate.ts
@@ -1,6 +1,6 @@
 import { getAuth } from "@firebase/auth";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import {useEffect, useState} from "react";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { setShowPlanCreatedModal } from "src/redux/plan";
 import {
@@ -21,10 +21,12 @@ export const usePlanCreate = ({ planCandidateSetId, planId }: Props) => {
     const router = useRouter();
     const { preview: plan, savePlanFromCandidateRequestStatus } =
         reduxPlanCandidateSelector();
+    const [isCreatingPlan, setIsCreatingPlan] = useState(false);
 
     const createPlan = async ({ planId }: { planId: string }) => {
         const auth = getAuth();
         const authToken = await auth.currentUser?.getIdToken(true);
+        setIsCreatingPlan(true);
         dispatch(
             savePlanFromCandidate({
                 session: planCandidateSetId,
@@ -39,6 +41,8 @@ export const usePlanCreate = ({ planCandidateSetId, planId }: Props) => {
         if (!plan) return;
         if (savePlanFromCandidateRequestStatus === RequestStatuses.FULFILLED) {
             router.push(Routes.plans.plan(plan.id)).then(() => {
+                // 遷移が終了したタイミングでモーダルが閉じるようにする
+                setIsCreatingPlan(false);
                 // 戻ったときに再リダイレクトされないようにする
                 dispatch(resetPlanCandidates());
             });
@@ -48,6 +52,6 @@ export const usePlanCreate = ({ planCandidateSetId, planId }: Props) => {
 
     return {
         createPlan,
-        savePlanFromCandidateRequestStatus,
+        isCreatingPlan,
     };
 };

--- a/src/view/hooks/usePlanCreate.ts
+++ b/src/view/hooks/usePlanCreate.ts
@@ -1,6 +1,6 @@
 import { getAuth } from "@firebase/auth";
 import { useRouter } from "next/router";
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { setShowPlanCreatedModal } from "src/redux/plan";
 import {


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
|before| after |
|---|-------|
|プランを保存したするときに、「保存中」のモーダルが消えた後、プラン候補の画面が一瞬表示され、保存済みプランのページに遷移する|プランを保存すると遷移が完了するまでモーダルが表示され、プラン候補の画面がちらつくことは無い|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #702

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 保存後の画面遷移中にプラン候補の画面がちらつかないことを確認

```shell
# poroto
export BRANCH_POROTO=feature/creating_plan_dialog
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````