### PR TITLE
アカウントページ・NavBarのアイコンアイコンがページ遷移のたびに更新されないようにする

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,9 @@ const nextConfig = {
     eslint: {
         ignoreDuringBuilds: true,
     },
+    images: {
+        domains: ['lh3.googleusercontent.com'],
+    },
     env: {
         APP_ENV: process.env.APP_ENV,
 

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -12,6 +12,10 @@ export const Size = {
     PlaceCardPaddingH: Padding.p16,
     NavBar: {
         height: "50px",
+        avatar: {
+            width: 33,
+            height: 33,
+        },
     },
     BottomNavigation: {
         height: 50,

--- a/src/view/constants/zIndex.ts
+++ b/src/view/constants/zIndex.ts
@@ -2,4 +2,5 @@ export const zIndex = {
     footer: 10,
     bottomNavigation: 100,
     dialog: 100,
+    navBarAvatarIcon: 1,
 };

--- a/src/view/hooks/useAuth.ts
+++ b/src/view/hooks/useAuth.ts
@@ -15,7 +15,9 @@ import { LocalStorageKeys } from "src/view/constants/localStorageKey";
 export const useAuth = () => {
     const dispatch = useAppDispatch();
     const { user, firebaseIdToken } = reduxAuthSelector();
-    const [isLoggedInUser, setIsLoggedInUser] = useState(false);
+    const [isLoggedInUser, setIsLoggedInUser] = useState(
+        hasValue(firebaseIdToken)
+    );
 
     useEffect(() => {
         setIsLoggedInUser(getLoggedIn() || hasValue(firebaseIdToken));

--- a/src/view/user/UserAvatar.tsx
+++ b/src/view/user/UserAvatar.tsx
@@ -1,5 +1,7 @@
-import { Avatar } from "@chakra-ui/react";
+import { Avatar, Center, Skeleton } from "@chakra-ui/react";
+import Image from "next/image";
 import { User } from "src/domain/models/User";
+import { Size } from "src/view/constants/size";
 
 type Props = {
     user: User | null;
@@ -8,14 +10,46 @@ type Props = {
 
 export function UserAvatar({ user, onClick }: Props) {
     return (
-        <button onClick={onClick}>
-            <Avatar
-                h="33px"
-                w="33px"
-                src={user?.avatarImage}
-                border="1px solid rgba(0,0,0,.1)"
-                backgroundColor={user?.avatarImage ? "whiter" : "#a9a9a9"}
-            />
-        </button>
+        <Center onClick={onClick}>
+            <Center
+                w={Size.NavBar.avatar.width + "px"}
+                h={Size.NavBar.avatar.height + "px"}
+                borderRadius="50%"
+                overflow="hidden"
+                backgroundColor="rgba(0,0,0,.1)"
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+                position="relative"
+            >
+                {user ? (
+                    <>
+                        <Skeleton
+                            position="absolute"
+                            top="0"
+                            right="0"
+                            bottom="0"
+                            left="0"
+                        />
+                        <Image
+                            height={33}
+                            width={33}
+                            alt="avatar image"
+                            src={user.avatarImage}
+                            style={{ zIndex: 1}}
+                        />
+                    </>
+                ) : (
+                    <Avatar
+                        h="33px"
+                        w="33px"
+                        border="1px solid rgba(0,0,0,.1)"
+                        backgroundColor={
+                            user?.avatarImage ? "whiter" : "#a9a9a9"
+                        }
+                    />
+                )}
+            </Center>
+        </Center>
     );
 }

--- a/src/view/user/UserAvatar.tsx
+++ b/src/view/user/UserAvatar.tsx
@@ -2,6 +2,7 @@ import { Avatar, Center, Skeleton } from "@chakra-ui/react";
 import Image from "next/image";
 import { User } from "src/domain/models/User";
 import { Size } from "src/view/constants/size";
+import { zIndex } from "src/view/constants/zIndex";
 
 type Props = {
     user: User | null;
@@ -36,7 +37,7 @@ export function UserAvatar({ user, onClick }: Props) {
                             width={33}
                             alt="avatar image"
                             src={user.avatarImage}
-                            style={{ zIndex: 1}}
+                            style={{ zIndex: zIndex.navBarAvatarIcon }}
                         />
                     </>
                 ) : (


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|場所|before| after |
|----|---|-------|
|/account|タブでアカウントページに切り替えるたびに、ログインを促す画面が一瞬移る|ログイン済みの場合はログインを促す画面は表示されない|
|NabBarのユーザーアイコン|ページを切り替えるたびに画像が再読み込みされる|ページを切り替えても再読み込みされない|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #711 
- close #705 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] ログイン済みの場合、タブでアカウントページに切り替えても、ログインを促す画面は表示されない
- [x] ログイン済みの場合、ページを切り替えても、アカウントのアイコンが再読み込みされない

```shell
# poroto
export BRANCH_POROTO=feature/account
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````