### PR TITLE
[プラン詳細ページ] 縦長画像のときにヘッダー部の縦横比が変化しないようにする

### DIFF
--- a/src/view/plandetail/header/PlaceImageGallery.tsx
+++ b/src/view/plandetail/header/PlaceImageGallery.tsx
@@ -29,7 +29,7 @@ export const PlaceImageGallery = ({
     }, [currentPage]);
 
     return (
-        <Box position="relative">
+        <Box position="relative" w="100%">
             <AmbientBackgroundImage
                 scale={5}
                 margin={4}

--- a/src/view/plandetail/header/PlaceList.tsx
+++ b/src/view/plandetail/header/PlaceList.tsx
@@ -17,6 +17,8 @@ export function PlaceList({ places, onClickPlace }: Props) {
             w="100%"
             overflowX="auto"
             whiteSpace="nowrap"
+            // 要素が少ないときに中央寄せになるようにする
+            justifyContent="space-evenly"
             /*親要素で余白をつけると、スクロール時に範囲外が切れてしまう*/
             px={Size.PlanDetailHeader.px}
             /*スクロールバーと要素間の余白*/

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -79,7 +79,13 @@ export function PlanDetailPageHeader({
                     ref={infoRef}
                     spacing={Size.PlanDetailHeader.Info.spacingY + "px"}
                 >
-                    <Center px={Size.PlanDetailHeader.px} w="100%" maxW={Size.PlanDetailHeader.maxW} flex={1} zIndex={0}>
+                    <Center
+                        px={Size.PlanDetailHeader.px}
+                        w="100%"
+                        maxW={Size.PlanDetailHeader.maxW}
+                        flex={1}
+                        zIndex={0}
+                    >
                         <PlaceImageGallery
                             places={placesWithImages}
                             currentPage={currentPage}

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -79,7 +79,7 @@ export function PlanDetailPageHeader({
                     ref={infoRef}
                     spacing={Size.PlanDetailHeader.Info.spacingY + "px"}
                 >
-                    <Center px={Size.PlanDetailHeader.px} flex={1} zIndex={0}>
+                    <Center px={Size.PlanDetailHeader.px} w="100%" maxW={Size.PlanDetailHeader.maxW} flex={1} zIndex={0}>
                         <PlaceImageGallery
                             places={placesWithImages}
                             currentPage={currentPage}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- プラン詳細画面で場所の画像が縦長の小さい画像のとき、レイアウトが崩れてしまうバグを修正

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/e5274e8f-a5d7-407d-b8f0-aae7a40f53a4)|![image](https://github.com/poroto-app/poroto/assets/55840281/8fb64a8f-6c2d-4da3-9bcd-0b94e6b03e79)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] GAギャラリーでプランを作成したときにレイアウトが崩れないことを確認

```shell
# poroto
export BRANCH_POROTO=feature/plan_detail_header_thumbnail_width
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````