### PR TITLE
プラン詳細ページ・探すページの下部に適切な余白が入るようにする

### DIFF
--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -144,7 +144,7 @@ export default function PlanPage() {
 
         // Footerの高さ分スクロールしたら表示する
         const scrollHandler = () => {
-            setIsPlanFooterVisible(scrollY >= Size.PlanCandidate.Footer.h);
+            setIsPlanFooterVisible(scrollY >= Size.PlanFooter.h);
         };
         window.addEventListener("scroll", scrollHandler);
         return () => {

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -166,7 +166,10 @@ export default function PlanPage() {
     if (!plan) return <NotFound />;
 
     return (
-        <Center flexDirection="column" pb="32px">
+        <Center
+            flexDirection="column"
+            pb={32 + (isPlanFooterVisible ? Size.PlanFooter.h : 0) + "px"}
+        >
             <Head>
                 <title>{plan.title} | komichi</title>
             </Head>

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -272,14 +272,11 @@ function PlanDetailPage({
             <Center
                 w="100%"
                 flexDirection="column"
-                pb={Size.PlanCandidate.Footer.h + "px"}
+                pb={Size.PlanFooter.h + "px"}
             >
                 <VStack
                     w="100%"
-                    minH={
-                        !isPC &&
-                        `calc(100vh - ${Size.PlanCandidate.Footer.h + "px"})`
-                    }
+                    minH={!isPC && `calc(100vh - ${Size.PlanFooter.h + "px"})`}
                     scrollSnapAlign="start"
                 >
                     <PlanDetailPageHeader

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -20,6 +20,7 @@ export default function SearchPage() {
 
     return (
         <Layout
+            height="auto"
             navBar={<NavBar />}
             bottomNavigation={
                 <BottomNavigation page={BottomNavigationPages.Search} />

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -50,9 +50,7 @@ export const Size = {
         h: "200px",
         borderRadius: "20px",
     },
-    PlanCandidate: {
-        Footer: {
-            h: 80,
-        },
+    PlanFooter: {
+        h: 80,
     },
 };

--- a/src/view/plan/PlanFooter.tsx
+++ b/src/view/plan/PlanFooter.tsx
@@ -34,7 +34,7 @@ export function PlanFooter({ visible = true, children }: Props) {
                 <Center
                     backgroundColor="white"
                     borderTop="1px solid rgba(0,0,0,.1)"
-                    h={Size.PlanCandidate.Footer.h + "px"}
+                    h={Size.PlanFooter.h + "px"}
                     w="100%"
                     position="fixed"
                     px="16px"


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

- 保存済みプラン詳細ページで、画面下部にFooterの高さ分、余分に余白が入るようにする

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/acd888b6-ecb3-4959-81b2-41699f852984)|![image](https://github.com/poroto-app/poroto/assets/55840281/2e24e876-73ed-4969-b6bc-048a3b6a330c)|
|![image](https://github.com/poroto-app/poroto/assets/55840281/34ef3067-1194-4c58-bfd9-07165135ca6e)|![image](https://github.com/poroto-app/poroto/assets/55840281/79c92487-8de9-4015-9a66-2477d060a6ed)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] 自分が作成した保存済みプラン詳細ページの画面下部に適切な余白が入ることを確認（Footerが表示されない）
- [x] 自分以外が作成した保存済みプラン詳細ページの画面下部にFooterを考慮した余白が入ることを確認
- [x] sp表示の探すページの画面下部に、適切な余白が入ることを確認

```shell
# poroto
export BRANCH_POROTO=feature/bottom_space
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````