### PR TITLE
ユーザーのプロフィール情報を更新するためのコンポーネントを作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react": "^18.2.0",
     "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
+    "react-easy-crop": "^5.0.7",
     "react-icons": "^5.2.1",
     "react-infinite-scroller": "^1.2.6",
     "react-redux": "^9.1.0",

--- a/src/stories/account/EditUserProfileDialog.stories.tsx
+++ b/src/stories/account/EditUserProfileDialog.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { mockUser } from "src/stories/mock/user";
+import { EditUserProfileDialog } from "src/view/account/EditUserProfileDialog";
+
+export default {
+    title: "account/EditUserProfileDialog",
+    component: EditUserProfileDialog,
+    tags: ["autodocs"],
+    parameters: {},
+} as Meta<typeof EditUserProfileDialog>;
+
+type Story = StoryObj<typeof EditUserProfileDialog>;
+
+export const Primary: Story = {
+    args: {
+        isVisible: true,
+        user: mockUser,
+    },
+};

--- a/src/stories/account/EditUserProfileDialog.stories.tsx
+++ b/src/stories/account/EditUserProfileDialog.stories.tsx
@@ -14,6 +14,9 @@ type Story = StoryObj<typeof EditUserProfileDialog>;
 export const Primary: Story = {
     args: {
         isVisible: true,
-        user: mockUser,
+        user: {
+            ...mockUser,
+            avatarImage: "https://picsum.photos/id/45/1280/720",
+        },
     },
 };

--- a/src/stories/account/UserCard.stories.tsx
+++ b/src/stories/account/UserCard.stories.tsx
@@ -29,3 +29,10 @@ export const Editable: Story = {
         isEditable: true,
     },
 };
+
+export const Editing: Story = {
+    args: {
+        user: mockUser,
+        isEditing: true,
+    },
+};

--- a/src/stories/account/UserCard.stories.tsx
+++ b/src/stories/account/UserCard.stories.tsx
@@ -22,3 +22,10 @@ export const Loading: Story = {
         user: null,
     },
 };
+
+export const Editable: Story = {
+    args: {
+        user: mockUser,
+        isEditable: true,
+    },
+};

--- a/src/stories/account/UserCard.stories.tsx
+++ b/src/stories/account/UserCard.stories.tsx
@@ -29,10 +29,3 @@ export const Editable: Story = {
         isEditable: true,
     },
 };
-
-export const Editing: Story = {
-    args: {
-        user: mockUser,
-        isEditing: true,
-    },
-};

--- a/src/view/account/EditUserProfileDialog.tsx
+++ b/src/view/account/EditUserProfileDialog.tsx
@@ -1,20 +1,34 @@
 import {
     Box,
+    Button,
     Center,
     HStack,
     Icon,
     Input,
+    Slider,
+    SliderFilledTrack,
+    SliderThumb,
+    SliderTrack,
+    Spinner,
     Text,
     VStack,
 } from "@chakra-ui/react";
-import { useState } from "react";
-import { MdClose, MdPhotoCamera } from "react-icons/md";
+import { useRef, useState } from "react";
+import Cropper from "react-easy-crop";
+import {
+    MdArrowBack,
+    MdClose,
+    MdPhotoCamera,
+    MdZoomIn,
+    MdZoomOut,
+} from "react-icons/md";
 import { User } from "src/domain/models/User";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
 import { RoundedButton } from "src/view/common/RoundedButton";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
 import { Padding } from "src/view/constants/padding";
+import { useCropImage } from "src/view/hooks/useCropImage";
 
 type Props = {
     isVisible: boolean;
@@ -33,24 +47,95 @@ export function EditUserProfileDialog({
     onClose,
 }: Props) {
     const [userName, setUserName] = useState(user.name);
+    const [imageToCrop, setImageToCrop] = useState<string | null>(null);
+    const [croppedImage, setCroppedImage] = useState<string | null>(null);
+    const [isLoadingFileInput, setIsLoadingFileInput] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleOnEditPhoto = () => {
+        fileInputRef.current?.click();
+    };
+
+    const onFileChanged = ({ files }: { files: FileList | null }) => {
+        setIsLoadingFileInput(false);
+        if (!files || files.length === 0) {
+            return;
+        }
+        const file = files[0];
+        const reader = new FileReader();
+        reader.onload = () => {
+            setIsLoadingFileInput(false);
+            const dataUrl = reader.result as string;
+            setImageToCrop(dataUrl);
+        };
+        setIsLoadingFileInput(true);
+        reader.readAsDataURL(file);
+    };
 
     const handleOnSave = () => {
         onSaveProfile?.({ name: userName });
     };
 
+    const handleOnCloseImageEditor = () => {
+        setImageToCrop(null);
+
+        // 同じ画像が選択された時にもイベントが発火するようにするためリセットする
+        if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+        }
+    };
+
+    const handleOnCropImage = ({
+        croppedImage,
+    }: {
+        croppedImage: string | null;
+    }) => {
+        setImageToCrop(null);
+        handleOnCloseImageEditor();
+        if (!croppedImage) return;
+        setCroppedImage(croppedImage);
+    };
+
     return (
-        <FullscreenDialog visible={isVisible} onClickOutside={onClose}>
+        <FullscreenDialog
+            visible={isVisible}
+            onClickOutside={onClose}
+            paddingY={Padding.p16}
+            paddingX={Padding.p8}
+        >
             <RoundedDialog>
-                <VStack px={Padding.p16} py={Padding.p16} minH="350px">
+                <VStack minH="500px">
+                    {imageToCrop ? (
+                        <ProfileImageEditor
+                            src={imageToCrop}
+                            onSave={handleOnCropImage}
+                            onClose={handleOnCloseImageEditor}
+                        />
+                    ) : (
                         <ProfileEditor
                             userName={userName}
-                            profileImageUrl={user.avatarImage}
+                            profileImageUrl={croppedImage ?? user.avatarImage}
+                            isLoadingFileInput={isLoadingFileInput}
                             onUpdateUserName={setUserName}
+                            onUpdateProfileImage={handleOnEditPhoto}
                             onClose={onClose}
                             onSave={handleOnSave}
                         />
+                    )}
                 </VStack>
             </RoundedDialog>
+            <input
+                ref={fileInputRef}
+                id="file-input"
+                type="file"
+                accept="image/*"
+                onChange={(e) =>
+                    onFileChanged({
+                        files: e.target.files,
+                    })
+                }
+                style={{ display: "none" }}
+            />
         </FullscreenDialog>
     );
 }
@@ -58,13 +143,17 @@ export function EditUserProfileDialog({
 function ProfileEditor({
     userName,
     profileImageUrl,
+    isLoadingFileInput,
     onUpdateUserName,
+    onUpdateProfileImage,
     onClose,
     onSave,
 }: {
     userName: string;
     profileImageUrl: string;
+    isLoadingFileInput?: boolean;
     onUpdateUserName: (name: string) => void;
+    onUpdateProfileImage: () => void;
     onClose: () => void;
     onSave: () => void;
 }) {
@@ -74,12 +163,14 @@ function ProfileEditor({
         <VStack
             w="100%"
             h="100%"
+            px={Padding.p16}
+            py={Padding.p16}
             flex={1}
             spacing={Padding.p16}
             justifyContent="space-between"
         >
             <HStack w="100%" pb={Padding.p16}>
-                <Text flex={1} fontWeight="semibold">
+                <Text flex={1} fontWeight="semibold" fontSize={18}>
                     プロフィールを編集
                 </Text>
                 <Center as="button" onClick={onClose}>
@@ -93,8 +184,8 @@ function ProfileEditor({
             </HStack>
             <Box position="relative" pb="16px">
                 <Box
-                    width="150px"
-                    height="150px"
+                    width="200px"
+                    height="200px"
                     backgroundColor="gray.200"
                     borderRadius="100%"
                     overflow="hidden"
@@ -108,21 +199,30 @@ function ProfileEditor({
                     bottom={0}
                     left={0}
                 >
-                    <Center
+                    <HStack
                         as="button"
                         border="1px solid rgba(0,0,0,.1)"
                         backgroundColor="white"
                         borderRadius="100"
-                        px={Padding.p8}
-                        py={Padding.p4}
+                        px={Padding.p16}
+                        py={Padding.p8}
+                        boxShadow="rgba(0, 0, 0, 0.12) 0px 6px 16px 0px"
+                        onClick={onUpdateProfileImage}
                     >
-                        <Icon
-                            w="24px"
-                            h="24px"
-                            color="rgba(0,0,0,.7)"
-                            as={MdPhotoCamera}
-                        />
-                    </Center>
+                        {isLoadingFileInput ? (
+                            <Spinner size="sm" color="blue.500" />
+                        ) : (
+                            <Icon
+                                w="24px"
+                                h="24px"
+                                color="rgba(0,0,0,.7)"
+                                as={MdPhotoCamera}
+                            />
+                        )}
+                        <Text fontWeight={600} fontSize={14}>
+                            編集
+                        </Text>
+                    </HStack>
                 </Center>
             </Box>
             <VStack
@@ -157,6 +257,103 @@ function ProfileEditor({
             <RoundedButton onClick={onSave}>
                 <Text>保存</Text>
             </RoundedButton>
+        </VStack>
+    );
+}
+
+function ProfileImageEditor({
+    src,
+    onClose,
+    onSave,
+}: {
+    src: string;
+    onSave: (params: { croppedImage: string }) => void;
+    onClose: () => void;
+}) {
+    const {
+        crop,
+        zoom,
+        isCropInProgress,
+        setCrop,
+        setZoom,
+        cropImage,
+        onCropComplete,
+    } = useCropImage({
+        originalImageSrc: src,
+    });
+
+    const handleSave = async () => {
+        const croppedImage = await cropImage();
+        onSave({ croppedImage });
+    };
+
+    return (
+        <VStack w="100%" h="100%" flex={1}>
+            <HStack w="100%" px={Padding.p16} py={Padding.p16}>
+                <Center as="button" onClick={onClose}>
+                    <Icon
+                        w="24px"
+                        h="24px"
+                        color="rgba(0,0,0,.5)"
+                        as={MdArrowBack}
+                    />
+                </Center>
+                <Text flex={1} fontWeight="semibold" fontSize={18}>
+                    写真を編集
+                </Text>
+                <Button
+                    colorScheme="blue"
+                    borderRadius="100px"
+                    onClick={handleSave}
+                    isLoading={isCropInProgress}
+                >
+                    保存
+                </Button>
+            </HStack>
+            <Box flex={1} width="100%" overflow="hidden" position="relative">
+                <Cropper
+                    image={src}
+                    onCropChange={setCrop}
+                    crop={crop}
+                    cropShape="round"
+                    zoom={zoom}
+                    aspect={1}
+                    onCropComplete={onCropComplete}
+                    showGrid={false}
+                />
+            </Box>
+            <VStack px={Padding.p16} py={Padding.p16} w="100%">
+                <Center w="100%">
+                    <HStack w="100%" maxW="300px">
+                        <Icon
+                            w="24px"
+                            h="24px"
+                            color="rgba(0,0,0,.5)"
+                            as={MdZoomOut}
+                        />
+                        <Slider
+                            aria-label="slider-ex-1"
+                            defaultValue={zoom}
+                            min={1}
+                            max={3}
+                            step={0.1}
+                            flex={1}
+                            onChange={(value) => setZoom(value)}
+                        >
+                            <SliderTrack>
+                                <SliderFilledTrack />
+                            </SliderTrack>
+                            <SliderThumb />
+                        </Slider>
+                        <Icon
+                            w="24px"
+                            h="24px"
+                            color="rgba(0,0,0,.5)"
+                            as={MdZoomIn}
+                        />
+                    </HStack>
+                </Center>
+            </VStack>
         </VStack>
     );
 }

--- a/src/view/account/EditUserProfileDialog.tsx
+++ b/src/view/account/EditUserProfileDialog.tsx
@@ -1,0 +1,162 @@
+import {
+    Box,
+    Center,
+    HStack,
+    Icon,
+    Input,
+    Text,
+    VStack,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { MdClose, MdPhotoCamera } from "react-icons/md";
+import { User } from "src/domain/models/User";
+import { FullscreenDialog } from "src/view/common/FullscreenDialog";
+import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
+import { RoundedButton } from "src/view/common/RoundedButton";
+import { RoundedDialog } from "src/view/common/RoundedDialog";
+import { Padding } from "src/view/constants/padding";
+
+type Props = {
+    isVisible: boolean;
+    user: User;
+    onSaveProfile?: (props: {
+        name?: string;
+        profileImageUrl?: string;
+    }) => void;
+    onClose?: () => void;
+};
+
+export function EditUserProfileDialog({
+    user,
+    isVisible,
+    onSaveProfile,
+    onClose,
+}: Props) {
+    const [userName, setUserName] = useState(user.name);
+
+    const handleOnSave = () => {
+        onSaveProfile?.({ name: userName });
+    };
+
+    return (
+        <FullscreenDialog visible={isVisible} onClickOutside={onClose}>
+            <RoundedDialog>
+                <VStack px={Padding.p16} py={Padding.p16} minH="350px">
+                        <ProfileEditor
+                            userName={userName}
+                            profileImageUrl={user.avatarImage}
+                            onUpdateUserName={setUserName}
+                            onClose={onClose}
+                            onSave={handleOnSave}
+                        />
+                </VStack>
+            </RoundedDialog>
+        </FullscreenDialog>
+    );
+}
+
+function ProfileEditor({
+    userName,
+    profileImageUrl,
+    onUpdateUserName,
+    onClose,
+    onSave,
+}: {
+    userName: string;
+    profileImageUrl: string;
+    onUpdateUserName: (name: string) => void;
+    onClose: () => void;
+    onSave: () => void;
+}) {
+    const [focusUserName, setFocusUserName] = useState(false);
+
+    return (
+        <VStack
+            w="100%"
+            h="100%"
+            flex={1}
+            spacing={Padding.p16}
+            justifyContent="space-between"
+        >
+            <HStack w="100%" pb={Padding.p16}>
+                <Text flex={1} fontWeight="semibold">
+                    プロフィールを編集
+                </Text>
+                <Center as="button" onClick={onClose}>
+                    <Icon
+                        w="24px"
+                        h="24px"
+                        color="rgba(0,0,0,.5)"
+                        as={MdClose}
+                    />
+                </Center>
+            </HStack>
+            <Box position="relative" pb="16px">
+                <Box
+                    width="150px"
+                    height="150px"
+                    backgroundColor="gray.200"
+                    borderRadius="100%"
+                    overflow="hidden"
+                >
+                    <ImageWithSkeleton src={profileImageUrl} />
+                </Box>
+                <Center
+                    w="100%"
+                    position="absolute"
+                    right={0}
+                    bottom={0}
+                    left={0}
+                >
+                    <Center
+                        as="button"
+                        border="1px solid rgba(0,0,0,.1)"
+                        backgroundColor="white"
+                        borderRadius="100"
+                        px={Padding.p8}
+                        py={Padding.p4}
+                    >
+                        <Icon
+                            w="24px"
+                            h="24px"
+                            color="rgba(0,0,0,.7)"
+                            as={MdPhotoCamera}
+                        />
+                    </Center>
+                </Center>
+            </Box>
+            <VStack
+                w="100%"
+                border={`1px solid ${focusUserName ? "rgba(29,155,240)" : "rgba(0,0,0,.1)"}`}
+                alignItems="flex-start"
+                px={Padding.p8}
+                py={Padding.p4}
+                spacing={0}
+                borderRadius="8px"
+            >
+                <Text
+                    color={
+                        focusUserName ? "rgba(29,155,240)" : "rgba(0,0,0,.6)"
+                    }
+                    fontSize="12px"
+                >
+                    名前
+                </Text>
+                <Input
+                    border="none"
+                    value={userName}
+                    px={0}
+                    py={0}
+                    height="auto"
+                    onChange={(e) => onUpdateUserName(e.target.value)}
+                    _focus={{ border: "none", boxShadow: "none" }}
+                    onFocus={() => setFocusUserName(true)}
+                    onBlur={() => setFocusUserName(false)}
+                />
+            </VStack>
+            <RoundedButton onClick={onSave}>
+                <Text>保存</Text>
+            </RoundedButton>
+        </VStack>
+    );
+}

--- a/src/view/account/UserCard.tsx
+++ b/src/view/account/UserCard.tsx
@@ -1,48 +1,16 @@
-import {
-    Box,
-    Center,
-    HStack,
-    Icon,
-    Input,
-    Text,
-    VStack,
-} from "@chakra-ui/react";
-import {ReactNode, useState} from "react";
-import {MdClose, MdOutlineEdit, MdPhotoCamera} from "react-icons/md";
+import { Box, Center, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { MdOutlineEdit } from "react-icons/md";
 import { User } from "src/domain/models/User";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
-import { RoundedButton } from "src/view/common/RoundedButton";
 import { Padding } from "src/view/constants/padding";
 
 type Props = {
     user: User | null;
     isEditable?: boolean;
-    isEditing?: boolean;
     onEdit?: () => void;
-    onSaveProfile?: (props: {name?: string, profileImageUrl?: string}) => void;
-    onCloseEdit?: () => void;
 };
 
-export function UserCard({
-    user,
-    isEditable = false,
-    isEditing = false,
-    onEdit,
-}: Props) {
-    if (isEditing)
-        return (
-            <Container>
-                <Editing user={user} />
-            </Container>
-        );
-    return (
-        <Container>
-            <Preview user={user} isEditable={isEditable} onEdit={onEdit} />
-        </Container>
-    );
-}
-
-function Container({ children }: { children?: ReactNode }) {
+export function UserCard({ user, isEditable = false, onEdit }: Props) {
     return (
         <Center
             w="100%"
@@ -52,84 +20,28 @@ function Container({ children }: { children?: ReactNode }) {
             borderRadius="20px"
             boxShadow="0px 0px 20px #F0DFCA"
         >
-            {children}
-        </Center>
-    );
-}
-
-function Preview({ user, isEditable, onEdit }: Props) {
-    return (
-        <VStack spacing={Padding.p16} position="relative" w="100%">
-            {isEditable && (
-                <HStack
-                    as="button"
-                    px="8px"
-                    py="4px"
-                    border="1px solid rgba(0,0,0,.1)"
-                    borderRadius="20px"
-                    position="absolute"
-                    top="12px"
-                    right="12px"
-                    onClick={onEdit}
-                >
-                    <Icon
-                        w="24px"
-                        h="24px"
-                        color="rgba(0,0,0,.5)"
-                        as={MdOutlineEdit}
-                    />
-                    <Text>編集</Text>
-                </HStack>
-            )}
-            <Box
-                width="100px"
-                height="100px"
-                backgroundColor="gray.200"
-                borderRadius="100%"
-                overflow="hidden"
-            >
-                {user && <ImageWithSkeleton src={user.avatarImage} />}
-            </Box>
-            <Center maxW="100%" h="50px">
-                {user ? (
-                    <Text fontWeight="bold" fontSize="32px">
-                        {user.name}
-                    </Text>
-                ) : (
-                    <Box
-                        borderRadius="30px"
-                        w="300px"
-                        h="32px"
-                        backgroundColor="gray.200"
-                    />
+            <VStack spacing={Padding.p16} position="relative" w="100%">
+                {isEditable && (
+                    <HStack
+                        as="button"
+                        px="8px"
+                        py="4px"
+                        border="1px solid rgba(0,0,0,.1)"
+                        borderRadius="20px"
+                        position="absolute"
+                        top="12px"
+                        right="12px"
+                        onClick={onEdit}
+                    >
+                        <Icon
+                            w="24px"
+                            h="24px"
+                            color="rgba(0,0,0,.5)"
+                            as={MdOutlineEdit}
+                        />
+                        <Text>編集</Text>
+                    </HStack>
                 )}
-            </Center>
-        </VStack>
-    );
-}
-
-function Editing({ user, onSaveProfile, onCloseEdit }: Props) {
-    const [userName, setUserName] = useState(user.name);
-    const [focusUserName, setFocusUserName] = useState(false);
-
-    const handleOnSave = () => {
-        onSaveProfile?.({ name: userName });
-    }
-
-    return (
-        <VStack w="100%" spacing={Padding.p16} maxW="600px">
-            <HStack w="100%" pb={Padding.p16}>
-                <Text flex={1} fontWeight="semibold">プロフィールを編集</Text>
-                <Center as="button" onClick={onCloseEdit}>
-                    <Icon
-                        w="24px"
-                        h="24px"
-                        color="rgba(0,0,0,.5)"
-                        as={MdClose}
-                    />
-                </Center>
-            </HStack>
-            <Box position="relative" pb="16px">
                 <Box
                     width="100px"
                     height="100px"
@@ -139,60 +51,21 @@ function Editing({ user, onSaveProfile, onCloseEdit }: Props) {
                 >
                     {user && <ImageWithSkeleton src={user.avatarImage} />}
                 </Box>
-                <Center
-                    w="100%"
-                    position="absolute"
-                    right={0}
-                    bottom={0}
-                    left={0}
-                >
-                    <Center
-                        as="button"
-                        border="1px solid rgba(0,0,0,.1)"
-                        backgroundColor="white"
-                        borderRadius="100"
-                        px={Padding.p8}
-                        py={Padding.p4}
-                    >
-                        <Icon
-                            w="24px"
-                            h="24px"
-                            color="rgba(0,0,0,.7)"
-                            as={MdPhotoCamera}
+                <Center maxW="100%" h="50px">
+                    {user ? (
+                        <Text fontWeight="bold" fontSize="32px">
+                            {user.name}
+                        </Text>
+                    ) : (
+                        <Box
+                            borderRadius="30px"
+                            w="300px"
+                            h="32px"
+                            backgroundColor="gray.200"
                         />
-                    </Center>
+                    )}
                 </Center>
-            </Box>
-            <VStack
-                w="100%"
-                border={`1px solid ${focusUserName ? "rgba(29,155,240)" : "rgba(0,0,0,.1)"  }`}
-                alignItems="flex-start"
-                px={Padding.p8}
-                py={Padding.p4}
-                spacing={0}
-                borderRadius="8px"
-            >
-                <Text
-                    color={focusUserName ? "rgba(29,155,240)" : "rgba(0,0,0,.6)"}
-                    fontSize="12px"
-                >
-                    名前
-                </Text>
-                <Input
-                    border="none"
-                    value={userName}
-                    px={0}
-                    py={0}
-                    height="auto"
-                    onChange={(e) => setUserName(e.target.value)}
-                    _focus={{ border: "none", boxShadow: "none" }}
-                    onFocus={() => setFocusUserName(true)}
-                    onBlur={() => setFocusUserName(false)}
-                />
             </VStack>
-            <RoundedButton onClick={() => handleOnSave()}>
-                <Text>保存</Text>
-            </RoundedButton>
-        </VStack>
+        </Center>
     );
 }

--- a/src/view/account/UserCard.tsx
+++ b/src/view/account/UserCard.tsx
@@ -1,13 +1,16 @@
-import { Box, Center, Text, VStack } from "@chakra-ui/react";
+import { Box, Center, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { MdOutlineEdit } from "react-icons/md";
 import { User } from "src/domain/models/User";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
 import { Padding } from "src/view/constants/padding";
 
 type Props = {
     user: User | null;
+    isEditable?: boolean;
+    onEdit?: () => void;
 };
 
-export function UserCard({ user }: Props) {
+export function UserCard({ user, isEditable = false, onEdit }: Props) {
     return (
         <VStack
             w="100%"
@@ -17,7 +20,29 @@ export function UserCard({ user }: Props) {
             borderRadius="20px"
             boxShadow="0px 0px 20px #F0DFCA"
             spacing={Padding.p16}
+            position="relative"
         >
+            {isEditable && (
+                <HStack
+                    as="button"
+                    px="8px"
+                    py="4px"
+                    border="1px solid rgba(0,0,0,.1)"
+                    borderRadius="20px"
+                    position="absolute"
+                    top="12px"
+                    right="12px"
+                    onClick={onEdit}
+                >
+                    <Icon
+                        w="24px"
+                        h="24px"
+                        color="rgba(0,0,0,.5)"
+                        as={MdOutlineEdit}
+                    />
+                    <Text>編集</Text>
+                </HStack>
+            )}
             <Box
                 width="100px"
                 height="100px"

--- a/src/view/account/UserCard.tsx
+++ b/src/view/account/UserCard.tsx
@@ -1,27 +1,65 @@
-import { Box, Center, HStack, Icon, Text, VStack } from "@chakra-ui/react";
-import { MdOutlineEdit } from "react-icons/md";
+import {
+    Box,
+    Center,
+    HStack,
+    Icon,
+    Input,
+    Text,
+    VStack,
+} from "@chakra-ui/react";
+import {ReactNode, useState} from "react";
+import {MdClose, MdOutlineEdit, MdPhotoCamera} from "react-icons/md";
 import { User } from "src/domain/models/User";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
+import { RoundedButton } from "src/view/common/RoundedButton";
 import { Padding } from "src/view/constants/padding";
 
 type Props = {
     user: User | null;
     isEditable?: boolean;
+    isEditing?: boolean;
     onEdit?: () => void;
+    onSaveProfile?: (props: {name?: string, profileImageUrl?: string}) => void;
+    onCloseEdit?: () => void;
 };
 
-export function UserCard({ user, isEditable = false, onEdit }: Props) {
+export function UserCard({
+    user,
+    isEditable = false,
+    isEditing = false,
+    onEdit,
+}: Props) {
+    if (isEditing)
+        return (
+            <Container>
+                <Editing user={user} />
+            </Container>
+        );
     return (
-        <VStack
+        <Container>
+            <Preview user={user} isEditable={isEditable} onEdit={onEdit} />
+        </Container>
+    );
+}
+
+function Container({ children }: { children?: ReactNode }) {
+    return (
+        <Center
             w="100%"
             py={Padding.p16}
             px={Padding.p16}
             backgroundColor="white"
             borderRadius="20px"
             boxShadow="0px 0px 20px #F0DFCA"
-            spacing={Padding.p16}
-            position="relative"
         >
+            {children}
+        </Center>
+    );
+}
+
+function Preview({ user, isEditable, onEdit }: Props) {
+    return (
+        <VStack spacing={Padding.p16} position="relative" w="100%">
             {isEditable && (
                 <HStack
                     as="button"
@@ -66,6 +104,95 @@ export function UserCard({ user, isEditable = false, onEdit }: Props) {
                     />
                 )}
             </Center>
+        </VStack>
+    );
+}
+
+function Editing({ user, onSaveProfile, onCloseEdit }: Props) {
+    const [userName, setUserName] = useState(user.name);
+    const [focusUserName, setFocusUserName] = useState(false);
+
+    const handleOnSave = () => {
+        onSaveProfile?.({ name: userName });
+    }
+
+    return (
+        <VStack w="100%" spacing={Padding.p16} maxW="600px">
+            <HStack w="100%" pb={Padding.p16}>
+                <Text flex={1} fontWeight="semibold">プロフィールを編集</Text>
+                <Center as="button" onClick={onCloseEdit}>
+                    <Icon
+                        w="24px"
+                        h="24px"
+                        color="rgba(0,0,0,.5)"
+                        as={MdClose}
+                    />
+                </Center>
+            </HStack>
+            <Box position="relative" pb="16px">
+                <Box
+                    width="100px"
+                    height="100px"
+                    backgroundColor="gray.200"
+                    borderRadius="100%"
+                    overflow="hidden"
+                >
+                    {user && <ImageWithSkeleton src={user.avatarImage} />}
+                </Box>
+                <Center
+                    w="100%"
+                    position="absolute"
+                    right={0}
+                    bottom={0}
+                    left={0}
+                >
+                    <Center
+                        as="button"
+                        border="1px solid rgba(0,0,0,.1)"
+                        backgroundColor="white"
+                        borderRadius="100"
+                        px={Padding.p8}
+                        py={Padding.p4}
+                    >
+                        <Icon
+                            w="24px"
+                            h="24px"
+                            color="rgba(0,0,0,.7)"
+                            as={MdPhotoCamera}
+                        />
+                    </Center>
+                </Center>
+            </Box>
+            <VStack
+                w="100%"
+                border={`1px solid ${focusUserName ? "rgba(29,155,240)" : "rgba(0,0,0,.1)"  }`}
+                alignItems="flex-start"
+                px={Padding.p8}
+                py={Padding.p4}
+                spacing={0}
+                borderRadius="8px"
+            >
+                <Text
+                    color={focusUserName ? "rgba(29,155,240)" : "rgba(0,0,0,.6)"}
+                    fontSize="12px"
+                >
+                    名前
+                </Text>
+                <Input
+                    border="none"
+                    value={userName}
+                    px={0}
+                    py={0}
+                    height="auto"
+                    onChange={(e) => setUserName(e.target.value)}
+                    _focus={{ border: "none", boxShadow: "none" }}
+                    onFocus={() => setFocusUserName(true)}
+                    onBlur={() => setFocusUserName(false)}
+                />
+            </VStack>
+            <RoundedButton onClick={() => handleOnSave()}>
+                <Text>保存</Text>
+            </RoundedButton>
         </VStack>
     );
 }

--- a/src/view/account/UserCard.tsx
+++ b/src/view/account/UserCard.tsx
@@ -1,4 +1,12 @@
-import { Box, Center, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import {
+    Avatar,
+    Box,
+    Center,
+    HStack,
+    Icon,
+    Text,
+    VStack,
+} from "@chakra-ui/react";
 import { MdOutlineEdit } from "react-icons/md";
 import { User } from "src/domain/models/User";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
@@ -49,7 +57,11 @@ export function UserCard({ user, isEditable = false, onEdit }: Props) {
                     borderRadius="100%"
                     overflow="hidden"
                 >
-                    {user && <ImageWithSkeleton src={user.avatarImage} />}
+                    {user?.avatarImage ? (
+                        <ImageWithSkeleton src={user.avatarImage} />
+                    ) : (
+                        <Avatar size="full" />
+                    )}
                 </Box>
                 <Center maxW="100%" h="50px">
                     {user ? (

--- a/src/view/constants/padding.ts
+++ b/src/view/constants/padding.ts
@@ -1,5 +1,6 @@
 // TODO: この定数を用いて統一する
 export const Padding = {
+    p4: "4px",
     p8: "8px",
     p16: "16px",
     p24: "24px",

--- a/src/view/hooks/useCropImage.ts
+++ b/src/view/hooks/useCropImage.ts
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { Area } from "react-easy-crop";
+
+export const useCropImage = ({
+    originalImageSrc,
+}: {
+    originalImageSrc: string;
+}) => {
+    const [zoom, setZoom] = useState(1);
+    const [crop, setCrop] = useState({ x: 0, y: 0 });
+    const [croppedImage, setCroppedImage] = useState(null);
+    const [isCropInProgress, setIsCropInProgress] = useState(false);
+    const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(
+        null
+    );
+
+    const onCropComplete = (croppedArea: Area, croppedAreaPixels: Area) => {
+        setCroppedAreaPixels(croppedAreaPixels);
+    };
+
+    const cropImage = async () => {
+        if (isCropInProgress) {
+            return null;
+        }
+
+        if (!croppedAreaPixels) {
+            return null;
+        }
+
+        setIsCropInProgress(true);
+        let croppedImg: string | null = null;
+        try {
+            croppedImg = await createCroppedImage(
+                originalImageSrc,
+                croppedAreaPixels,
+                0,
+                { horizontal: false, vertical: false }
+            );
+            setCroppedImage(croppedImg);
+        } finally {
+            setIsCropInProgress(false);
+        }
+
+        return croppedImg;
+    };
+
+    return {
+        crop,
+        zoom,
+        croppedImage,
+        isCropInProgress,
+        setCrop,
+        setZoom,
+        cropImage,
+        onCropComplete,
+    };
+};
+
+function createImage(url: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+        const image = new Image();
+        image.addEventListener("load", () => resolve(image));
+        image.addEventListener("error", (error) => reject(error));
+        image.setAttribute("crossOrigin", "anonymous");
+        image.src = url;
+    });
+}
+
+function getRadianAngle(degreeValue: number) {
+    return (degreeValue * Math.PI) / 180;
+}
+
+function rotateSize(width: number, height: number, rotation: number) {
+    const rotRad = getRadianAngle(rotation);
+    return {
+        width:
+            Math.abs(Math.cos(rotRad) * width) +
+            Math.abs(Math.sin(rotRad) * height),
+        height:
+            Math.abs(Math.sin(rotRad) * width) +
+            Math.abs(Math.cos(rotRad) * height),
+    };
+}
+
+async function createCroppedImage(
+    imageSrc: string,
+    pixelCrop: Area,
+    rotation = 0,
+    flip = { horizontal: false, vertical: false }
+): Promise<string> {
+    const image = await createImage(imageSrc);
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+
+    if (!ctx) {
+        return null;
+    }
+
+    const rotRad = getRadianAngle(rotation);
+
+    // calculate bounding box of the rotated image
+    const { width: bBoxWidth, height: bBoxHeight } = rotateSize(
+        image.width,
+        image.height,
+        rotation
+    );
+
+    // set canvas size to match the bounding box
+    canvas.width = bBoxWidth;
+    canvas.height = bBoxHeight;
+
+    // translate canvas context to a central location to allow rotating and flipping around the center
+    ctx.translate(bBoxWidth / 2, bBoxHeight / 2);
+    ctx.rotate(rotRad);
+    ctx.scale(flip.horizontal ? -1 : 1, flip.vertical ? -1 : 1);
+    ctx.translate(-image.width / 2, -image.height / 2);
+
+    // draw rotated image
+    ctx.drawImage(image, 0, 0);
+
+    const croppedCanvas = document.createElement("canvas");
+    const croppedCtx = croppedCanvas.getContext("2d");
+
+    if (!croppedCtx) {
+        return null;
+    }
+
+    // Set the size of the cropped canvas
+    croppedCanvas.width = pixelCrop.width;
+    croppedCanvas.height = pixelCrop.height;
+
+    // Draw the cropped image onto the new canvas
+    croppedCtx.drawImage(
+        canvas,
+        pixelCrop.x,
+        pixelCrop.y,
+        pixelCrop.width,
+        pixelCrop.height,
+        0,
+        0,
+        pixelCrop.width,
+        pixelCrop.height
+    );
+
+    // As a blob
+    return new Promise((resolve, reject) => {
+        croppedCanvas.toBlob((file) => {
+            resolve(URL.createObjectURL(file));
+
+            canvas.remove();
+            croppedCanvas.remove();
+        }, "image/jpeg");
+    });
+}

--- a/src/view/user/UserAvatar.tsx
+++ b/src/view/user/UserAvatar.tsx
@@ -23,7 +23,7 @@ export function UserAvatar({ user, onClick }: Props) {
                 alignItems="center"
                 position="relative"
             >
-                {user ? (
+                {user?.avatarImage ? (
                     <>
                         <Skeleton
                             position="absolute"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13842,6 +13842,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+normalize-wheel@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-wheel/-/normalize-wheel-1.0.1.tgz#aec886affdb045070d856447df62ecf86146ec45"
+  integrity sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==
+
 npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
@@ -14877,6 +14882,14 @@ react-docgen@^7.0.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-easy-crop@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/react-easy-crop/-/react-easy-crop-5.0.7.tgz#b20cc2ea606a3731576101251a8190434cef1cf6"
+  integrity sha512-6d5IUt09M3HwdDGwrcjPVgfrOfYWAOku8sCTn/xU7b1vkEg+lExMLwW8UbR39L8ybQi0hJZTU57yprF9h5Q5Ig==
+  dependencies:
+    normalize-wheel "^1.0.1"
+    tslib "^2.0.1"
 
 react-element-to-jsx-string@^15.0.0:
   version "15.0.0"


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- アカウントページからユーザー名・アカウント画像を更新するためのUIを作成した。
- ユーザー導線上からは利用することはできない

|コンポーネント|before| after |
|---|---|-------|
|EditUserProfileDialog||<img width="380" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/40c3426e-2289-4b4c-a6a3-7c5dd0447053">|
|EditUserProfileDialog||<img width="384" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/0fb5e8a0-1643-4f58-8823-09d277948f97">|
|UserCard(isEditable=true)||<img width="387" alt="image" src="https://github.com/poroto-app/poroto/assets/55840281/d8b16eb7-67eb-4774-bf6c-9a7818ce9db2">|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #721 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] EditUserProfileDialogコンポーネントで写真を選択後、画像の切り抜きを行い、保存ボタンを押すと画像が更新されることを確認（Storybook）
- [x] EditUserProfileDialogコンポーネントで写真を更新後、同じ画像ファイルを指定しても切り抜き画面が表示されることを確認
- [x] EditUserProfileDialogコンポーネントで写真を選択後、切り抜き画面で戻るボタンを押すともとの画像が残っていることを確認 
- [x] EditUserProfileDialogコンポーネントで写真の選択をキャンセルできることを確認

```shell
# poroto
export BRANCH_POROTO=feature/update_user_profile
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````