### PR TITLE
文字リソースをi18n用のライブラリで管理

### DIFF
--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -4,6 +4,7 @@ import { AccountTranslationJa } from "src/locales/ja/account";
 import { CommonTranslationJa } from "src/locales/ja/common";
 import { HomeTranslationJa } from "src/locales/ja/home";
 import { NavigationTranslationJa } from "src/locales/ja/navigation";
+import { OgpTranslationJa } from "src/locales/ja/ogp";
 import { PlaceTranslationJa } from "src/locales/ja/place";
 import { PlanTranslationJa } from "src/locales/ja/plan";
 import { PwaTranslationJa } from "src/locales/ja/pwa";
@@ -12,6 +13,7 @@ import {
     CommonTranslationKeys,
     HomeTranslationKeys,
     NavigationTranslationKeys,
+    OgpTranslationKeys,
     PlaceTranslationKeys,
     PlanTranslationKeys,
     PwaTranslationKeys,
@@ -21,6 +23,7 @@ export type TranslationResourceType = {
     common: CommonTranslationKeys;
     account: AccountTranslationKeys;
     navigation: NavigationTranslationKeys;
+    ogp: OgpTranslationKeys;
     home: HomeTranslationKeys;
     place: PlaceTranslationKeys;
     plan: PlanTranslationKeys;
@@ -35,6 +38,7 @@ export const resources: {
         account: AccountTranslationJa,
         home: HomeTranslationJa,
         navigation: NavigationTranslationJa,
+        ogp: OgpTranslationJa,
         plan: PlanTranslationJa,
         place: PlaceTranslationJa,
         pwa: PwaTranslationJa,

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -53,8 +53,6 @@ i18n.use(initReactI18next).init({
     resources,
     lng: "ja",
     fallbackLng: "ja",
-    // lng: "",
-    // fallbackLng: "",
     interpolation: {
         escapeValue: false,
     },

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -1,10 +1,12 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
+import { AccountTranslationJa } from "src/locales/ja/account";
 import { CommonTranslationJa } from "src/locales/ja/common";
 import { HomeTranslationJa } from "src/locales/ja/home";
 import { PlaceTranslationJa } from "src/locales/ja/place";
 import { PlanTranslationJa } from "src/locales/ja/plan";
 import {
+    AccountTranslationKeys,
     CommonTranslationKeys,
     HomeTranslationKeys,
     PlaceTranslationKeys,
@@ -13,9 +15,10 @@ import {
 
 export type TranslationResourceType = {
     common: CommonTranslationKeys;
+    account: AccountTranslationKeys;
     home: HomeTranslationKeys;
-    plan: PlanTranslationKeys;
     place: PlaceTranslationKeys;
+    plan: PlanTranslationKeys;
 };
 
 export const resources: {
@@ -23,16 +26,23 @@ export const resources: {
 } = {
     ja: {
         common: CommonTranslationJa,
+        account: AccountTranslationJa,
         home: HomeTranslationJa,
         plan: PlanTranslationJa,
         place: PlaceTranslationJa,
     },
 } as const;
 
+export const TranslationNameSpaces = Object.keys(
+    resources
+) as (keyof TranslationResourceType)[];
+
 i18n.use(initReactI18next).init({
     resources,
     lng: "ja",
     fallbackLng: "ja",
+    // lng: "",
+    // fallbackLng: "",
     interpolation: {
         escapeValue: false,
     },

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -8,14 +8,16 @@ import { PlanTranslationJa } from "src/locales/ja/plan";
 import {
     AccountTranslationKeys,
     CommonTranslationKeys,
-    HomeTranslationKeys,
+    HomeTranslationKeys, NavigationTranslationKeys,
     PlaceTranslationKeys,
     PlanTranslationKeys,
 } from "src/locales/type";
+import {NavigationTranslationJa} from "src/locales/ja/navigation";
 
 export type TranslationResourceType = {
     common: CommonTranslationKeys;
     account: AccountTranslationKeys;
+    navigation: NavigationTranslationKeys;
     home: HomeTranslationKeys;
     place: PlaceTranslationKeys;
     plan: PlanTranslationKeys;
@@ -28,6 +30,7 @@ export const resources: {
         common: CommonTranslationJa,
         account: AccountTranslationJa,
         home: HomeTranslationJa,
+        navigation: NavigationTranslationJa,
         plan: PlanTranslationJa,
         place: PlaceTranslationJa,
     },

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -2,10 +2,20 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import { CommonTranslationJa } from "src/locales/ja/common";
 import { HomeTranslationJa } from "src/locales/ja/home";
+import { PlaceTranslationJa } from "src/locales/ja/place";
+import { PlanTranslationJa } from "src/locales/ja/plan";
+import {
+    CommonTranslationKeys,
+    HomeTranslationKeys,
+    PlaceTranslationKeys,
+    PlanTranslationKeys,
+} from "src/locales/type";
 
 export type TranslationResourceType = {
-    common: typeof CommonTranslationJa;
-    home: typeof HomeTranslationJa;
+    common: CommonTranslationKeys;
+    home: HomeTranslationKeys;
+    plan: PlanTranslationKeys;
+    place: PlaceTranslationKeys;
 };
 
 export const resources: {
@@ -14,6 +24,8 @@ export const resources: {
     ja: {
         common: CommonTranslationJa,
         home: HomeTranslationJa,
+        plan: PlanTranslationJa,
+        place: PlaceTranslationJa,
     },
 } as const;
 

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -3,16 +3,17 @@ import { initReactI18next } from "react-i18next";
 import { AccountTranslationJa } from "src/locales/ja/account";
 import { CommonTranslationJa } from "src/locales/ja/common";
 import { HomeTranslationJa } from "src/locales/ja/home";
+import { NavigationTranslationJa } from "src/locales/ja/navigation";
 import { PlaceTranslationJa } from "src/locales/ja/place";
 import { PlanTranslationJa } from "src/locales/ja/plan";
 import {
     AccountTranslationKeys,
     CommonTranslationKeys,
-    HomeTranslationKeys, NavigationTranslationKeys,
+    HomeTranslationKeys,
+    NavigationTranslationKeys,
     PlaceTranslationKeys,
     PlanTranslationKeys,
 } from "src/locales/type";
-import {NavigationTranslationJa} from "src/locales/ja/navigation";
 
 export type TranslationResourceType = {
     common: CommonTranslationKeys;

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -6,6 +6,7 @@ import { HomeTranslationJa } from "src/locales/ja/home";
 import { NavigationTranslationJa } from "src/locales/ja/navigation";
 import { PlaceTranslationJa } from "src/locales/ja/place";
 import { PlanTranslationJa } from "src/locales/ja/plan";
+import { PwaTranslationJa } from "src/locales/ja/pwa";
 import {
     AccountTranslationKeys,
     CommonTranslationKeys,
@@ -13,6 +14,7 @@ import {
     NavigationTranslationKeys,
     PlaceTranslationKeys,
     PlanTranslationKeys,
+    PwaTranslationKeys,
 } from "src/locales/type";
 
 export type TranslationResourceType = {
@@ -22,6 +24,7 @@ export type TranslationResourceType = {
     home: HomeTranslationKeys;
     place: PlaceTranslationKeys;
     plan: PlanTranslationKeys;
+    pwa: PwaTranslationKeys;
 };
 
 export const resources: {
@@ -34,6 +37,7 @@ export const resources: {
         navigation: NavigationTranslationJa,
         plan: PlanTranslationJa,
         place: PlaceTranslationJa,
+        pwa: PwaTranslationJa,
     },
 } as const;
 

--- a/src/locales/ja/account.ts
+++ b/src/locales/ja/account.ts
@@ -20,12 +20,12 @@ export const AccountTranslationJa: AccountTranslationKeys = {
     retainDataRetryLaterMessage:
         "しばらく時間をおいて再度お試しください。<br/> 引き継ぎはログインメニューからいつでもできます！",
 
-    promptLoginTitle: "新しい景色に、{{br}}会いに行こう。",
-    promptLoginDescription:
+    loginTitle: "新しい景色に、{{br}}会いに行こう。",
+    loginDescription:
         "作成したプランやお気に入りの場所をいつでも見られるようになります。",
 
-    promptRetainDataBeforeLoginTitle:
+    retainDataBeforeLoginTitle:
         "ログイン前の状態を<br />引き継ぎますか？",
-    promptRetainDataBeforeLoginDescription:
+    retainDataBeforeLoginDescription:
         "「保存したプラン」や「いいね」した記録を引き継ぐことができます。",
 };

--- a/src/locales/ja/account.ts
+++ b/src/locales/ja/account.ts
@@ -3,10 +3,24 @@ import { AccountTranslationKeys } from "src/locales/type";
 export const AccountTranslationJa: AccountTranslationKeys = {
     login: "ログイン",
     logout: "ログアウト",
-    retainDataBeforeLogin: "ログイン前のデータを引き継ぐ",
     loginByGoogle: "Googleでログイン",
+
+    retainDataBeforeLogin: "ログイン前のデータを引き継ぐ",
+    retainData: "引き継ぐ",
+    retainingData: "データを<br />引き継いでいます...",
+    retainingDataWaitMessage: "しばらくお待ちください！",
+    retainDataSuccess: "引き継ぎが成功しました！",
+    retainDataFailed: "引き継ぎに失敗しました。",
+    retainDataCanceledMessage: "引き継ぎは<br/>ログインメニューから<br/>いつでもできます！",
+    retainDataRetryLaterMessage:
+        " しばらく時間をおいて再度お試しください。<br/> 引き継ぎはログインメニューからいつでもできます！",
 
     promptLoginTitle: "新しい景色に、{{br}}会いに行こう。",
     promptLoginDescription:
         "作成したプランやお気に入りの場所をいつでも見られるようになります。",
+
+    promptRetainDataBeforeLoginTitle:
+        "ログイン前の状態を<br />引き継ぎますか？",
+    promptRetainDataBeforeLoginDescription:
+        "「保存したプラン」や「いいね」した記録を引き継ぐことができます。",
 };

--- a/src/locales/ja/account.ts
+++ b/src/locales/ja/account.ts
@@ -1,0 +1,12 @@
+import { AccountTranslationKeys } from "src/locales/type";
+
+export const AccountTranslationJa: AccountTranslationKeys = {
+    login: "ログイン",
+    logout: "ログアウト",
+    retainDataBeforeLogin: "ログイン前のデータを引き継ぐ",
+    loginByGoogle: "Googleでログイン",
+
+    promptLoginTitle: "新しい景色に、{{br}}会いに行こう。",
+    promptLoginDescription:
+        "作成したプランやお気に入りの場所をいつでも見られるようになります。",
+};

--- a/src/locales/ja/account.ts
+++ b/src/locales/ja/account.ts
@@ -1,10 +1,6 @@
 import { AccountTranslationKeys } from "src/locales/type";
 
 export const AccountTranslationJa: AccountTranslationKeys = {
-    login: "ログイン",
-    logout: "ログアウト",
-    loginByGoogle: "Googleでログイン",
-
     name: "名前",
     editProfile: "プロフィールを編集",
     editProfileImage: "写真を編集",
@@ -19,13 +15,14 @@ export const AccountTranslationJa: AccountTranslationKeys = {
         "引き継ぎは<br/>ログインメニューから<br/>いつでもできます！",
     retainDataRetryLaterMessage:
         "しばらく時間をおいて再度お試しください。<br/> 引き継ぎはログインメニューからいつでもできます！",
+    retainDataBeforeLoginTitle: "ログイン前の状態を<br />引き継ぎますか？",
+    retainDataBeforeLoginDescription:
+        "「保存したプラン」や「いいね」した記録を引き継ぐことができます。",
 
+    login: "ログイン",
+    loginByGoogle: "Googleでログイン",
     loginTitle: "新しい景色に、{{br}}会いに行こう。",
     loginDescription:
         "作成したプランやお気に入りの場所をいつでも見られるようになります。",
-
-    retainDataBeforeLoginTitle:
-        "ログイン前の状態を<br />引き継ぎますか？",
-    retainDataBeforeLoginDescription:
-        "「保存したプラン」や「いいね」した記録を引き継ぐことができます。",
+    logout: "ログアウト",
 };

--- a/src/locales/ja/account.ts
+++ b/src/locales/ja/account.ts
@@ -5,6 +5,10 @@ export const AccountTranslationJa: AccountTranslationKeys = {
     logout: "ログアウト",
     loginByGoogle: "Googleでログイン",
 
+    name: "名前",
+    editProfile: "プロフィールを編集",
+    editProfileImage: "写真を編集",
+
     retainDataBeforeLogin: "ログイン前のデータを引き継ぐ",
     retainData: "引き継ぐ",
     retainingData: "データを<br />引き継いでいます...",

--- a/src/locales/ja/account.ts
+++ b/src/locales/ja/account.ts
@@ -11,7 +11,8 @@ export const AccountTranslationJa: AccountTranslationKeys = {
     retainingDataWaitMessage: "しばらくお待ちください！",
     retainDataSuccess: "引き継ぎが成功しました！",
     retainDataFailed: "引き継ぎに失敗しました。",
-    retainDataCanceledMessage: "引き継ぎは<br/>ログインメニューから<br/>いつでもできます！",
+    retainDataCanceledMessage:
+        "引き継ぎは<br/>ログインメニューから<br/>いつでもできます！",
     retainDataRetryLaterMessage:
         " しばらく時間をおいて再度お試しください。<br/> 引き継ぎはログインメニューからいつでもできます！",
 

--- a/src/locales/ja/account.ts
+++ b/src/locales/ja/account.ts
@@ -14,7 +14,7 @@ export const AccountTranslationJa: AccountTranslationKeys = {
     retainDataCanceledMessage:
         "引き継ぎは<br/>ログインメニューから<br/>いつでもできます！",
     retainDataRetryLaterMessage:
-        " しばらく時間をおいて再度お試しください。<br/> 引き継ぎはログインメニューからいつでもできます！",
+        "しばらく時間をおいて再度お試しください。<br/> 引き継ぎはログインメニューからいつでもできます！",
 
     promptLoginTitle: "新しい景色に、{{br}}会いに行こう。",
     promptLoginDescription:

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -4,6 +4,7 @@ export const CommonTranslationJa: CommonTranslationKeys = {
     save: "保存",
     cancel: "キャンセル",
     close: "とじる",
+    edit: "編集",
     backToHome: "ホームに戻る",
     info: "情報",
     time: "時間",

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -2,7 +2,8 @@ import { CommonTranslationKeys } from "src/locales/type";
 
 export const CommonTranslationJa: CommonTranslationKeys = {
     save: "保存",
-    close: "閉じる",
+    cancel: "キャンセル",
+    close: "とじる",
     backToHome: "ホームに戻る",
     info: "情報",
     time: "時間",

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -15,6 +15,7 @@ export const CommonTranslationJa: CommonTranslationKeys = {
 
     minutesLabel: "{{minutes}}分",
     priceLabel: "{{price}}円",
+    YYYYMMDDHHMM: "{{year}}年{{month}}月{{day}}日 {{hour}}:{{minute}}",
 
     serverError: "サーバーでエラーが発生しました。",
     notFound: "お探しのページが見つかりませんでした。",

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -6,6 +6,8 @@ export const CommonTranslationJa: CommonTranslationKeys = {
     close: "とじる",
     edit: "編集",
     backToHome: "ホームに戻る",
+    reload: "再読み込み",
+
     info: "情報",
     time: "時間",
     budget: "予算",

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -3,6 +3,7 @@ import { CommonTranslationKeys } from "src/locales/type";
 export const CommonTranslationJa: CommonTranslationKeys = {
     add: "追加",
     backToHome: "ホームに戻る",
+    budget: "予算",
     cancel: "キャンセル",
     close: "とじる",
     delete: "削除",
@@ -12,13 +13,13 @@ export const CommonTranslationJa: CommonTranslationKeys = {
     save: "保存",
 
     info: "情報",
-    time: "時間",
-    budget: "予算",
 
     minutesLabel: "{{minutes}}分",
     priceLabel: "{{price}}円",
-    YYYYMMDDHHMM: "{{year}}年{{month}}月{{day}}日 {{hour}}:{{minute}}",
+    notFound: "お探しのページが見つかりませんでした。",
 
     serverError: "サーバーでエラーが発生しました。",
-    notFound: "お探しのページが見つかりませんでした。",
+
+    time: "時間",
+    YYYYMMDDHHMM: "{{year}}年{{month}}月{{day}}日 {{hour}}:{{minute}}",
 };

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -2,13 +2,14 @@ import { CommonTranslationKeys } from "src/locales/type";
 
 export const CommonTranslationJa: CommonTranslationKeys = {
     add: "追加",
-    save: "保存",
+    backToHome: "ホームに戻る",
     cancel: "キャンセル",
     close: "とじる",
+    delete: "削除",
     edit: "編集",
-    backToHome: "ホームに戻る",
     reload: "再読み込み",
     retry: "再試行",
+    save: "保存",
 
     info: "情報",
     time: "時間",

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -11,6 +11,7 @@ export const CommonTranslationJa: CommonTranslationKeys = {
     reload: "再読み込み",
     retry: "再試行",
     save: "保存",
+    upload: "アップロード",
 
     info: "情報",
 

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -7,6 +7,7 @@ export const CommonTranslationJa: CommonTranslationKeys = {
     edit: "編集",
     backToHome: "ホームに戻る",
     reload: "再読み込み",
+    retry: "再試行",
 
     info: "情報",
     time: "時間",

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -14,6 +14,7 @@ export const CommonTranslationJa: CommonTranslationKeys = {
     budget: "予算",
 
     minutesLabel: "{{minutes}}分",
+    priceLabel: "{{price}}円",
 
     serverError: "サーバーでエラーが発生しました。",
     notFound: "お探しのページが見つかりませんでした。",

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -2,4 +2,8 @@ import { CommonTranslationKeys } from "src/locales/type";
 
 export const CommonTranslationJa: CommonTranslationKeys = {
     save: "保存",
+    close: "閉じる",
+    backToHome: "ホームに戻る",
+    time: "時間",
+    budget: "予算",
 };

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -12,6 +12,8 @@ export const CommonTranslationJa: CommonTranslationKeys = {
     time: "時間",
     budget: "予算",
 
+    minutesLabel: "{{minutes}}分",
+
     serverError: "サーバーでエラーが発生しました。",
     notFound: "お探しのページが見つかりませんでした。",
 };

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -1,6 +1,7 @@
 import { CommonTranslationKeys } from "src/locales/type";
 
 export const CommonTranslationJa: CommonTranslationKeys = {
+    add: "追加",
     save: "保存",
     cancel: "キャンセル",
     close: "とじる",

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -8,4 +8,7 @@ export const CommonTranslationJa: CommonTranslationKeys = {
     info: "情報",
     time: "時間",
     budget: "予算",
+
+    serverError: "サーバーでエラーが発生しました。",
+    notFound: "お探しのページが見つかりませんでした。",
 };

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -4,6 +4,7 @@ export const CommonTranslationJa: CommonTranslationKeys = {
     save: "保存",
     close: "閉じる",
     backToHome: "ホームに戻る",
+    info: "情報",
     time: "時間",
     budget: "予算",
 };

--- a/src/locales/ja/home.ts
+++ b/src/locales/ja/home.ts
@@ -1,9 +1,9 @@
 import { HomeTranslationKeys } from "src/locales/type";
 
 export const HomeTranslationJa: HomeTranslationKeys = {
-    promptCreatePlan: "暇つぶしプランを作ろう",
-    fromFavoritePlace: "好きな場所から",
-    fromCurrentLocation: "現在地から",
+    createPlanTitle: "暇つぶしプランを作ろう",
+    createPlanFromFavoritePlace: "好きな場所から",
+    createPlanFromCurrentLocation: "現在地から",
 
     recentlyCreatedPlans: "最近作成されたプラン",
 };

--- a/src/locales/ja/home.ts
+++ b/src/locales/ja/home.ts
@@ -1,5 +1,9 @@
 import { HomeTranslationKeys } from "src/locales/type";
 
 export const HomeTranslationJa: HomeTranslationKeys = {
+    promptCreatePlan: "暇つぶしプランを作ろう",
+    fromFavoritePlace: "好きな場所から",
+    fromCurrentLocation: "現在地から",
+
     recentlyCreatedPlans: "最近作成されたプラン",
 };

--- a/src/locales/ja/navigation.ts
+++ b/src/locales/ja/navigation.ts
@@ -1,7 +1,7 @@
-import {NavigationTranslationKeys} from "src/locales/type";
+import { NavigationTranslationKeys } from "src/locales/type";
 
 export const NavigationTranslationJa: NavigationTranslationKeys = {
     home: "ホーム",
     search: "探す",
     myPage: "マイページ",
-}
+};

--- a/src/locales/ja/navigation.ts
+++ b/src/locales/ja/navigation.ts
@@ -1,0 +1,7 @@
+import {NavigationTranslationKeys} from "src/locales/type";
+
+export const NavigationTranslationJa: NavigationTranslationKeys = {
+    home: "ホーム",
+    search: "探す",
+    myPage: "マイページ",
+}

--- a/src/locales/ja/ogp.ts
+++ b/src/locales/ja/ogp.ts
@@ -1,0 +1,16 @@
+import { OgpTranslationKeys } from "src/locales/type";
+
+export const OgpTranslationJa: OgpTranslationKeys = {
+    topPageTitle: "komichi",
+    topPageDescription: "暇つぶしプランを komichi があなたに代わって作ります！",
+
+    placeSearchPageTitle: "好きな場所からプランを作る | komichi",
+    placeSearchPageDescription:
+        "お気に入りの場所や観光名所から、思い出に残るプランを作ります",
+
+    planInterestPageFromCurrentLocationTitle: "近場でプランを作る | komichi",
+    planInterestPageFromSelectedPlaceTitle:
+        "好きな場所からプランを作る | komichi",
+    planInterestPageDescription:
+        "今の気分にあわせて近場で楽しめるプランを作ります",
+};

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -8,4 +8,9 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
     category: "カテゴリ",
     priceRange: "価格帯",
     estimatedStayDuration: "滞在時間",
+
+    favoritePlaces: "お気に入りの場所",
+    favoritePlacesEmptyTitle: "まだ、旅は始まったばかり。",
+    favoritePlacesEmptyDescription:
+        "気になった場所に「いいね」すると、そこからプランを作ることができます。",
 };

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -1,0 +1,11 @@
+import { PlaceTranslationKeys } from "src/locales/type";
+
+export const PlaceTranslationJa: PlaceTranslationKeys = {
+    searchByInstagram: "Instagramで検索",
+    searchByGoogleMaps: "Googleマップで検索",
+    uploadPhoto: "写真をアップロード",
+
+    category: "カテゴリ",
+    priceRange: "価格帯",
+    estimatedStayDuration: "滞在時間",
+};

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -8,6 +8,7 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
     category: "カテゴリ",
     priceRange: "価格帯",
     estimatedStayDuration: "滞在時間",
+    noInformation: "情報がありません",
 
     favoritePlaces: "お気に入りの場所",
     favoritePlacesEmptyTitle: "まだ、旅は始まったばかり。",

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -4,7 +4,6 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
     searchPlace: "場所を検索",
     skipCurrentLocationRetrieval: "現在地取得をスキップする",
     tapToSelectPlace: "場所を選択",
-    createPlanFromSelectedPlace: "選択した場所からプランを作成",
 
     searchByInstagram: "Instagramで検索",
     searchByGoogleMaps: "Googleマップで検索",
@@ -28,11 +27,11 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
     favoritePlacesEmptyDescription:
         "気になった場所に「いいね」すると、そこからプランを作ることができます。",
 
-    showRecommendedTouristSpots: "おすすめの観光スポットを表示",
+    recommendedTouristSpotsShow: "おすすめの観光スポットを表示",
     recommendedTouristSpotsTitle: "おすすめの観光スポット",
-    promptRecommendedTouristSpotsSearching:
+    recommendedTouristSpotsSearching:
         "おすすめの観光スポットを探しています...",
-    recommendedTouristSearchFailed:
+    recommendedTouristSpotsSearchFailed:
         "おすすめの観光地を取得中にエラーが発生しました。",
 
     loginToSaveFavoritePlace:

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -9,6 +9,9 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
     searchByInstagram: "Instagramで検索",
     searchByGoogleMaps: "Googleマップで検索",
 
+    nearbyPlacesSearching: "近くに何があるかを探しています...",
+    selectPlaceCategoryMessage: "どんな場所に行きたいですか？",
+
     uploadPlacePhoto: "写真をアップロード",
     uploadPlacePhotoSuccess: "写真のアップロードが完了しました",
     uploadPlacePhotoFailed: "写真のアップロードに失敗しました",

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -1,6 +1,11 @@
 import { PlaceTranslationKeys } from "src/locales/type";
 
 export const PlaceTranslationJa: PlaceTranslationKeys = {
+    searchPlace: "場所を検索",
+    skipCurrentLocationRetrieval: "現在地取得をスキップする",
+    tapToSelectPlace: "場所を選択",
+    createPlanFromSelectedPlace: "選択した場所からプランを作成",
+
     searchByInstagram: "Instagramで検索",
     searchByGoogleMaps: "Googleマップで検索",
     uploadPhoto: "写真をアップロード",
@@ -14,4 +19,11 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
     favoritePlacesEmptyTitle: "まだ、旅は始まったばかり。",
     favoritePlacesEmptyDescription:
         "気になった場所に「いいね」すると、そこからプランを作ることができます。",
+
+    showRecommendedTouristSpots: "おすすめの観光スポットを表示",
+    recommendedTouristSpotsTitle: "おすすめの観光スポット",
+    promptRecommendedTouristSpotsSearching:
+        "おすすめの観光スポットを探しています...",
+    recommendedTouristSearchFailed:
+        "おすすめの観光地を取得中にエラーが発生しました。",
 };

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -27,4 +27,7 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
         "おすすめの観光スポットを探しています...",
     recommendedTouristSearchFailed:
         "おすすめの観光地を取得中にエラーが発生しました。",
+
+    loginToSaveFavoritePlace:
+        "ログインすると気に入った場所を保存することができます。",
 };

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -10,6 +10,7 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
     searchByGoogleMaps: "Googleマップで検索",
     uploadPhoto: "写真をアップロード",
 
+    address: "住所",
     category: "カテゴリ",
     priceRange: "価格帯",
     estimatedStayDuration: "滞在時間",

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -37,4 +37,11 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
 
     loginToSaveFavoritePlace:
         "ログインすると気に入った場所を保存することができます。",
+
+    relatedPlacesShow: "関連する場所を表示",
+    relatedPlacesTitle: "「{{placeName}}」に関連する場所",
+    relatedPlacesDescription: "気になった場所をタップ",
+
+    replacePlace: "入れ替える",
+    replacePlaceConfirmTitle: "この場所と入れ替えますか？",
 };

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -8,7 +8,11 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
 
     searchByInstagram: "Instagramで検索",
     searchByGoogleMaps: "Googleマップで検索",
-    uploadPhoto: "写真をアップロード",
+
+    uploadPlacePhoto: "写真をアップロード",
+    uploadPlacePhotoSuccess: "写真のアップロードが完了しました",
+    uploadPlacePhotoFailed: "写真のアップロードに失敗しました",
+    uploadPlacePhotoFailedDescription: "もう一度試してみてください。",
 
     address: "住所",
     category: "カテゴリ",

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -1,46 +1,43 @@
 import { PlaceTranslationKeys } from "src/locales/type";
 
 export const PlaceTranslationJa: PlaceTranslationKeys = {
-    searchPlace: "場所を検索",
-    skipCurrentLocationRetrieval: "現在地取得をスキップする",
-    tapToSelectPlace: "場所を選択",
-
-    searchByInstagram: "Instagramで検索",
-    searchByGoogleMaps: "Googleマップで検索",
-
-    nearbyPlacesSearching: "近くに何があるかを探しています...",
-    selectPlaceCategoryMessage: "どんな場所に行きたいですか？",
-
-    uploadPlacePhoto: "写真をアップロード",
-    uploadPlacePhotoSuccess: "写真のアップロードが完了しました",
-    uploadPlacePhotoFailed: "写真のアップロードに失敗しました",
-    uploadPlacePhotoFailedDescription: "もう一度試してみてください。",
-
     address: "住所",
     category: "カテゴリ",
-    priceRange: "価格帯",
     estimatedStayDuration: "滞在時間",
+    nearbyPlacesSearching: "近くに何があるかを探しています...",
     noInformation: "情報がありません",
+    priceRange: "価格帯",
 
     favoritePlaces: "お気に入りの場所",
-    favoritePlacesEmptyTitle: "まだ、旅は始まったばかり。",
     favoritePlacesEmptyDescription:
         "気になった場所に「いいね」すると、そこからプランを作ることができます。",
-
-    recommendedTouristSpotsShow: "おすすめの観光スポットを表示",
-    recommendedTouristSpotsTitle: "おすすめの観光スポット",
-    recommendedTouristSpotsSearching:
-        "おすすめの観光スポットを探しています...",
-    recommendedTouristSpotsSearchFailed:
-        "おすすめの観光地を取得中にエラーが発生しました。",
+    favoritePlacesEmptyTitle: "まだ、旅は始まったばかり。",
 
     loginToSaveFavoritePlace:
         "ログインすると気に入った場所を保存することができます。",
 
+    recommendedTouristSpotsSearchFailed:
+        "おすすめの観光地を取得中にエラーが発生しました。",
+    recommendedTouristSpotsSearching: "おすすめの観光スポットを探しています...",
+    recommendedTouristSpotsShow: "おすすめの観光スポットを表示",
+    recommendedTouristSpotsTitle: "おすすめの観光スポット",
+
+    relatedPlacesDescription: "気になった場所をタップ",
     relatedPlacesShow: "関連する場所を表示",
     relatedPlacesTitle: "「{{placeName}}」に関連する場所",
-    relatedPlacesDescription: "気になった場所をタップ",
-
     replacePlace: "入れ替える",
     replacePlaceConfirmTitle: "この場所と入れ替えますか？",
+
+    searchByGoogleMaps: "Googleマップで検索",
+    searchByInstagram: "Instagramで検索",
+    searchPlace: "場所を検索",
+    selectPlaceCategoryMessage: "どんな場所に行きたいですか？",
+    skipCurrentLocationRetrieval: "現在地取得をスキップする",
+
+    tapToSelectPlace: "場所を選択",
+
+    uploadPlacePhoto: "写真をアップロード",
+    uploadPlacePhotoFailed: "写真のアップロードに失敗しました",
+    uploadPlacePhotoFailedDescription: "もう一度試してみてください。",
+    uploadPlacePhotoSuccess: "写真のアップロードが完了しました",
 };

--- a/src/locales/ja/place.ts
+++ b/src/locales/ja/place.ts
@@ -37,6 +37,7 @@ export const PlaceTranslationJa: PlaceTranslationKeys = {
     tapToSelectPlace: "場所を選択",
 
     uploadPlacePhoto: "写真をアップロード",
+    uploadPlacePhotoConfirmTitle: "この写真をアップロードしますか？",
     uploadPlacePhotoFailed: "写真のアップロードに失敗しました",
     uploadPlacePhotoFailedDescription: "もう一度試してみてください。",
     uploadPlacePhotoSuccess: "写真のアップロードが完了しました",

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -45,12 +45,19 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     savedPlansEmptyDescription:
         "保存したプランはいつでも見返すことができます。",
 
+    showPlan: "プランをみてみる",
+
+    createPlanInProgressTitle: "プランを作成しています",
+    createPlanFailedTitle: "プランを作成できませんでした",
+    createPlanFailedDescription: "他の場所からプランを作成してみませんか？",
+
     createPlanFromThisPlace: "この場所からプランを作る",
 
     planCreatingTitle: "プランを作成しています",
     planCreateFailedTitle: "プランの作成に失敗しました",
     planCreatedSuccessfullyTitle: "プランが完成しました!",
 
+    reorderPlaces: "場所を並び替え",
     reorderPlacesSuccess: "並び替えが成功しました",
     reorderPlacesFailed: "並び替えに失敗しました",
 };

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -38,6 +38,9 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     loadingMap: "地図を読み込んでいます",
     loadingPlan: "プランを読み込んでいます",
 
+    loginRecommendationTitle: "あなただけのプランを、いつもそばに",
+    loginRecommendationDescription: "ログインすると、作成したプランをいつでも見返すことができます。",
+
     nearbyPlans: "近くのプラン",
     nearbyPlansEmptyDescription: "最初のプランを作ってみませんか？",
     nearbyPlansEmptyTitle: "近くで作成されたプランはありませんでした",

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -13,6 +13,10 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     promptCreateNewPlan: "新しいプランを作ってみませんか？",
     promptPreparingCustomPlan:
         "カスタマイズ用のプランを準備しています。もう少しお待ちください",
+    promptSearchingNearbyPlans: "近くのプランを検索しています...",
+    promptTurnOnLocationServiceToSearchNearbyPlans:
+        "位置情報を許可すると、近くのプランを探すことができます。",
+    promptLocationServiceUnavailable: "位置情報をオンにしてプランを取得",
 
     placesInPlan: "プラン内の場所",
     clickMarkerToShowPlaceDetail:

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -60,4 +60,7 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     reorderPlaces: "場所を並び替え",
     reorderPlacesSuccess: "並び替えが成功しました",
     reorderPlacesFailed: "並び替えに失敗しました",
+    reorderPlacesMinuteFromStartLocation: "出発地点から{{minute}}分",
+    reorderPlacesMinuteFromPreviousPlace: "前の場所から{{minute}}分",
+    reorderPlacesMinimizeWalkingDistance: "歩く距離を最短にする",
 };

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -6,6 +6,7 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     loadingPlan: "プランを読み込んでいます",
     planInfo: "プランの情報",
     saveThisPlan: "このプランを保存",
+    copyPlanUrl: "プランのURLをコピー",
     copiedPlanUrl: "プランのURLをコピーしました",
     createPlan: "プランを作成",
 
@@ -42,4 +43,6 @@ export const PlanTranslationJa: PlanTranslationKeys = {
         "保存したプランはいつでも見返すことができます。",
 
     createPlanFromThisPlace: "この場所からプランを作る",
+
+    planCreatedSuccessfullyTitle: "プランが完成しました!",
 };

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -50,4 +50,7 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     planCreatingTitle: "プランを作成しています",
     planCreateFailedTitle: "プランの作成に失敗しました",
     planCreatedSuccessfullyTitle: "プランが完成しました!",
+
+    reorderPlacesSuccess: "並び替えが成功しました",
+    reorderPlacesFailed: "並び替えに失敗しました",
 };

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -32,4 +32,6 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     savedPlansEmptyTitle: "プランを作って、保存しよう！",
     savedPlansEmptyDescription:
         "保存したプランはいつでも見返すことができます。",
+
+    createPlanFromThisPlace: "この場所からプランを作る",
 };

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -1,0 +1,30 @@
+import { PlanTranslationKeys } from "src/locales/type";
+
+export const PlanTranslationJa: PlanTranslationKeys = {
+    plan: "プラン",
+    album: "アルバム",
+    loadingPlan: "プランを読み込んでいます",
+    planInfo: "プランの情報",
+    saveThisPlan: "このプランを保存",
+    nearbyPlans: "近くのプラン",
+    copiedPlanUrl: "プランのURLをコピーしました",
+
+    promptShareCreatedPlan: "作ったプランを共有してみましょう！",
+    promptCreateNewPlan: "新しいプランを作ってみませんか？",
+    promptPreparingCustomPlan:
+        "カスタマイズ用のプランを準備しています。もう少しお待ちください",
+
+    placesInPlan: "プラン内の場所",
+    clickMarkerToShowPlaceDetail:
+        "マーカーをクリックすると場所の詳細が表示されます",
+
+    saveAsImage: "画像として保存",
+    searchRouteOnGoogleMaps: "Googleマップで経路を調べる",
+    customizePlan: "このプランをカスタマイズする",
+
+    failedToCreatePlan: "プランを作成することができませんでした",
+
+    loadingMap: "地図を読み込んでいます",
+    cannotDisplayBecauseThePlanDoesNotContainAnyPlaces:
+        "プランに場所が含まれていないため表示できません。",
+};

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -1,74 +1,76 @@
 import { PlanTranslationKeys } from "src/locales/type";
 
 export const PlanTranslationJa: PlanTranslationKeys = {
-    plan: "プラン",
     album: "アルバム",
-    loadingPlan: "プランを読み込んでいます",
-    planInfo: "プランの情報",
-    saveThisPlan: "このプランを保存",
-    copyPlanUrl: "プランのURLをコピー",
+    plan: "プラン",
+
+    addNewPlaceToPlanConfirmTitle: "この場所をプランに追加しますか？",
+    addNewPlaceToPlanMinuteFromPreviousPlace: "前の場所から{{minute}}分",
+    addNewPlaceToPlanTitle: "プランに新しい場所を追加",
+
+    cannotDisplayBecauseThePlanDoesNotContainAnyPlaces:
+        "プランに場所が含まれていないため表示できません。",
+    clickMarkerToShowPlaceDetail:
+        "マーカーをクリックすると場所の詳細が表示されます",
+
     copiedPlanUrl: "プランのURLをコピーしました",
+    copyPlanUrl: "プランのURLをコピー",
+
     createPlan: "プランを作成",
+    createNewPlanTitle: "新しいプランを作ってみませんか？",
+    createPlanInProgressTitle: "プランを作成しています",
+    createPlanFailed: "プランを作成することができませんでした",
+    createPlanFailedDescription: "他の場所からプランを作成してみませんか？",
+    createPlanFailedTitle: "プランを作成できませんでした",
+
     createPlanFromOtherLocation: "他の場所からプランを作成",
+    createPlanFromThisPlace: "この場所からプランを作る",
     createPlanFromSelectedPlace: "選択した場所からプランを作成",
 
-    addNewPlaceToPlanTitle: "プランに新しい場所を追加",
-    addNewPlaceToPlanMinuteFromPreviousPlace: "前の場所から{{minute}}分",
-    addNewPlaceToPlanConfirmTitle: "この場所をプランに追加しますか？",
+    customizePlan: "このプランをカスタマイズする",
+    customizePlanCreated: "カスタマイズ用のプランの準備ができました！",
+    customizePlanCreating:
+        "カスタマイズ用のプランを準備しています。もう少しお待ちください",
 
     deletePlaceFromPlanConfirmTitle:
         "<bold>「{{name}}」</bold>をプランから削除しますか？",
 
+    loadingMap: "地図を読み込んでいます",
+    loadingPlan: "プランを読み込んでいます",
+
     nearbyPlans: "近くのプラン",
-    nearbyPlansEmptyTitle: "近くで作成されたプランはありませんでした",
     nearbyPlansEmptyDescription: "最初のプランを作ってみませんか？",
+    nearbyPlansEmptyTitle: "近くで作成されたプランはありませんでした",
 
-    customizePlanCreating:
-        "カスタマイズ用のプランを準備しています。もう少しお待ちください",
-    customizePlanCreated: "カスタマイズ用のプランの準備ができました！",
+    planCreateFailedTitle: "プランの作成に失敗しました",
+    planCreatedSuccessfullyTitle: "プランが完成しました!",
+    planCreatingTitle: "プランを作成しています",
 
-    shareCreatedPlanMessage: "作ったプランを共有してみましょう！",
-    createNewPlanTitle: "新しいプランを作ってみませんか？",
+    planInfo: "プランの情報",
+    placesInPlan: "プラン内の場所",
+
+    reorderPlaces: "場所を並び替え",
+    reorderPlacesFailed: "並び替えに失敗しました",
+    reorderPlacesMinuteFromPreviousPlace: "前の場所から{{minute}}分",
+    reorderPlacesMinuteFromStartLocation: "出発地点から{{minute}}分",
+    reorderPlacesMinimizeWalkingDistance: "歩く距離を最短にする",
+    reorderPlacesSuccess: "並び替えが成功しました",
+
+    saveAsImage: "画像として保存",
+    saveThisPlan: "このプランを保存",
+    showPlan: "プランをみてみる",
+
+    savedPlans: "保存したプラン",
+    savedPlansEmptyDescription:
+        "保存したプランはいつでも見返すことができます。",
+    savedPlansEmptyTitle: "プランを作って、保存しよう！",
+
     searchNearbyPlansInProgress: "近くのプランを検索しています...",
     searchNearbyPlansLocationPermissionDenied:
         "位置情報を許可すると、近くのプランを探すことができます。",
-    searchNearbyPlansLocationPermissionNotGranted: "位置情報をオンにしてプランを取得",
-
-    placesInPlan: "プラン内の場所",
-    clickMarkerToShowPlaceDetail:
-        "マーカーをクリックすると場所の詳細が表示されます",
-
-    saveAsImage: "画像として保存",
+    searchNearbyPlansLocationPermissionNotGranted:
+        "位置情報をオンにしてプランを取得",
     searchRouteOnGoogleMaps: "Googleマップで経路を調べる",
-    customizePlan: "このプランをカスタマイズする",
 
-    createPlanFailed: "プランを作成することができませんでした",
-
-    loadingMap: "地図を読み込んでいます",
-    cannotDisplayBecauseThePlanDoesNotContainAnyPlaces:
-        "プランに場所が含まれていないため表示できません。",
-
-    savedPlans: "保存したプラン",
-    savedPlansEmptyTitle: "プランを作って、保存しよう！",
-    savedPlansEmptyDescription:
-        "保存したプランはいつでも見返すことができます。",
-
-    showPlan: "プランをみてみる",
-
-    createPlanInProgressTitle: "プランを作成しています",
-    createPlanFailedTitle: "プランを作成できませんでした",
-    createPlanFailedDescription: "他の場所からプランを作成してみませんか？",
-
-    createPlanFromThisPlace: "この場所からプランを作る",
-
-    planCreatingTitle: "プランを作成しています",
-    planCreateFailedTitle: "プランの作成に失敗しました",
-    planCreatedSuccessfullyTitle: "プランが完成しました!",
-
-    reorderPlaces: "場所を並び替え",
-    reorderPlacesSuccess: "並び替えが成功しました",
-    reorderPlacesFailed: "並び替えに失敗しました",
-    reorderPlacesMinuteFromStartLocation: "出発地点から{{minute}}分",
-    reorderPlacesMinuteFromPreviousPlace: "前の場所から{{minute}}分",
-    reorderPlacesMinimizeWalkingDistance: "歩く距離を最短にする",
+    shareCreatedPlanMessage: "作ったプランを共有してみましょう！",
 };

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -44,5 +44,7 @@ export const PlanTranslationJa: PlanTranslationKeys = {
 
     createPlanFromThisPlace: "この場所からプランを作る",
 
+    planCreatingTitle: "プランを作成しています",
+    planCreateFailedTitle: "プランの作成に失敗しました",
     planCreatedSuccessfullyTitle: "プランが完成しました!",
 };

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -27,4 +27,9 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     loadingMap: "地図を読み込んでいます",
     cannotDisplayBecauseThePlanDoesNotContainAnyPlaces:
         "プランに場所が含まれていないため表示できません。",
+
+    savedPlans: "保存したプラン",
+    savedPlansEmptyTitle: "プランを作って、保存しよう！",
+    savedPlansEmptyDescription:
+        "保存したプランはいつでも見返すことができます。",
 };

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -15,6 +15,9 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     addNewPlaceToPlanMinuteFromPreviousPlace: "前の場所から{{minute}}分",
     addNewPlaceToPlanConfirmTitle: "この場所をプランに追加しますか？",
 
+    deletePlaceFromPlanConfirmTitle:
+        "<bold>「{{name}}」</bold>をプランから削除しますか？",
+
     nearbyPlans: "近くのプラン",
     nearbyPlansEmptyTitle: "近くで作成されたプランはありませんでした",
     nearbyPlansEmptyDescription: "最初のプランを作ってみませんか？",

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -39,7 +39,8 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     loadingPlan: "プランを読み込んでいます",
 
     loginRecommendationTitle: "あなただけのプランを、いつもそばに",
-    loginRecommendationDescription: "ログインすると、作成したプランをいつでも見返すことができます。",
+    loginRecommendationDescription:
+        "ログインすると、作成したプランをいつでも見返すことができます。",
 
     nearbyPlans: "近くのプラン",
     nearbyPlansEmptyDescription: "最初のプランを作ってみませんか？",

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -10,6 +10,7 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     copiedPlanUrl: "プランのURLをコピーしました",
     createPlan: "プランを作成",
     createPlanFromOtherLocation: "他の場所からプランを作成",
+    createPlanFromSelectedPlace: "選択した場所からプランを作成",
 
     addNewPlaceToPlanTitle: "プランに新しい場所を追加",
     addNewPlaceToPlanMinuteFromPreviousPlace: "前の場所から{{minute}}分",
@@ -26,12 +27,12 @@ export const PlanTranslationJa: PlanTranslationKeys = {
         "カスタマイズ用のプランを準備しています。もう少しお待ちください",
     customizePlanCreated: "カスタマイズ用のプランの準備ができました！",
 
-    promptShareCreatedPlan: "作ったプランを共有してみましょう！",
-    promptCreateNewPlan: "新しいプランを作ってみませんか？",
-    promptSearchingNearbyPlans: "近くのプランを検索しています...",
-    promptLocationPermissionDenied:
+    shareCreatedPlanMessage: "作ったプランを共有してみましょう！",
+    createNewPlanTitle: "新しいプランを作ってみませんか？",
+    searchNearbyPlansInProgress: "近くのプランを検索しています...",
+    searchNearbyPlansLocationPermissionDenied:
         "位置情報を許可すると、近くのプランを探すことができます。",
-    promptLocationPermissionNotGranted: "位置情報をオンにしてプランを取得",
+    searchNearbyPlansLocationPermissionNotGranted: "位置情報をオンにしてプランを取得",
 
     placesInPlan: "プラン内の場所",
     clickMarkerToShowPlaceDetail:
@@ -41,7 +42,7 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     searchRouteOnGoogleMaps: "Googleマップで経路を調べる",
     customizePlan: "このプランをカスタマイズする",
 
-    failedToCreatePlan: "プランを作成することができませんでした",
+    createPlanFailed: "プランを作成することができませんでした",
 
     loadingMap: "地図を読み込んでいます",
     cannotDisplayBecauseThePlanDoesNotContainAnyPlaces:

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -6,17 +6,21 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     loadingPlan: "プランを読み込んでいます",
     planInfo: "プランの情報",
     saveThisPlan: "このプランを保存",
-    nearbyPlans: "近くのプラン",
     copiedPlanUrl: "プランのURLをコピーしました",
+    createPlan: "プランを作成",
+
+    nearbyPlans: "近くのプラン",
+    nearbyPlansEmptyTitle: "近くで作成されたプランはありませんでした",
+    nearbyPlansEmptyDescription: "最初のプランを作ってみませんか？",
 
     promptShareCreatedPlan: "作ったプランを共有してみましょう！",
     promptCreateNewPlan: "新しいプランを作ってみませんか？",
     promptPreparingCustomPlan:
         "カスタマイズ用のプランを準備しています。もう少しお待ちください",
     promptSearchingNearbyPlans: "近くのプランを検索しています...",
-    promptTurnOnLocationServiceToSearchNearbyPlans:
+    promptLocationPermissionDenied:
         "位置情報を許可すると、近くのプランを探すことができます。",
-    promptLocationServiceUnavailable: "位置情報をオンにしてプランを取得",
+    promptLocationPermissionNotGranted: "位置情報をオンにしてプランを取得",
 
     placesInPlan: "プラン内の場所",
     clickMarkerToShowPlaceDetail:

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -15,10 +15,12 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     nearbyPlansEmptyTitle: "近くで作成されたプランはありませんでした",
     nearbyPlansEmptyDescription: "最初のプランを作ってみませんか？",
 
+    customizePlanCreating:
+        "カスタマイズ用のプランを準備しています。もう少しお待ちください",
+    customizePlanCreated: "カスタマイズ用のプランの準備ができました！",
+
     promptShareCreatedPlan: "作ったプランを共有してみましょう！",
     promptCreateNewPlan: "新しいプランを作ってみませんか？",
-    promptPreparingCustomPlan:
-        "カスタマイズ用のプランを準備しています。もう少しお待ちください",
     promptSearchingNearbyPlans: "近くのプランを検索しています...",
     promptLocationPermissionDenied:
         "位置情報を許可すると、近くのプランを探すことができます。",

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -11,6 +11,10 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     createPlan: "プランを作成",
     createPlanFromOtherLocation: "他の場所からプランを作成",
 
+    addNewPlaceToPlanTitle: "プランに新しい場所を追加",
+    addNewPlaceToPlanMinuteFromPreviousPlace: "前の場所から{{minute}}分",
+    addNewPlaceToPlanConfirmTitle: "この場所をプランに追加しますか？",
+
     nearbyPlans: "近くのプラン",
     nearbyPlansEmptyTitle: "近くで作成されたプランはありませんでした",
     nearbyPlansEmptyDescription: "最初のプランを作ってみませんか？",

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -9,6 +9,7 @@ export const PlanTranslationJa: PlanTranslationKeys = {
     copyPlanUrl: "プランのURLをコピー",
     copiedPlanUrl: "プランのURLをコピーしました",
     createPlan: "プランを作成",
+    createPlanFromOtherLocation: "他の場所からプランを作成",
 
     nearbyPlans: "近くのプラン",
     nearbyPlansEmptyTitle: "近くで作成されたプランはありませんでした",

--- a/src/locales/ja/pwa.ts
+++ b/src/locales/ja/pwa.ts
@@ -1,0 +1,9 @@
+import { PwaTranslationKeys } from "src/locales/type";
+
+export const PwaTranslationJa: PwaTranslationKeys = {
+    addToHomeScreen: "ホームに追加",
+    alreadyAddedToHomeScreen: "すでにホームに追加されています",
+    addToHomeScreenInstructionTitle: "ホーム画面への追加方法",
+
+    promptAddToHomeScreen: "komichiを<br/>ホームに追加しますか？",
+};

--- a/src/locales/ja/pwa.ts
+++ b/src/locales/ja/pwa.ts
@@ -2,8 +2,10 @@ import { PwaTranslationKeys } from "src/locales/type";
 
 export const PwaTranslationJa: PwaTranslationKeys = {
     addToHomeScreen: "ホームに追加",
+    addedToHomeScreen: "ホームに追加しました",
     alreadyAddedToHomeScreen: "すでにホームに追加されています",
     addToHomeScreenInstructionTitle: "ホーム画面への追加方法",
 
     promptAddToHomeScreen: "komichiを<br/>ホームに追加しますか？",
+    pwaInstallationConfirmedResponse: "ご回答いただき、ありがとうございます。",
 };

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -1,5 +1,6 @@
 export type CommonTranslationKeys = {
     add: string;
+    delete: string;
     save: string;
     close: string;
     cancel: string;
@@ -84,6 +85,8 @@ export type PlanTranslationKeys = {
     addNewPlaceToPlanTitle: string;
     addNewPlaceToPlanMinuteFromPreviousPlace: string;
     addNewPlaceToPlanConfirmTitle: string;
+
+    deletePlaceFromPlanConfirmTitle: string;
 
     customizePlan: string;
     customizePlanCreating: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -124,6 +124,9 @@ export type PlanTranslationKeys = {
     reorderPlaces: string;
     reorderPlacesSuccess: string;
     reorderPlacesFailed: string;
+    reorderPlacesMinuteFromStartLocation: string;
+    reorderPlacesMinuteFromPreviousPlace: string;
+    reorderPlacesMinimizeWalkingDistance: string;
 };
 
 export type PlaceTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -114,6 +114,9 @@ export type PlanTranslationKeys = {
     planCreatingTitle: string;
     planCreateFailedTitle: string;
     planCreatedSuccessfullyTitle: string;
+
+    reorderPlacesSuccess: string;
+    reorderPlacesFailed: string;
 };
 
 export type PlaceTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -1,4 +1,5 @@
 export type CommonTranslationKeys = {
+    add: string;
     save: string;
     close: string;
     cancel: string;
@@ -79,6 +80,10 @@ export type PlanTranslationKeys = {
     copiedPlanUrl: string;
     createPlan: string;
     createPlanFromOtherLocation: string;
+
+    addNewPlaceToPlanTitle: string;
+    addNewPlaceToPlanMinuteFromPreviousPlace: string;
+    addNewPlaceToPlanConfirmTitle: string;
 
     customizePlan: string;
     customizePlanCreating: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -105,6 +105,9 @@ export type PlanTranslationKeys = {
     loadingMap: string;
     loadingPlan: string;
 
+    loginRecommendationTitle: string;
+    loginRecommendationDescription: string;
+
     nearbyPlans: string;
     nearbyPlansEmptyDescription: string;
     nearbyPlansEmptyTitle: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -36,6 +36,12 @@ export type HomeTranslationKeys = {
     recentlyCreatedPlans: string;
 };
 
+export type NavigationTranslationKeys = {
+    home: string;
+    search: string;
+    myPage: string;
+}
+
 export type PlanTranslationKeys = {
     plan: string;
     album: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -138,8 +138,10 @@ export type PlaceTranslationKeys = {
 
 export type PwaTranslationKeys = {
     addToHomeScreen: string;
+    addedToHomeScreen: string;
     alreadyAddedToHomeScreen: string;
     addToHomeScreenInstructionTitle: string;
 
     promptAddToHomeScreen: string;
+    pwaInstallationConfirmedResponse: string;
 };

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -8,6 +8,9 @@ export type CommonTranslationKeys = {
 };
 
 export type HomeTranslationKeys = {
+    promptCreatePlan: string;
+    fromFavoritePlace: string;
+    fromCurrentLocation: string;
     recentlyCreatedPlans: string;
 };
 

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -104,3 +104,11 @@ export type PlaceTranslationKeys = {
     favoritePlacesEmptyTitle: string;
     favoritePlacesEmptyDescription: string;
 };
+
+export type PwaTranslationKeys = {
+    addToHomeScreen: string;
+    alreadyAddedToHomeScreen: string;
+    addToHomeScreenInstructionTitle: string;
+
+    promptAddToHomeScreen: string;
+};

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -137,6 +137,8 @@ export type PlaceTranslationKeys = {
     recommendedTouristSpotsTitle: string;
     promptRecommendedTouristSpotsSearching: string;
     recommendedTouristSearchFailed: string;
+
+    loginToSaveFavoritePlace: string;
 };
 
 export type PwaTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -2,6 +2,7 @@ export type CommonTranslationKeys = {
     save: string;
     close: string;
     cancel: string;
+    edit: string;
     backToHome: string;
     info: string;
     time: string;
@@ -15,6 +16,10 @@ export type AccountTranslationKeys = {
     login: string;
     logout: string;
     loginByGoogle: string;
+
+    name: string;
+    editProfile: string;
+    editProfileImage: string;
 
     retainDataBeforeLogin: string;
     retainData: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -6,22 +6,21 @@ export type CommonTranslationKeys = {
     close: string;
     delete: string;
     edit: string;
+    reload: string;
+    retry: string;
+    save: string;
 
     info: string;
 
     minutesLabel: string;
-    notFound: string;
     priceLabel: string;
+    notFound: string;
 
-    reload: string;
-    retry: string;
-    save: string;
     serverError: string;
 
     time: string;
     YYYYMMDDHHMM: string;
 };
-
 
 export type AccountTranslationKeys = {
     name: string;
@@ -47,9 +46,9 @@ export type AccountTranslationKeys = {
 };
 
 export type HomeTranslationKeys = {
-    promptCreatePlan: string;
-    fromFavoritePlace: string;
-    fromCurrentLocation: string;
+    createPlanTitle: string;
+    createPlanFromFavoritePlace: string;
+    createPlanFromCurrentLocation: string;
     recentlyCreatedPlans: string;
 };
 
@@ -72,24 +71,30 @@ export type OgpTranslationKeys = {
 };
 
 export type PlanTranslationKeys = {
+    album: string;
+    plan: string;
+
     addNewPlaceToPlanConfirmTitle: string;
     addNewPlaceToPlanMinuteFromPreviousPlace: string;
     addNewPlaceToPlanTitle: string;
-    album: string;
 
     cannotDisplayBecauseThePlanDoesNotContainAnyPlaces: string;
     clickMarkerToShowPlaceDetail: string;
+
     copiedPlanUrl: string;
     copyPlanUrl: string;
-    createNewPlanTitle: string;
+
     createPlan: string;
+    createNewPlanTitle: string;
+    createPlanInProgressTitle: string;
     createPlanFailed: string;
     createPlanFailedDescription: string;
     createPlanFailedTitle: string;
+
     createPlanFromOtherLocation: string;
     createPlanFromThisPlace: string;
     createPlanFromSelectedPlace: string;
-    createPlanInProgressTitle: string;
+
     customizePlan: string;
     customizePlanCreated: string;
     customizePlanCreating: string;
@@ -103,10 +108,10 @@ export type PlanTranslationKeys = {
     nearbyPlansEmptyDescription: string;
     nearbyPlansEmptyTitle: string;
 
-    plan: string;
     planCreateFailedTitle: string;
     planCreatedSuccessfullyTitle: string;
     planCreatingTitle: string;
+
     planInfo: string;
     placesInPlan: string;
 
@@ -119,6 +124,8 @@ export type PlanTranslationKeys = {
 
     saveAsImage: string;
     saveThisPlan: string;
+    showPlan: string;
+
     savedPlans: string;
     savedPlansEmptyDescription: string;
     savedPlansEmptyTitle: string;
@@ -126,50 +133,47 @@ export type PlanTranslationKeys = {
     searchNearbyPlansLocationPermissionDenied: string;
     searchNearbyPlansLocationPermissionNotGranted: string;
     searchRouteOnGoogleMaps: string;
+
     shareCreatedPlanMessage: string;
-    showPlan: string;
 };
 
-
 export type PlaceTranslationKeys = {
-    searchPlace: string;
-    skipCurrentLocationRetrieval: string;
-    tapToSelectPlace: string;
-
-    searchByInstagram: string;
-    searchByGoogleMaps: string;
-
-    nearbyPlacesSearching: string;
-    selectPlaceCategoryMessage: string;
-
-    uploadPlacePhoto: string;
-    uploadPlacePhotoSuccess: string;
-    uploadPlacePhotoFailed: string;
-    uploadPlacePhotoFailedDescription: string;
-
     address: string;
     category: string;
-    priceRange: string;
     estimatedStayDuration: string;
+    nearbyPlacesSearching: string;
     noInformation: string;
+    priceRange: string;
 
     favoritePlaces: string;
-    favoritePlacesEmptyTitle: string;
     favoritePlacesEmptyDescription: string;
-
-    recommendedTouristSpotsShow: string;
-    recommendedTouristSpotsTitle: string;
-    recommendedTouristSpotsSearching: string;
-    recommendedTouristSpotsSearchFailed: string;
+    favoritePlacesEmptyTitle: string;
 
     loginToSaveFavoritePlace: string;
 
+    recommendedTouristSpotsSearchFailed: string;
+    recommendedTouristSpotsSearching: string;
+    recommendedTouristSpotsShow: string;
+    recommendedTouristSpotsTitle: string;
+
+    relatedPlacesDescription: string;
     relatedPlacesShow: string;
     relatedPlacesTitle: string;
-    relatedPlacesDescription: string;
-
     replacePlace: string;
     replacePlaceConfirmTitle: string;
+
+    searchByGoogleMaps: string;
+    searchByInstagram: string;
+    searchPlace: string;
+    selectPlaceCategoryMessage: string;
+    skipCurrentLocationRetrieval: string;
+
+    tapToSelectPlace: string;
+
+    uploadPlacePhoto: string;
+    uploadPlacePhotoFailed: string;
+    uploadPlacePhotoFailedDescription: string;
+    uploadPlacePhotoSuccess: string;
 };
 
 export type PwaTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -1,6 +1,7 @@
 export type CommonTranslationKeys = {
     save: string;
     close: string;
+    cancel: string;
     backToHome: string;
     info: string;
     time: string;
@@ -10,11 +11,22 @@ export type CommonTranslationKeys = {
 export type AccountTranslationKeys = {
     login: string;
     logout: string;
-    retainDataBeforeLogin: string;
     loginByGoogle: string;
+
+    retainDataBeforeLogin: string;
+    retainData: string;
+    retainingData: string;
+    retainingDataWaitMessage: string;
+    retainDataSuccess: string;
+    retainDataFailed: string;
+    retainDataCanceledMessage: string;
+    retainDataRetryLaterMessage: string;
 
     promptLoginTitle: string;
     promptLoginDescription: string;
+
+    promptRetainDataBeforeLoginTitle: string;
+    promptRetainDataBeforeLoginDescription: string;
 };
 
 export type HomeTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -1,31 +1,29 @@
 export type CommonTranslationKeys = {
     add: string;
-    delete: string;
-    save: string;
-    close: string;
-    cancel: string;
-    edit: string;
     backToHome: string;
-    reload: string;
-    retry: string;
+    budget: string;
+    cancel: string;
+    close: string;
+    delete: string;
+    edit: string;
 
     info: string;
-    time: string;
-    budget: string;
-    YYYYMMDDHHMM: string;
 
     minutesLabel: string;
+    notFound: string;
     priceLabel: string;
 
+    reload: string;
+    retry: string;
+    save: string;
     serverError: string;
-    notFound: string;
+
+    time: string;
+    YYYYMMDDHHMM: string;
 };
 
-export type AccountTranslationKeys = {
-    login: string;
-    logout: string;
-    loginByGoogle: string;
 
+export type AccountTranslationKeys = {
     name: string;
     editProfile: string;
     editProfileImage: string;
@@ -38,12 +36,14 @@ export type AccountTranslationKeys = {
     retainDataFailed: string;
     retainDataCanceledMessage: string;
     retainDataRetryLaterMessage: string;
+    retainDataBeforeLoginTitle: string;
+    retainDataBeforeLoginDescription: string;
 
-    promptLoginTitle: string;
-    promptLoginDescription: string;
-
-    promptRetainDataBeforeLoginTitle: string;
-    promptRetainDataBeforeLoginDescription: string;
+    login: string;
+    loginByGoogle: string;
+    loginTitle: string;
+    loginDescription: string;
+    logout: string;
 };
 
 export type HomeTranslationKeys = {
@@ -72,76 +72,69 @@ export type OgpTranslationKeys = {
 };
 
 export type PlanTranslationKeys = {
-    plan: string;
-    album: string;
-    loadingPlan: string;
-    planInfo: string;
-    saveThisPlan: string;
-    copyPlanUrl: string;
-    copiedPlanUrl: string;
-    createPlan: string;
-    createPlanFromOtherLocation: string;
-
-    addNewPlaceToPlanTitle: string;
-    addNewPlaceToPlanMinuteFromPreviousPlace: string;
     addNewPlaceToPlanConfirmTitle: string;
+    addNewPlaceToPlanMinuteFromPreviousPlace: string;
+    addNewPlaceToPlanTitle: string;
+    album: string;
+
+    cannotDisplayBecauseThePlanDoesNotContainAnyPlaces: string;
+    clickMarkerToShowPlaceDetail: string;
+    copiedPlanUrl: string;
+    copyPlanUrl: string;
+    createNewPlanTitle: string;
+    createPlan: string;
+    createPlanFailed: string;
+    createPlanFailedDescription: string;
+    createPlanFailedTitle: string;
+    createPlanFromOtherLocation: string;
+    createPlanFromThisPlace: string;
+    createPlanFromSelectedPlace: string;
+    createPlanInProgressTitle: string;
+    customizePlan: string;
+    customizePlanCreated: string;
+    customizePlanCreating: string;
 
     deletePlaceFromPlanConfirmTitle: string;
 
-    customizePlan: string;
-    customizePlanCreating: string;
-    customizePlanCreated: string;
-
-    promptShareCreatedPlan: string;
-    promptCreateNewPlan: string;
-    promptSearchingNearbyPlans: string;
-    promptLocationPermissionDenied: string;
-    promptLocationPermissionNotGranted: string;
+    loadingMap: string;
+    loadingPlan: string;
 
     nearbyPlans: string;
-    nearbyPlansEmptyTitle: string;
     nearbyPlansEmptyDescription: string;
+    nearbyPlansEmptyTitle: string;
 
-    placesInPlan: string;
-    clickMarkerToShowPlaceDetail: string;
-
-    saveAsImage: string;
-    searchRouteOnGoogleMaps: string;
-
-    failedToCreatePlan: string;
-
-    loadingMap: string;
-    cannotDisplayBecauseThePlanDoesNotContainAnyPlaces: string;
-
-    savedPlans: string;
-    savedPlansEmptyTitle: string;
-    savedPlansEmptyDescription: string;
-
-    showPlan: string;
-
-    createPlanInProgressTitle: string;
-    createPlanFailedTitle: string;
-    createPlanFailedDescription: string;
-
-    createPlanFromThisPlace: string;
-
-    planCreatingTitle: string;
+    plan: string;
     planCreateFailedTitle: string;
     planCreatedSuccessfullyTitle: string;
+    planCreatingTitle: string;
+    planInfo: string;
+    placesInPlan: string;
 
     reorderPlaces: string;
-    reorderPlacesSuccess: string;
     reorderPlacesFailed: string;
-    reorderPlacesMinuteFromStartLocation: string;
     reorderPlacesMinuteFromPreviousPlace: string;
+    reorderPlacesMinuteFromStartLocation: string;
     reorderPlacesMinimizeWalkingDistance: string;
+    reorderPlacesSuccess: string;
+
+    saveAsImage: string;
+    saveThisPlan: string;
+    savedPlans: string;
+    savedPlansEmptyDescription: string;
+    savedPlansEmptyTitle: string;
+    searchNearbyPlansInProgress: string;
+    searchNearbyPlansLocationPermissionDenied: string;
+    searchNearbyPlansLocationPermissionNotGranted: string;
+    searchRouteOnGoogleMaps: string;
+    shareCreatedPlanMessage: string;
+    showPlan: string;
 };
+
 
 export type PlaceTranslationKeys = {
     searchPlace: string;
     skipCurrentLocationRetrieval: string;
     tapToSelectPlace: string;
-    createPlanFromSelectedPlace: string;
 
     searchByInstagram: string;
     searchByGoogleMaps: string;
@@ -164,10 +157,10 @@ export type PlaceTranslationKeys = {
     favoritePlacesEmptyTitle: string;
     favoritePlacesEmptyDescription: string;
 
-    showRecommendedTouristSpots: string;
+    recommendedTouristSpotsShow: string;
     recommendedTouristSpotsTitle: string;
-    promptRecommendedTouristSpotsSearching: string;
-    recommendedTouristSearchFailed: string;
+    recommendedTouristSpotsSearching: string;
+    recommendedTouristSpotsSearchFailed: string;
 
     loginToSaveFavoritePlace: string;
 

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -127,7 +127,11 @@ export type PlaceTranslationKeys = {
 
     searchByInstagram: string;
     searchByGoogleMaps: string;
-    uploadPhoto: string;
+
+    uploadPlacePhoto: string;
+    uploadPlacePhotoSuccess: string;
+    uploadPlacePhotoFailed: string;
+    uploadPlacePhotoFailedDescription: string;
 
     address: string;
     category: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -10,6 +10,8 @@ export type CommonTranslationKeys = {
     time: string;
     budget: string;
 
+    minutesLabel: string;
+
     serverError: string;
     notFound: string;
 };
@@ -99,6 +101,7 @@ export type PlaceTranslationKeys = {
     category: string;
     priceRange: string;
     estimatedStayDuration: string;
+    noInformation: string;
 
     favoritePlaces: string;
     favoritePlacesEmptyTitle: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -54,6 +54,18 @@ export type NavigationTranslationKeys = {
     myPage: string;
 };
 
+export type OgpTranslationKeys = {
+    topPageTitle: string;
+    topPageDescription: string;
+
+    placeSearchPageTitle: string;
+    placeSearchPageDescription: string;
+
+    planInterestPageFromCurrentLocationTitle: string;
+    planInterestPageFromSelectedPlaceTitle: string;
+    planInterestPageDescription: string;
+};
+
 export type PlanTranslationKeys = {
     plan: string;
     album: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -5,6 +5,7 @@ export type CommonTranslationKeys = {
     edit: string;
     backToHome: string;
     reload: string;
+    retry: string;
 
     info: string;
     time: string;
@@ -106,6 +107,11 @@ export type PlanTranslationKeys = {
 };
 
 export type PlaceTranslationKeys = {
+    searchPlace: string;
+    skipCurrentLocationRetrieval: string;
+    tapToSelectPlace: string;
+    createPlanFromSelectedPlace: string;
+
     searchByInstagram: string;
     searchByGoogleMaps: string;
     uploadPhoto: string;
@@ -118,6 +124,11 @@ export type PlaceTranslationKeys = {
     favoritePlaces: string;
     favoritePlacesEmptyTitle: string;
     favoritePlacesEmptyDescription: string;
+
+    showRecommendedTouristSpots: string;
+    recommendedTouristSpotsTitle: string;
+    promptRecommendedTouristSpotsSearching: string;
+    recommendedTouristSearchFailed: string;
 };
 
 export type PwaTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -159,6 +159,13 @@ export type PlaceTranslationKeys = {
     recommendedTouristSearchFailed: string;
 
     loginToSaveFavoritePlace: string;
+
+    relatedPlacesShow: string;
+    relatedPlacesTitle: string;
+    relatedPlacesDescription: string;
+
+    replacePlace: string;
+    replacePlaceConfirmTitle: string;
 };
 
 export type PwaTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -64,6 +64,8 @@ export type PlanTranslationKeys = {
     savedPlans: string;
     savedPlansEmptyTitle: string;
     savedPlansEmptyDescription: string;
+
+    createPlanFromThisPlace: string;
 };
 
 export type PlaceTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -1,7 +1,48 @@
 export type CommonTranslationKeys = {
     save: string;
+    close: string;
+    backToHome: string;
+    info: string;
+    time: string;
+    budget: string;
 };
 
 export type HomeTranslationKeys = {
     recentlyCreatedPlans: string;
+};
+
+export type PlanTranslationKeys = {
+    plan: string;
+    album: string;
+    loadingPlan: string;
+    planInfo: string;
+    saveThisPlan: string;
+    nearbyPlans: string;
+    copiedPlanUrl: string;
+
+    promptShareCreatedPlan: string;
+    promptCreateNewPlan: string;
+    promptPreparingCustomPlan: string;
+
+    placesInPlan: string;
+    clickMarkerToShowPlaceDetail: string;
+
+    saveAsImage: string;
+    searchRouteOnGoogleMaps: string;
+    customizePlan: string;
+
+    failedToCreatePlan: string;
+
+    loadingMap: string;
+    cannotDisplayBecauseThePlanDoesNotContainAnyPlaces: string;
+};
+
+export type PlaceTranslationKeys = {
+    searchByInstagram: string;
+    searchByGoogleMaps: string;
+    uploadPhoto: string;
+
+    category: string;
+    priceRange: string;
+    estimatedStayDuration: string;
 };

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -6,6 +6,9 @@ export type CommonTranslationKeys = {
     info: string;
     time: string;
     budget: string;
+
+    serverError: string;
+    notFound: string;
 };
 
 export type AccountTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -58,15 +58,19 @@ export type PlanTranslationKeys = {
     loadingPlan: string;
     planInfo: string;
     saveThisPlan: string;
-    nearbyPlans: string;
     copiedPlanUrl: string;
+    createPlan: string;
 
     promptShareCreatedPlan: string;
     promptCreateNewPlan: string;
     promptPreparingCustomPlan: string;
     promptSearchingNearbyPlans: string;
-    promptTurnOnLocationServiceToSearchNearbyPlans: string;
-    promptLocationServiceUnavailable: string;
+    promptLocationPermissionDenied: string;
+    promptLocationPermissionNotGranted: string;
+
+    nearbyPlans: string;
+    nearbyPlansEmptyTitle: string;
+    nearbyPlansEmptyDescription: string;
 
     placesInPlan: string;
     clickMarkerToShowPlaceDetail: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -4,6 +4,8 @@ export type CommonTranslationKeys = {
     cancel: string;
     edit: string;
     backToHome: string;
+    reload: string;
+
     info: string;
     time: string;
     budget: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -7,6 +7,16 @@ export type CommonTranslationKeys = {
     budget: string;
 };
 
+export type AccountTranslationKeys = {
+    login: string;
+    logout: string;
+    retainDataBeforeLogin: string;
+    loginByGoogle: string;
+
+    promptLoginTitle: string;
+    promptLoginDescription: string;
+};
+
 export type HomeTranslationKeys = {
     promptCreatePlan: string;
     fromFavoritePlace: string;
@@ -38,6 +48,10 @@ export type PlanTranslationKeys = {
 
     loadingMap: string;
     cannotDisplayBecauseThePlanDoesNotContainAnyPlaces: string;
+
+    savedPlans: string;
+    savedPlansEmptyTitle: string;
+    savedPlansEmptyDescription: string;
 };
 
 export type PlaceTranslationKeys = {
@@ -48,4 +62,8 @@ export type PlaceTranslationKeys = {
     category: string;
     priceRange: string;
     estimatedStayDuration: string;
+
+    favoritePlaces: string;
+    favoritePlacesEmptyTitle: string;
+    favoritePlacesEmptyDescription: string;
 };

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -128,6 +128,9 @@ export type PlaceTranslationKeys = {
     searchByInstagram: string;
     searchByGoogleMaps: string;
 
+    nearbyPlacesSearching: string;
+    selectPlaceCategoryMessage: string;
+
     uploadPlacePhoto: string;
     uploadPlacePhotoSuccess: string;
     uploadPlacePhotoFailed: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -10,6 +10,7 @@ export type CommonTranslationKeys = {
     info: string;
     time: string;
     budget: string;
+    YYYYMMDDHHMM: string;
 
     minutesLabel: string;
     priceLabel: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -12,6 +12,7 @@ export type CommonTranslationKeys = {
     budget: string;
 
     minutesLabel: string;
+    priceLabel: string;
 
     serverError: string;
     notFound: string;
@@ -76,6 +77,7 @@ export type PlanTranslationKeys = {
     copyPlanUrl: string;
     copiedPlanUrl: string;
     createPlan: string;
+    createPlanFromOtherLocation: string;
 
     promptShareCreatedPlan: string;
     promptCreateNewPlan: string;
@@ -121,6 +123,7 @@ export type PlaceTranslationKeys = {
     searchByGoogleMaps: string;
     uploadPhoto: string;
 
+    address: string;
     category: string;
     priceRange: string;
     estimatedStayDuration: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -109,12 +109,19 @@ export type PlanTranslationKeys = {
     savedPlansEmptyTitle: string;
     savedPlansEmptyDescription: string;
 
+    showPlan: string;
+
+    createPlanInProgressTitle: string;
+    createPlanFailedTitle: string;
+    createPlanFailedDescription: string;
+
     createPlanFromThisPlace: string;
 
     planCreatingTitle: string;
     planCreateFailedTitle: string;
     planCreatedSuccessfullyTitle: string;
 
+    reorderPlaces: string;
     reorderPlacesSuccess: string;
     reorderPlacesFailed: string;
 };

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -106,6 +106,8 @@ export type PlanTranslationKeys = {
 
     createPlanFromThisPlace: string;
 
+    planCreatingTitle: string;
+    planCreateFailedTitle: string;
     planCreatedSuccessfullyTitle: string;
 };
 

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -9,6 +9,7 @@ export type CommonTranslationKeys = {
     reload: string;
     retry: string;
     save: string;
+    upload: string;
 
     info: string;
 
@@ -171,6 +172,7 @@ export type PlaceTranslationKeys = {
     tapToSelectPlace: string;
 
     uploadPlacePhoto: string;
+    uploadPlacePhotoConfirmTitle: string;
     uploadPlacePhotoFailed: string;
     uploadPlacePhotoFailedDescription: string;
     uploadPlacePhotoSuccess: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -40,7 +40,7 @@ export type NavigationTranslationKeys = {
     home: string;
     search: string;
     myPage: string;
-}
+};
 
 export type PlanTranslationKeys = {
     plan: string;
@@ -54,6 +54,9 @@ export type PlanTranslationKeys = {
     promptShareCreatedPlan: string;
     promptCreateNewPlan: string;
     promptPreparingCustomPlan: string;
+    promptSearchingNearbyPlans: string;
+    promptTurnOnLocationServiceToSearchNearbyPlans: string;
+    promptLocationServiceUnavailable: string;
 
     placesInPlan: string;
     clickMarkerToShowPlaceDetail: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -73,6 +73,7 @@ export type PlanTranslationKeys = {
     loadingPlan: string;
     planInfo: string;
     saveThisPlan: string;
+    copyPlanUrl: string;
     copiedPlanUrl: string;
     createPlan: string;
 
@@ -104,6 +105,8 @@ export type PlanTranslationKeys = {
     savedPlansEmptyDescription: string;
 
     createPlanFromThisPlace: string;
+
+    planCreatedSuccessfullyTitle: string;
 };
 
 export type PlaceTranslationKeys = {

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -79,9 +79,12 @@ export type PlanTranslationKeys = {
     createPlan: string;
     createPlanFromOtherLocation: string;
 
+    customizePlan: string;
+    customizePlanCreating: string;
+    customizePlanCreated: string;
+
     promptShareCreatedPlan: string;
     promptCreateNewPlan: string;
-    promptPreparingCustomPlan: string;
     promptSearchingNearbyPlans: string;
     promptLocationPermissionDenied: string;
     promptLocationPermissionNotGranted: string;
@@ -95,7 +98,6 @@ export type PlanTranslationKeys = {
 
     saveAsImage: string;
     searchRouteOnGoogleMaps: string;
-    customizePlan: string;
 
     failedToCreatePlan: string;
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { AppProps } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { Provider } from "react-redux";
 import { copyObject } from "src/domain/util/object";
 import "src/locales/i18n";
@@ -20,14 +21,15 @@ import { Theme } from "src/view/common/Theme";
 import { PageMetaData } from "src/view/constants/meta";
 
 function App({ Component, pageProps }: AppProps) {
+    const { t } = useTranslation();
     return (
         <>
             <Head>
                 <meta charSet="utf-8" />
-                <title>{PageMetaData.top.title}</title>
+                <title>{PageMetaData(t).top.title}</title>
                 <meta
                     name="description"
-                    content={PageMetaData.top.description}
+                    content={PageMetaData(t).top.description}
                 />
                 <meta name="locale" content="ja" />
                 <meta
@@ -47,11 +49,11 @@ function App({ Component, pageProps }: AppProps) {
                 />
                 <link rel="icon" type="image/png" href="/favicon/favicon.png" />
                 {/* ogp */}
-                <meta property="og:title" content={PageMetaData.top.title} />
+                <meta property="og:title" content={PageMetaData(t).top.title} />
                 <meta property="og:site_name" content="komichi" />
                 <meta
                     property="og:description"
-                    content={PageMetaData.top.description}
+                    content={PageMetaData(t).top.description}
                 />
                 <meta property="og:url" content="https://komichi.app/" />
                 <meta

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { Center, Spinner, VStack } from "@chakra-ui/react";
 import { GetStaticProps } from "next";
 import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { MdTrendingUp } from "react-icons/md";
 import InfiniteScroll from "react-infinite-scroller";
 import { PlannerGraphQlApi } from "src/data/graphql/PlannerGraphQlApi";
@@ -36,6 +37,7 @@ type Props = {
 
 const IndexPage = (props: Props) => {
     const dispatch = useAppDispatch();
+    const { t } = useTranslation();
     const {
         plansRecentlyCreated,
         nextPageTokenPlansRecentlyCreated,
@@ -101,7 +103,7 @@ const IndexPage = (props: Props) => {
                 >
                     <PlanList plans={plansRecentlyCreated} px={Size.top.px}>
                         <PlanListSectionTitle
-                            title="最近作成されたプラン"
+                            title={t("home:recentlyCreatedPlans")}
                             icon={MdTrendingUp}
                         />
                     </PlanList>

--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -61,6 +61,7 @@ function PlaceSearchPage() {
     const router = useRouter();
     const isSkipFetchCurrentLocation =
         router.query[RouteParams.SkipCurrentLocation] === "true";
+    const { t } = useTranslation();
     const dispatch = useAppDispatch();
     const { currentLocation } = reduxLocationSelector();
     const { placeSearchResults, placeSelected, moveToSelectedLocation } =
@@ -172,7 +173,7 @@ function PlaceSearchPage() {
     if (fetchCurrentLocationStatus && !location)
         return (
             <FetchLocationDialog
-                skipLocationLabel="現在地取得をスキップする"
+                skipLocationLabel={t("place:skipCurrentLocationRetrieval")}
                 isSkipCurrentLocationVisible={true}
                 fetchLocationRequestStatus={
                     fetchCurrentLocationStatus ?? RequestStatuses.PENDING
@@ -184,7 +185,7 @@ function PlaceSearchPage() {
     return (
         <VStack w="100%" h="100%" spacing={0}>
             <Head>
-                <title>好きな場所からプランを作る | komichi</title>
+                <title>{t("ogp:placeSearchPageTitle")}</title>
             </Head>
             <NavBar />
             <VStack w="100%" h="100%" position="relative">
@@ -262,6 +263,7 @@ const SearchButton = ({
     placeSelected: boolean;
     onClick: () => void;
 }) => {
+    const { t } = useTranslation();
     return (
         <Center
             position="fixed"
@@ -277,8 +279,8 @@ const SearchButton = ({
                     onClick={onClick}
                 >
                     {placeSelected
-                        ? "タップして場所を選択"
-                        : "指定した場所からプランを作成"}
+                        ? t("place:tapToSelectPlace")
+                        : t("place:createPlanFromSelectedPlace")}
                 </RoundedIconButton>
             </Box>
         </Center>

--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -280,7 +280,7 @@ const SearchButton = ({
                 >
                     {placeSelected
                         ? t("place:tapToSelectPlace")
-                        : t("place:createPlanFromSelectedPlace")}
+                        : t("plan:createPlanFromSelectedPlace")}
                 </RoundedIconButton>
             </Box>
         </Center>

--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -3,6 +3,7 @@ import { getAnalytics, logEvent } from "@firebase/analytics";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { MdDone, MdOutlineTouchApp } from "react-icons/md";
 import { GeoLocation } from "src/data/graphql/generated";
 import { PlaceSearchResult } from "src/domain/models/PlaceSearchResult";
@@ -41,13 +42,14 @@ import { PlaceSearchResults } from "src/view/place/PlaceSearchResults";
 import { ShowPlaceRecommendationButton } from "src/view/place/ShowPlaceRecommendationButton";
 
 export default function Page() {
+    const { t } = useTranslation();
     return (
         <>
             <Head>
-                <title>{PageMetaData.place.search.title}</title>
+                <title>{PageMetaData(t).place.search.title}</title>
                 <meta
                     name="description"
-                    content={PageMetaData.place.search.description}
+                    content={PageMetaData(t).place.search.description}
                 />
             </Head>
             <PlaceSearchPage />

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -329,7 +329,7 @@ export default function PlanPage() {
                 onClose={uploadImageProps.onCloseDialog}
             />
             {isCreatingPlanFromSavedPlan && (
-                <LoadingModal title={t("plan:promptPreparingCustomPlan")} />
+                <LoadingModal title={t("plan:customizePlanCreating")} />
             )}
             <>
                 <PlanFooter visible={isPlanFooterVisible}>

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -83,7 +83,7 @@ export default function PlanPage() {
 
         toast({
             title: t("plan:copiedPlanUrl"),
-            description: t("plan:promptShareCreatedPlan"),
+            description: t("plan:shareCreatedPlanMessage"),
             status: "success",
             duration: 3000, // ポップアップが表示される時間（ミリ秒）
             isClosable: true,
@@ -289,7 +289,7 @@ export default function PlanPage() {
                         contentPaddingX={0}
                         sectionHeader={
                             <PlanListSectionTitle
-                                title={t("plan:promptCreateNewPlan")}
+                                title={t("plan:createNewPlanTitle")}
                                 icon={MdOutlineExplore}
                                 px={Size.PlanDetail.px}
                             />

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -3,6 +3,7 @@ import { getAnalytics, logEvent } from "@firebase/analytics";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { MdOutlineExplore, MdOutlineNearMe } from "react-icons/md";
 import { Place } from "src/domain/models/Place";
 import { getPlanPriceRange } from "src/domain/models/Plan";
@@ -50,6 +51,7 @@ import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
 import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
 
 export default function PlanPage() {
+    const { t } = useTranslation();
     const { id } = useRouter().query;
     const dispatch = useAppDispatch();
     const router = useRouter();
@@ -80,8 +82,8 @@ export default function PlanPage() {
         navigator.clipboard.writeText(url);
 
         toast({
-            title: "プランのURLをコピーしました",
-            description: "作ったプランを共有してみましょう！",
+            title: t("plan:copiedPlanUrl"),
+            description: t("plan:promptShareCreatedPlan"),
             status: "success",
             duration: 3000, // ポップアップが表示される時間（ミリ秒）
             isClosable: true,
@@ -158,7 +160,7 @@ export default function PlanPage() {
             // プランを取得したあとで、同じプランを再取得したときに画面がロード中になるのを防ぐ
             plan?.id !== id)
     )
-        return <LoadingModal title="プランを読み込んでいます" />;
+        return <LoadingModal title={t("plan:loadingPlan")} />;
 
     if (fetchPlanRequestStatus === RequestStatuses.REJECTED)
         return <ErrorPage />;
@@ -208,7 +210,7 @@ export default function PlanPage() {
                 <PlanPageSection
                     sectionHeader={
                         <SectionTitle
-                            title="プランの情報"
+                            title={t("plan:planInfo")}
                             px={Size.PlanDetail.px}
                         />
                     }
@@ -223,7 +225,10 @@ export default function PlanPage() {
                 </PlanPageSection>
                 <PlanPageSection
                     sectionHeader={
-                        <SectionTitle title="プラン" px={Size.PlanDetail.px} />
+                        <SectionTitle
+                            title={t("plan:plan")}
+                            px={Size.PlanDetail.px}
+                        />
                     }
                 >
                     <PlanPlaceList
@@ -238,8 +243,8 @@ export default function PlanPage() {
                 <PlanPageSection
                     sectionHeader={
                         <SectionTitle
-                            title="プラン内の場所"
-                            description="マーカーをクリックすると場所の詳細が表示されます"
+                            title={t("plan:placesInPlan")}
+                            description={t("plan:clickMarkerToShowPlaceDetail")}
                             px={Size.PlanDetail.px}
                         />
                     }
@@ -259,7 +264,7 @@ export default function PlanPage() {
                             contentPaddingX={0}
                             sectionHeader={
                                 <PlanListSectionTitle
-                                    title="近くのプラン"
+                                    title={t("plan:nearbyPlans")}
                                     icon={MdOutlineNearMe}
                                     px={Size.PlanDetail.px}
                                 />
@@ -284,7 +289,7 @@ export default function PlanPage() {
                         contentPaddingX={0}
                         sectionHeader={
                             <PlanListSectionTitle
-                                title="新しいプランを作ってみませんか？"
+                                title={t("plan:promptCreateNewPlan")}
                                 icon={MdOutlineExplore}
                                 px={Size.PlanDetail.px}
                             />
@@ -324,7 +329,7 @@ export default function PlanPage() {
                 onClose={uploadImageProps.onCloseDialog}
             />
             {isCreatingPlanFromSavedPlan && (
-                <LoadingModal title="カスタマイズ用のプランを準備しています。もう少しお待ちください。" />
+                <LoadingModal title={t("plan:promptPreparingCustomPlan")} />
             )}
             <>
                 <PlanFooter visible={isPlanFooterVisible}>
@@ -342,7 +347,7 @@ export default function PlanPage() {
                             });
                         }}
                     >
-                        このプランをカスタムする
+                        {t("plan:customizePlan")}
                     </Button>
                 </PlanFooter>
             </>

--- a/src/pages/plans/interest.tsx
+++ b/src/pages/plans/interest.tsx
@@ -2,6 +2,7 @@ import { getAnalytics, logEvent } from "@firebase/analytics";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { ReactNode, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { LocationCategory } from "src/domain/models/LocationCategory";
 import { LocationCategoryWithPlace } from "src/domain/models/LocationCategoryWithPlace";
 import {
@@ -39,17 +40,18 @@ import { MatchInterestPageTemplate } from "src/view/plan/MatchInterestPageTempla
 
 export default function Page() {
     const router = useRouter();
+    const { t } = useTranslation();
     return (
         <>
             <Head>
                 <title>
-                    {PageMetaData.plans.interest.title(
+                    {PageMetaData(t).plans.interest.title(
                         router.query["location"] !== "true"
                     )}
                 </title>
                 <meta
                     name="description"
-                    content={PageMetaData.plans.interest.description}
+                    content={PageMetaData(t).plans.interest.description}
                 />
             </Head>
             <PlanInterestPage />

--- a/src/pages/plans/interest.tsx
+++ b/src/pages/plans/interest.tsx
@@ -231,6 +231,7 @@ export function PlanInterestPageComponent({
     handleRejectCategory,
     navBar,
 }: Props) {
+    const { t } = useTranslation();
     if (!currentCategory) {
         if (
             matchInterestRequestStatus === RequestStatuses.FULFILLED &&
@@ -241,12 +242,12 @@ export function PlanInterestPageComponent({
         if (matchInterestRequestStatus === RequestStatuses.REJECTED)
             return <ErrorPage />;
 
-        return <LoadingModal title="近くに何があるかを探しています。" />;
+        return <LoadingModal title={t("place:nearbyPlacesSearching")} />;
     }
 
     return (
         <MatchInterestPageTemplate
-            message="どんな場所に行きたいですか？"
+            message={t("place:selectPlaceCategoryMessage")}
             navBar={navBar}
         >
             <CategorySelect

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Center, Text, VStack } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { getPlanPriceRange } from "src/domain/models/Plan";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { hasValue } from "src/domain/util/null";
@@ -43,8 +44,8 @@ import { PlanInfoSection } from "src/view/plandetail/PlanInfoSection";
 import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
 import { PlanDetailPageHeader } from "src/view/plandetail/header/PlanDetailPageHeader";
 
-// TODO: 編集途中でログインした場合は、いいねした場所を引き継げるようにする
 const SelectPlanPage = () => {
+    const { t } = useTranslation();
     const dispatch = useAppDispatch();
 
     const router = useRouter();
@@ -89,7 +90,7 @@ const SelectPlanPage = () => {
             isCreatingPlanFromLocation ||
             isFetchingPlanCandidate
         )
-            return <LoadingModal title="プランを作成しています" />;
+            return <LoadingModal title={t("plan:createPlanInProgressTitle")} />;
 
         // プラン候補取得失敗
         if (fetchCachedCreatedPlansRequestStatus === RequestStatuses.REJECTED)
@@ -129,11 +130,9 @@ const SelectPlanPage = () => {
                         </Box>
                         <VStack spacing="8px">
                             <Text fontSize="1.2rem" fontWeight="bold">
-                                プランを作成できませんでした
+                                {t("plan:createPlanFailedTitle")}
                             </Text>
-                            <Text>
-                                他の場所からプランを作成してみませんか？
-                            </Text>
+                            <Text>{t("plan:createPlanFailedDescription")}</Text>
                         </VStack>
                     </VStack>
                     <AvailablePlaceSection
@@ -174,7 +173,7 @@ const SelectPlanPage = () => {
                         onClick={scrollToPlanDetailPage}
                     >
                         <Text color="white" fontWeight="bold" fontSize="18px">
-                            プランをみてみる
+                            {t("plan:showPlan")}
                         </Text>
                     </ButtonWithBlur>
                 </VStack>
@@ -207,6 +206,7 @@ function PlanDetailPage({
     planCandidateSetId,
     isPlanFooterVisible,
 }: Props) {
+    const { t } = useTranslation();
     const { plan, currentLocation, createdBasedOnCurrentLocation } =
         usePlanCandidate({
             planId: planId,
@@ -268,7 +268,7 @@ function PlanDetailPage({
     });
 
     if (isCreatingPlan) {
-        return <LoadingModal title="プランを作成しています" />;
+        return <LoadingModal title={t("plan:createPlanInProgressTitle")} />;
     }
 
     if (!plan || !planId) {
@@ -306,7 +306,7 @@ function PlanDetailPage({
                     <PlanPageSection
                         sectionHeader={
                             <SectionTitle
-                                title="プランの情報"
+                                title={t("plan:planInfo")}
                                 px={Size.PlanDetail.px}
                             />
                         }
@@ -322,7 +322,7 @@ function PlanDetailPage({
                     <PlanPageSection
                         sectionHeader={
                             <SectionTitle
-                                title="プラン"
+                                title={t("plan:plan")}
                                 px={Size.PlanDetail.px}
                             />
                         }
@@ -350,8 +350,10 @@ function PlanDetailPage({
                     <PlanPageSection
                         sectionHeader={
                             <SectionTitle
-                                title="プラン内の場所"
-                                description="マーカーをクリックすると場所の詳細が表示されます"
+                                title={t("plan:placesInPlan")}
+                                description={t(
+                                    "plan:clickMarkerToShowPlaceDetail"
+                                )}
                                 px={Size.PlanDetail.px}
                             />
                         }
@@ -379,7 +381,7 @@ function PlanDetailPage({
                     borderRadius={20}
                     onClick={() => showReorderDialog()}
                 >
-                    場所を並び替え
+                    {t("plan:reorderPlaces")}
                 </Button>
                 <Button
                     variant="solid"
@@ -389,7 +391,7 @@ function PlanDetailPage({
                     borderRadius={20}
                     onClick={() => createPlan({ planId: plan.id })}
                 >
-                    このプランを保存
+                    {t("plan:saveThisPlan")}
                 </Button>
             </PlanFooter>
             {/*Dialog*/}

--- a/src/view/account/EditUserProfileDialog.tsx
+++ b/src/view/account/EditUserProfileDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "@chakra-ui/react";
 import { useRef, useState } from "react";
 import Cropper from "react-easy-crop";
+import { useTranslation } from "react-i18next";
 import {
     MdArrowBack,
     MdClose,
@@ -157,6 +158,7 @@ function ProfileEditor({
     onClose: () => void;
     onSave: () => void;
 }) {
+    const { t } = useTranslation();
     const [focusUserName, setFocusUserName] = useState(false);
 
     return (
@@ -171,7 +173,7 @@ function ProfileEditor({
         >
             <HStack w="100%" pb={Padding.p16}>
                 <Text flex={1} fontWeight="semibold" fontSize={18}>
-                    プロフィールを編集
+                    {t("account:editProfile")}
                 </Text>
                 <Center as="button" onClick={onClose}>
                     <Icon
@@ -220,7 +222,7 @@ function ProfileEditor({
                             />
                         )}
                         <Text fontWeight={600} fontSize={14}>
-                            編集
+                            {t("common:edit")}
                         </Text>
                     </HStack>
                 </Center>
@@ -240,7 +242,7 @@ function ProfileEditor({
                     }
                     fontSize="12px"
                 >
-                    名前
+                    {t("account:name")}
                 </Text>
                 <Input
                     border="none"
@@ -255,7 +257,7 @@ function ProfileEditor({
                 />
             </VStack>
             <RoundedButton onClick={onSave}>
-                <Text>保存</Text>
+                <Text>{t("common:save")}</Text>
             </RoundedButton>
         </VStack>
     );
@@ -270,6 +272,8 @@ function ProfileImageEditor({
     onSave: (params: { croppedImage: string }) => void;
     onClose: () => void;
 }) {
+    const { t } = useTranslation();
+
     const {
         crop,
         zoom,
@@ -299,7 +303,7 @@ function ProfileImageEditor({
                     />
                 </Center>
                 <Text flex={1} fontWeight="semibold" fontSize={18}>
-                    写真を編集
+                    {t("account:editProfileImage")}
                 </Text>
                 <Button
                     colorScheme="blue"
@@ -307,7 +311,7 @@ function ProfileImageEditor({
                     onClick={handleSave}
                     isLoading={isCropInProgress}
                 >
-                    保存
+                    {t("common:save")}
                 </Button>
             </HStack>
             <Box flex={1} width="100%" overflow="hidden" position="relative">

--- a/src/view/account/LikePlacesList.tsx
+++ b/src/view/account/LikePlacesList.tsx
@@ -1,4 +1,5 @@
 import { Text, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { MdOutlineFavoriteBorder } from "react-icons/md";
 import { Place } from "src/domain/models/Place";
 import { createArrayWithSize } from "src/domain/util/array";
@@ -22,11 +23,12 @@ export function LikePlacesList({
     onSelectLikePlace,
     numPlaceHolders = 6,
 }: Props) {
+    const { t } = useTranslation();
     return (
         <VStack w="100%">
             <PlanListSectionTitle
                 px={Padding.p16}
-                title="お気に入りの場所"
+                title={t("place:favoritePlaces")}
                 icon={MdOutlineFavoriteBorder}
             />
             <HorizontalScrollableList
@@ -89,6 +91,7 @@ function LikePlaces({
 }
 
 function Empty() {
+    const { t } = useTranslation();
     return (
         <VStack
             w="100%"
@@ -114,11 +117,9 @@ function Empty() {
             />
             <VStack spacing={0} alignItems="flex-start">
                 <Text fontSize="1.2rem" fontWeight="bold">
-                    まだ、旅は始まったばかり。
+                    {t("place:favoritePlacesEmptyTitle")}
                 </Text>
-                <Text>
-                    気になった場所に「いいね」すると、そこからプランを作ることができます。
-                </Text>
+                <Text>{t("place:favoritePlacesEmptyDescription")}</Text>
             </VStack>
         </VStack>
     );

--- a/src/view/account/NotLoggedIn.tsx
+++ b/src/view/account/NotLoggedIn.tsx
@@ -45,9 +45,7 @@ export function NotLoggedIn({ onLogin }: Props) {
                     <Text fontSize="32px" fontWeight="bold">
                         {text}
                     </Text>
-                    <Text>
-                        作成したプランやお気に入りの場所をいつでも見られるようになります。
-                    </Text>
+                    <Text>{t("account:promptLoginDescription")}</Text>
                 </VStack>
                 <Center
                     as="button"

--- a/src/view/account/NotLoggedIn.tsx
+++ b/src/view/account/NotLoggedIn.tsx
@@ -1,4 +1,6 @@
 import { Center, Text, VStack, useBreakpointValue } from "@chakra-ui/react";
+import { Trans, useTranslation } from "react-i18next";
+import { TranslationNameSpaces } from "src/locales/i18n";
 import OnTheWayIcon from "src/view/assets/svg/on_the_way.svg";
 
 type Props = {
@@ -6,15 +8,28 @@ type Props = {
 };
 
 export function NotLoggedIn({ onLogin }: Props) {
+    const { t, i18n } = useTranslation();
     const text = useBreakpointValue({
         base: (
-            <>
-                新しい景色に、
-                <br />
-                会いに行こう。
-            </>
+            <Trans
+                t={t}
+                tOptions={{
+                    ns: TranslationNameSpaces,
+                }}
+                i18nKey="account:promptLoginTitle"
+                values={{ br: "<br/>" }}
+            />
         ),
-        sm: "新しい景色に、会いに行こう。",
+        sm: (
+            <Trans
+                t={t}
+                tOptions={{
+                    ns: TranslationNameSpaces,
+                }}
+                i18nKey="account:promptLoginTitle"
+                values={{ br: "" }}
+            />
+        ),
     });
 
     return (
@@ -57,7 +72,7 @@ export function NotLoggedIn({ onLogin }: Props) {
                     onClick={onLogin}
                 >
                     <Text color="#BD9F8E" fontWeight="bold" fontSize="18px">
-                        Googleでログイン
+                        {t("account:loginByGoogle")}
                     </Text>
                 </Center>
             </VStack>

--- a/src/view/account/NotLoggedIn.tsx
+++ b/src/view/account/NotLoggedIn.tsx
@@ -12,11 +12,11 @@ export function NotLoggedIn({ onLogin }: Props) {
     const text = useBreakpointValue({
         base: (
             <AppTrans
-                i18nKey="account:promptLoginTitle"
+                i18nKey="account:loginTitle"
                 values={{ br: <br /> }}
             />
         ),
-        sm: <AppTrans i18nKey="account:promptLoginTitle" values={{ br: "" }} />,
+        sm: <AppTrans i18nKey="account:loginTitle" values={{ br: "" }} />,
     });
 
     return (
@@ -45,7 +45,7 @@ export function NotLoggedIn({ onLogin }: Props) {
                     <Text fontSize="32px" fontWeight="bold">
                         {text}
                     </Text>
-                    <Text>{t("account:promptLoginDescription")}</Text>
+                    <Text>{t("account:loginDescription")}</Text>
                 </VStack>
                 <Center
                     as="button"

--- a/src/view/account/NotLoggedIn.tsx
+++ b/src/view/account/NotLoggedIn.tsx
@@ -1,7 +1,7 @@
 import { Center, Text, VStack, useBreakpointValue } from "@chakra-ui/react";
-import { Trans, useTranslation } from "react-i18next";
-import { TranslationNameSpaces } from "src/locales/i18n";
+import { useTranslation } from "react-i18next";
 import OnTheWayIcon from "src/view/assets/svg/on_the_way.svg";
+import { AppTrans } from "src/view/common/AppTrans";
 
 type Props = {
     onLogin?: () => void;
@@ -11,25 +11,12 @@ export function NotLoggedIn({ onLogin }: Props) {
     const { t, i18n } = useTranslation();
     const text = useBreakpointValue({
         base: (
-            <Trans
-                t={t}
-                tOptions={{
-                    ns: TranslationNameSpaces,
-                }}
+            <AppTrans
                 i18nKey="account:promptLoginTitle"
-                values={{ br: "<br/>" }}
+                values={{ br: <br /> }}
             />
         ),
-        sm: (
-            <Trans
-                t={t}
-                tOptions={{
-                    ns: TranslationNameSpaces,
-                }}
-                i18nKey="account:promptLoginTitle"
-                values={{ br: "" }}
-            />
-        ),
+        sm: <AppTrans i18nKey="account:promptLoginTitle" values={{ br: "" }} />,
     });
 
     return (

--- a/src/view/account/NotLoggedIn.tsx
+++ b/src/view/account/NotLoggedIn.tsx
@@ -10,12 +10,7 @@ type Props = {
 export function NotLoggedIn({ onLogin }: Props) {
     const { t, i18n } = useTranslation();
     const text = useBreakpointValue({
-        base: (
-            <AppTrans
-                i18nKey="account:loginTitle"
-                values={{ br: <br /> }}
-            />
-        ),
+        base: <AppTrans i18nKey="account:loginTitle" values={{ br: <br /> }} />,
         sm: <AppTrans i18nKey="account:loginTitle" values={{ br: "" }} />,
     });
 

--- a/src/view/account/UserCard.tsx
+++ b/src/view/account/UserCard.tsx
@@ -7,6 +7,7 @@ import {
     Text,
     VStack,
 } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { MdOutlineEdit } from "react-icons/md";
 import { User } from "src/domain/models/User";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
@@ -19,6 +20,7 @@ type Props = {
 };
 
 export function UserCard({ user, isEditable = false, onEdit }: Props) {
+    const { t } = useTranslation();
     return (
         <Center
             w="100%"
@@ -47,7 +49,7 @@ export function UserCard({ user, isEditable = false, onEdit }: Props) {
                             color="rgba(0,0,0,.5)"
                             as={MdOutlineEdit}
                         />
-                        <Text>編集</Text>
+                        <Text>{t("common:edit")}</Text>
                     </HStack>
                 )}
                 <Box

--- a/src/view/account/UsersPlan.tsx
+++ b/src/view/account/UsersPlan.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, VStack } from "@chakra-ui/react";
 import { CSSProperties } from "react";
+import { useTranslation } from "react-i18next";
 import { MdOutlineBookmarkBorder } from "react-icons/md";
 import { Transition, TransitionStatus } from "react-transition-group";
 import { Plan } from "src/domain/models/Plan";
@@ -25,6 +26,7 @@ const transitionStyles: {
 };
 
 export function UsersPlan({ plans, isLoading }: Props) {
+    const { t } = useTranslation();
     return (
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -58,7 +60,7 @@ export function UsersPlan({ plans, isLoading }: Props) {
                             ads={false}
                         >
                             <PlanListSectionTitle
-                                title="保存したプラン"
+                                title={t("plan:savedPlans")}
                                 icon={MdOutlineBookmarkBorder}
                                 px={Padding.p16}
                             />
@@ -71,6 +73,7 @@ export function UsersPlan({ plans, isLoading }: Props) {
 }
 
 function Empty() {
+    const { t } = useTranslation();
     return (
         <VStack
             w="100%"

--- a/src/view/account/UsersPlan.tsx
+++ b/src/view/account/UsersPlan.tsx
@@ -99,9 +99,9 @@ function Empty() {
             />
             <VStack spacing={0} alignItems="flex-start">
                 <Text fontSize="1.2rem" fontWeight="bold">
-                    プランを作って、保存しよう！
+                    {t("plan:savedPlansEmptyTitle")}
                 </Text>
-                <Text>保存したプランはいつでも見返すことができます。</Text>
+                <Text>{t("plan:savedPlansEmptyDescription")}</Text>
             </VStack>
         </VStack>
     );

--- a/src/view/common/AppTrans.tsx
+++ b/src/view/common/AppTrans.tsx
@@ -7,7 +7,7 @@ export function AppTrans({
     values,
 }: {
     i18nKey: ParseKeys<Namespace, TOptions, string>;
-    values?: {};
+    values?: { [key: string]: string | number | JSX.Element }
 }) {
     const { t } = useTranslation();
     return (

--- a/src/view/common/AppTrans.tsx
+++ b/src/view/common/AppTrans.tsx
@@ -1,0 +1,23 @@
+import { ParseKeys, type Namespace, type TOptions } from "i18next";
+import { Trans, useTranslation } from "react-i18next";
+import { TranslationNameSpaces } from "src/locales/i18n";
+
+export function AppTrans({
+    i18nKey,
+    values,
+}: {
+    i18nKey: ParseKeys<Namespace, TOptions, string>;
+    values?: {};
+}) {
+    const { t } = useTranslation();
+    return (
+        <Trans
+            t={t}
+            tOptions={{
+                ns: TranslationNameSpaces,
+            }}
+            i18nKey={i18nKey}
+            values={values}
+        />
+    );
+}

--- a/src/view/common/AppTrans.tsx
+++ b/src/view/common/AppTrans.tsx
@@ -15,6 +15,10 @@ export function AppTrans({
             t={t}
             tOptions={{
                 ns: TranslationNameSpaces,
+                interpolation: { escapeValue: false },
+            }}
+            components={{
+                bold: <strong />,
             }}
             i18nKey={i18nKey}
             values={values}

--- a/src/view/common/AppTrans.tsx
+++ b/src/view/common/AppTrans.tsx
@@ -7,7 +7,7 @@ export function AppTrans({
     values,
 }: {
     i18nKey: ParseKeys<Namespace, TOptions, string>;
-    values?: { [key: string]: string | number | JSX.Element }
+    values?: { [key: string]: string | number | JSX.Element };
 }) {
     const { t } = useTranslation();
     return (

--- a/src/view/common/ErrorPage.tsx
+++ b/src/view/common/ErrorPage.tsx
@@ -46,14 +46,14 @@ export function ErrorPage({ navBar }: Props) {
                         borderRadius="50px"
                         onClick={handleReload}
                     >
-                        再読込
+                        {t("common:reload")}
                     </Button>
                     <Link
                         href={Routes.home}
                         w="100%"
                         _hover={{ textDecoration: "none" }}
                     >
-                        <RoundedButton>ホームに戻る</RoundedButton>
+                        <RoundedButton>{t("common:backToHome")}</RoundedButton>
                     </Link>
                 </>
             }

--- a/src/view/common/ErrorPage.tsx
+++ b/src/view/common/ErrorPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@chakra-ui/next-js";
 import { Button } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import { useTranslation } from "react-i18next";
 import Notify from "src/view/assets/svg/notify.svg";
 import { FailurePage } from "src/view/common/FailurePage";
 import { RoundedButton } from "src/view/common/RoundedButton";
@@ -13,6 +14,7 @@ type Props = {
 
 export function ErrorPage({ navBar }: Props) {
     const router = useRouter();
+    const { t } = useTranslation();
 
     const handleReload = () => {
         router.reload();
@@ -23,7 +25,7 @@ export function ErrorPage({ navBar }: Props) {
             navBar={navBar}
             title="505"
             statusMessage="Server Error"
-            statusDescription="サーバーでエラーが発生しました。"
+            statusDescription={t("common:serverError")}
             image={
                 <Notify
                     viewBox="0 0 790 512.20805"

--- a/src/view/common/NotFound.tsx
+++ b/src/view/common/NotFound.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@chakra-ui/next-js";
 import { Image } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { FailurePage } from "src/view/common/FailurePage";
 import { Routes } from "src/view/constants/router";
 import { RoundedButton } from "./RoundedButton";
@@ -9,12 +10,13 @@ type Props = {
 };
 
 export const NotFound = ({ navBar }: Props) => {
+    const { t } = useTranslation();
     return (
         <FailurePage
             navBar={navBar}
             title="404"
             statusMessage="Not Found"
-            statusDescription="お探しのページが見つかりませんでした。"
+            statusDescription={t("common:notFound")}
             image={
                 <Image
                     w="100%"
@@ -29,7 +31,7 @@ export const NotFound = ({ navBar }: Props) => {
                     w="100%"
                     _hover={{ textDecoration: "none" }}
                 >
-                    <RoundedButton>ホームに戻る</RoundedButton>
+                    <RoundedButton>{t("common:backToHome")}</RoundedButton>
                 </Link>
             }
         />

--- a/src/view/constants/meta.tsx
+++ b/src/view/constants/meta.tsx
@@ -1,22 +1,23 @@
-export const PageMetaData = {
+import { TFunction } from "i18next";
+
+export const PageMetaData = (t: TFunction) => ({
     top: {
-        title: "komichi",
-        description: "暇つぶしプランをあなたの代わりに komichi が作ります",
+        title: t("ogp:topPageTitle"),
+        description: t("ogp:topPageDescription"),
     },
     place: {
         search: {
-            title: "好きな場所からプランを作る | komichi",
-            description:
-                "お気に入りの場所や観光名所から、思い出に残るプランを作ります",
+            title: t("ogp:placeSearchPageTitle"),
+            description: t("ogp:placeSearchPageDescription"),
         },
     },
     plans: {
         interest: {
             title: (fromCurrentLocation: boolean) =>
-                `${
-                    fromCurrentLocation ? "近場で" : "好きな場所から"
-                }プランを作る | komichi`,
-            description: "今の気分にあわせて近場で楽しめるプランを作ります",
+                fromCurrentLocation
+                    ? t("ogp:planInterestPageFromCurrentLocationTitle")
+                    : t("ogp:planInterestPageFromSelectedPlaceTitle"),
+            description: t("ogp:planInterestPageDescription"),
         },
     },
-};
+});

--- a/src/view/hooks/useAppTranslation.ts
+++ b/src/view/hooks/useAppTranslation.ts
@@ -1,0 +1,9 @@
+import { Namespace } from "i18next";
+import { useTranslation, UseTranslationResponse } from "react-i18next";
+
+export const useAppTranslation = (): UseTranslationResponse<
+    Namespace,
+    string
+> => {
+    return useTranslation();
+};

--- a/src/view/hooks/useCreatePlanFromSavedPlan.ts
+++ b/src/view/hooks/useCreatePlanFromSavedPlan.ts
@@ -1,6 +1,7 @@
 import { useToast } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { hasValue } from "src/domain/util/null";
 import {
@@ -14,6 +15,7 @@ import { Routes } from "src/view/constants/router";
 export const useCreatePlanFromSavedPlan = () => {
     const dispatch = useAppDispatch();
     const router = useRouter();
+    const { t } = useTranslation();
     const [isCreatingPlanFromSavedPlan, setIsCreatingPlanFromSavedPlan] =
         useState(false);
     const { createPlanSession, createPlanFromSavedPlanRequestStatus } =
@@ -31,7 +33,7 @@ export const useCreatePlanFromSavedPlan = () => {
                 .then(() => {
                     setIsCreatingPlanFromSavedPlan(false);
                     toast({
-                        title: "カスタマイズ用のプランの準備ができました！",
+                        title: t("plan:customizePlanCreated"),
                         status: "success",
                         duration: 3000,
                         isClosable: true,

--- a/src/view/hooks/usePlanPlaceReorder.ts
+++ b/src/view/hooks/usePlanPlaceReorder.ts
@@ -1,5 +1,6 @@
 import { ToastId, useToast } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Place } from "src/domain/models/Place";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { copyObject } from "src/domain/util/object";
@@ -15,6 +16,7 @@ import { usePlanCandidate } from "src/view/hooks/usePlanCandidate";
 export const usePlanPlaceReorder = ({ planId }: { planId: string }) => {
     const dispatch = useAppDispatch();
     const toast = useToast();
+    const { t } = useTranslation();
 
     const { plan, currentLocation, createdBasedOnCurrentLocation } =
         usePlanCandidate({
@@ -49,7 +51,7 @@ export const usePlanPlaceReorder = ({ planId }: { planId: string }) => {
             RequestStatuses.FULFILLED
         ) {
             toastId = toast({
-                title: "並び替えが成功しました",
+                title: t("plan:reorderPlacesSuccess"),
                 status: "success",
                 duration: 3000,
                 isClosable: true,
@@ -59,7 +61,7 @@ export const usePlanPlaceReorder = ({ planId }: { planId: string }) => {
             RequestStatuses.REJECTED
         ) {
             toastId = toast({
-                title: "並び替えに失敗しました",
+                title: t("plan:reorderPlacesFailed"),
                 status: "error",
                 duration: 3000,
                 isClosable: true,

--- a/src/view/hooks/usePwaInstall.ts
+++ b/src/view/hooks/usePwaInstall.ts
@@ -2,14 +2,15 @@ import { useToast } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useEffect, useState } from "react";
 import { isSafari } from "react-device-detect";
+import { useTranslation } from "react-i18next";
 import { hasValue } from "src/domain/util/null";
 import { AnalyticsEvents } from "src/view/constants/analytics";
 import { LocalStorageKeys } from "src/view/constants/localStorageKey";
 import { isPC } from "src/view/constants/userAgent";
 
-// TODO: iOSのインストール手順をダイアログで見せる（インストール手順をスクリーンショットで見せる）
 export const usePwaInstall = () => {
     const toast = useToast();
+    const { t } = useTranslation();
     const [pwaInstallEvent, setPwaInstallEvent] = useState<Event | null>(null);
     const [isPwaSupported, setIsPwaSupported] = useState(false);
     const [isRunningOnPwa, setIsRunningOnPwa] = useState(false);
@@ -50,7 +51,7 @@ export const usePwaInstall = () => {
 
     const markAlreadyInstalledToIosHome = () => {
         toast({
-            title: "ご回答いただき、ありがとうございます。",
+            title: t("pwa:pwaInstallationConfirmedResponse"),
             status: "success",
             duration: 3000,
             isClosable: true,
@@ -100,7 +101,7 @@ export const usePwaInstall = () => {
 
     const handleAppInstalled = () => {
         toast({
-            title: "ホームに追加されました",
+            title: t("pwa:addedToHomeScreen"),
             status: "success",
             duration: 5000,
             isClosable: true,

--- a/src/view/hooks/useUploadPlaceImage.ts
+++ b/src/view/hooks/useUploadPlaceImage.ts
@@ -8,6 +8,7 @@ import {
     uploadBytesResumable,
 } from "firebase/storage";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { getFileExtension } from "src/domain/util/file";
 import { reduxAuthSelector } from "src/redux/auth";
 import { reduxPlanSelector, uploadPlacePhotosInPlan } from "src/redux/plan";
@@ -40,6 +41,7 @@ export type UploadPlaceImageProps = {
 const useUploadPlaceImage = () => {
     const dispatch = useAppDispatch();
     const toast = useToast();
+    const { t } = useTranslation();
 
     const [localPlaceImageFiles, setLocalPlaceImageFiles] = useState<
         PlaceImageFile[]
@@ -125,7 +127,7 @@ const useUploadPlaceImage = () => {
             );
 
             toast({
-                title: "画像のアップロードが完了しました",
+                title: t("place:uploadPlacePhotoSuccess"),
                 status: "success",
                 duration: 3000,
                 isClosable: true,
@@ -134,8 +136,8 @@ const useUploadPlaceImage = () => {
             setUploadRequestStatus(UploadRequestStatus.FULFILLED);
         } catch (error) {
             toast({
-                title: "画像のアップロードに失敗しました",
-                description: "もう一度試してみてください。",
+                title: t("place:uploadPlacePhotoFailed"),
+                description: t("place:uploadPlacePhotoFailedDescription"),
                 status: "error",
                 duration: 5000,
                 isClosable: true,

--- a/src/view/hooks/useUserPlan.ts
+++ b/src/view/hooks/useUserPlan.ts
@@ -1,10 +1,12 @@
 import { useToast } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { reduxAuthSelector } from "src/redux/auth";
 import { reduxPlanSelector, updatePlaceLikeInPlan } from "src/redux/plan";
 import { useAppDispatch } from "src/redux/redux";
 
 export const useUserPlan = () => {
     const dispatch = useAppDispatch();
+    const { t } = useTranslation();
     const { likePlaceIds } = reduxPlanSelector();
     const { user, firebaseIdToken } = reduxAuthSelector();
     const toast = useToast();
@@ -21,7 +23,7 @@ export const useUserPlan = () => {
         if (!user || !firebaseIdToken) {
             // TODO: ダイアログで表示する
             toast({
-                title: "ログインすると気に入った場所を保存することができます。",
+                title: t("place:loginToSaveFavoritePlace"),
                 status: "info",
                 duration: 3000,
                 isClosable: true,

--- a/src/view/mdx/MdxBlogLayout.tsx
+++ b/src/view/mdx/MdxBlogLayout.tsx
@@ -8,9 +8,11 @@ import {
     VStack,
 } from "@chakra-ui/react";
 import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { MDXBlogProvider } from "src/view/mdx/MDXBlogProvider";
 import { MdxMeta } from "src/view/mdx/MdxMeta";
 import { NavBar } from "src/view/navigation/NavBar";
+import { TransactFn } from "store2";
 
 type Props = {
     children?: ReactNode;
@@ -40,17 +42,25 @@ export function MdxBlogLayout({ children, meta }: Props) {
     );
 }
 
-const formatDate = (dateString: string) => {
+const formatDate = (t: TransactFn, dateString: string) => {
     const date = new Date(dateString);
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const day = date.getDate();
     const hour = ("0" + date.getHours()).slice(-2);
     const minute = ("0" + date.getMinutes()).slice(-2);
-    return `${year}月${month}年${day}日 ${hour}:${minute}`;
+    // @ts-ignore
+    return t("common:YYYYMMDDHHMM", {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+    });
 };
 
 const Header = ({ meta }: { meta: MdxMeta }) => {
+    const { t } = useTranslation();
     return (
         <VStack w="100%" alignItems="flex-start">
             <Image src={meta.image} w="100%" mt={{ base: 0, sm: "32px" }} />
@@ -68,7 +78,9 @@ const Header = ({ meta }: { meta: MdxMeta }) => {
                 <Avatar src={meta.authorImage} name={meta.author} size="md" />
                 <VStack alignItems="flex-start" spacing={0}>
                     <Text>{meta.author}</Text>
-                    <Text color="rgba(0,0,0,.6)">{formatDate(meta.date)}</Text>
+                    <Text color="rgba(0,0,0,.6)">
+                        {formatDate(t, meta.date)}
+                    </Text>
                 </VStack>
             </HStack>
         </VStack>

--- a/src/view/mdx/MdxBlogLayout.tsx
+++ b/src/view/mdx/MdxBlogLayout.tsx
@@ -7,12 +7,12 @@ import {
     Text,
     VStack,
 } from "@chakra-ui/react";
+import { Namespace, TFunction } from "i18next";
 import { ReactNode } from "react";
-import { useTranslation } from "react-i18next";
+import { useAppTranslation } from "src/view/hooks/useAppTranslation";
 import { MDXBlogProvider } from "src/view/mdx/MDXBlogProvider";
 import { MdxMeta } from "src/view/mdx/MdxMeta";
 import { NavBar } from "src/view/navigation/NavBar";
-import { TransactFn } from "store2";
 
 type Props = {
     children?: ReactNode;
@@ -42,14 +42,13 @@ export function MdxBlogLayout({ children, meta }: Props) {
     );
 }
 
-const formatDate = (t: TransactFn, dateString: string) => {
+const formatDate = (t: TFunction<Namespace, string>, dateString: string) => {
     const date = new Date(dateString);
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const day = date.getDate();
     const hour = ("0" + date.getHours()).slice(-2);
     const minute = ("0" + date.getMinutes()).slice(-2);
-    // @ts-ignore
     return t("common:YYYYMMDDHHMM", {
         year,
         month,
@@ -60,7 +59,7 @@ const formatDate = (t: TransactFn, dateString: string) => {
 };
 
 const Header = ({ meta }: { meta: MdxMeta }) => {
-    const { t } = useTranslation();
+    const { t } = useAppTranslation();
     return (
         <VStack w="100%" alignItems="flex-start">
             <Image src={meta.image} w="100%" mt={{ base: 0, sm: "32px" }} />

--- a/src/view/navigation/BottomNavigation.tsx
+++ b/src/view/navigation/BottomNavigation.tsx
@@ -4,6 +4,7 @@ import { IconType } from "react-icons";
 import { MdAccountCircle, MdHome, MdSearch } from "react-icons/md";
 import { Routes } from "src/view/constants/router";
 import { Size } from "src/view/constants/size";
+import {useTranslation} from "react-i18next";
 
 type Props = {
     page: NavigationPage;
@@ -18,6 +19,7 @@ export type NavigationPage =
     (typeof BottomNavigationPages)[keyof typeof BottomNavigationPages];
 
 export function BottomNavigation({ page }: Props) {
+    const {t} = useTranslation();
     return (
         <Center
             as="nav"
@@ -31,19 +33,19 @@ export function BottomNavigation({ page }: Props) {
             <HStack w="100%" maxW="600px">
                 <NavigationItem
                     icon={MdHome}
-                    label="ホーム"
+                    label={t("navigation:home")}
                     link={Routes.home}
                     isActive={page === BottomNavigationPages.Home}
                 />
                 <NavigationItem
                     icon={MdSearch}
-                    label="探す"
+                    label={t("navigation:search")}
                     link={Routes.search}
                     isActive={page === BottomNavigationPages.Search}
                 />
                 <NavigationItem
                     icon={MdAccountCircle}
-                    label="マイページ"
+                    label={t("navigation:myPage")}
                     link={Routes.account}
                     isActive={page === BottomNavigationPages.Account}
                 />

--- a/src/view/navigation/BottomNavigation.tsx
+++ b/src/view/navigation/BottomNavigation.tsx
@@ -1,10 +1,10 @@
 import { Link } from "@chakra-ui/next-js";
 import { Center, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { IconType } from "react-icons";
 import { MdAccountCircle, MdHome, MdSearch } from "react-icons/md";
 import { Routes } from "src/view/constants/router";
 import { Size } from "src/view/constants/size";
-import {useTranslation} from "react-i18next";
 
 type Props = {
     page: NavigationPage;
@@ -19,7 +19,7 @@ export type NavigationPage =
     (typeof BottomNavigationPages)[keyof typeof BottomNavigationPages];
 
 export function BottomNavigation({ page }: Props) {
-    const {t} = useTranslation();
+    const { t } = useTranslation();
     return (
         <Center
             as="nav"

--- a/src/view/place/PlaceRecommendationDialog.tsx
+++ b/src/view/place/PlaceRecommendationDialog.tsx
@@ -116,7 +116,7 @@ const Loading = () => {
                     color={Colors.primary[400]}
                     size="32px"
                 />
-                <Text>{t("place:promptRecommendedTouristSpotsSearching")}</Text>
+                <Text>{t("place:recommendedTouristSpotsSearching")}</Text>
             </VStack>
         </Center>
     );
@@ -128,7 +128,7 @@ const Error = ({ onRetry }: { onRetry?: () => void }) => {
         <Center w="100%" h="100%">
             <VStack w="100%" spacing="16px">
                 <TowingIcon viewBox="0 0 648 648" height="300px" />
-                <Text>{t("place:recommendedTouristSearchFailed")}</Text>
+                <Text>{t("place:recommendedTouristSpotsSearchFailed")}</Text>
                 {onRetry && (
                     <RoundedButton onClick={onRetry}>
                         {t("common:retry")}

--- a/src/view/place/PlaceRecommendationDialog.tsx
+++ b/src/view/place/PlaceRecommendationDialog.tsx
@@ -8,6 +8,7 @@ import {
     Text,
     VStack,
 } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { MdClose } from "react-icons/md";
 import { Place } from "src/domain/models/Place";
 import {
@@ -42,6 +43,7 @@ export function PlaceRecommendationDialog({
     onRetry,
     onSelectPlace,
 }: Props) {
+    const { t } = useTranslation();
     return (
         <FullscreenDialog
             position={DialogPositions.BOTTOM}
@@ -69,7 +71,7 @@ export function PlaceRecommendationDialog({
                                 fontSize="20px"
                                 textAlign="center"
                             >
-                                おすすめの観光地
+                                {t("place:recommendedTouristSpotsTitle")}
                             </Text>
                             <Center
                                 cursor="pointer"
@@ -105,6 +107,7 @@ export function PlaceRecommendationDialog({
 }
 
 const Loading = () => {
+    const { t } = useTranslation();
     return (
         <Center w="100%" h="100%">
             <VStack spacing="16px">
@@ -113,20 +116,23 @@ const Loading = () => {
                     color={Colors.primary[400]}
                     size="32px"
                 />
-                <Text>おすすめの観光地を探しています...</Text>
+                <Text>{t("place:promptRecommendedTouristSpotsSearching")}</Text>
             </VStack>
         </Center>
     );
 };
 
 const Error = ({ onRetry }: { onRetry?: () => void }) => {
+    const { t } = useTranslation();
     return (
         <Center w="100%" h="100%">
             <VStack w="100%" spacing="16px">
                 <TowingIcon viewBox="0 0 648 648" height="300px" />
-                <Text>おすすめの観光地を取得中にエラーが発生しました。</Text>
+                <Text>{t("place:recommendedTouristSearchFailed")}</Text>
                 {onRetry && (
-                    <RoundedButton onClick={onRetry}>再試行</RoundedButton>
+                    <RoundedButton onClick={onRetry}>
+                        {t("common:retry")}
+                    </RoundedButton>
                 )}
             </VStack>
         </Center>

--- a/src/view/place/PlaceSearchBar.tsx
+++ b/src/view/place/PlaceSearchBar.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@chakra-ui/react";
 import { FormEvent, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { MdClose, MdSearch } from "react-icons/md";
 import { hasValue } from "src/domain/util/null";
 import styled from "styled-components";
@@ -10,6 +11,7 @@ type Props = {
 };
 
 export function PlaceSearchBar({ defaultValue = "", onSearch }: Props) {
+    const { t } = useTranslation();
     const [lastUsedQuery, setLastUsedQuery] = useState<string | null>(null);
     const [value, setValue] = useState(defaultValue);
 
@@ -56,7 +58,7 @@ export function PlaceSearchBar({ defaultValue = "", onSearch }: Props) {
                 <TextField
                     autoFocus
                     type="text"
-                    placeholder="場所を検索"
+                    placeholder={t("place:searchPlace")}
                     value={value}
                     onChange={(e) => setValue(e.currentTarget.value)}
                 />

--- a/src/view/place/ShowPlaceRecommendationButton.tsx
+++ b/src/view/place/ShowPlaceRecommendationButton.tsx
@@ -1,10 +1,12 @@
 import { Box, Text } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 
 type Props = {
     onClick?: () => void;
 };
 
 export function ShowPlaceRecommendationButton({ onClick }: Props) {
+    const { t } = useTranslation();
     return (
         <Box
             cursor="pointer"
@@ -15,7 +17,9 @@ export function ShowPlaceRecommendationButton({ onClick }: Props) {
             boxShadow="2px 2px 4px #A2A2A2"
             onClick={onClick}
         >
-            <Text color="#2D59C9">おすすめの場所を表示する</Text>
+            <Text color="#2D59C9">
+                {t("place:showRecommendedTouristSpots")}
+            </Text>
         </Box>
     );
 }

--- a/src/view/place/ShowPlaceRecommendationButton.tsx
+++ b/src/view/place/ShowPlaceRecommendationButton.tsx
@@ -18,7 +18,7 @@ export function ShowPlaceRecommendationButton({ onClick }: Props) {
             onClick={onClick}
         >
             <Text color="#2D59C9">
-                {t("place:showRecommendedTouristSpots")}
+                {t("place:recommendedTouristSpotsShow")}
             </Text>
         </Box>
     );

--- a/src/view/plan/NearbyPlanList.tsx
+++ b/src/view/plan/NearbyPlanList.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { MdOutlineExplore } from "react-icons/md";
 import { Plan } from "src/domain/models/Plan";
 import { isPC } from "src/view/constants/userAgent";
@@ -27,6 +28,7 @@ export function NearbyPlanList({
     isFetchingCurrentLocation,
     onRequestFetchNearByPlans,
 }: Props) {
+    const { t } = useTranslation();
     return (
         <PlanList
             plans={plans}
@@ -43,7 +45,7 @@ export function NearbyPlanList({
             px={px}
         >
             <PlanListSectionTitle
-                title="近くのプラン"
+                title={t("plan:nearbyPlans")}
                 icon={MdOutlineExplore}
                 px={px}
             />

--- a/src/view/plan/PlaceMap.tsx
+++ b/src/view/plan/PlaceMap.tsx
@@ -1,6 +1,7 @@
 import { Box, Center, HStack, Text, VStack } from "@chakra-ui/react";
 import { InfoWindow, Marker } from "@react-google-maps/api";
 import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ImageSizes, getImageSizeOf } from "src/domain/models/Image";
 import { Place } from "src/domain/models/Place";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
@@ -19,9 +20,14 @@ export const PlaceMap = ({ places }: Props) => {
 };
 
 const Map = ({ places }: { places: Place[] }) => {
+    const { t } = useTranslation();
     if (places.length === 0)
         return (
-            <MapPlaceHolder text="プランに場所が含まれていないため表示できません。" />
+            <MapPlaceHolder
+                text={t(
+                    "plan:cannotDisplayBecauseThePlanDoesNotContainAnyPlaces"
+                )}
+            />
         );
 
     return (
@@ -33,9 +39,7 @@ const Map = ({ places }: { places: Place[] }) => {
                 lat: places[0].location.latitude,
                 lng: places[0].location.longitude,
             }}
-            loadingPlaceHolder={
-                <MapPlaceHolder text="地図を読み込んでいます" />
-            }
+            loadingPlaceHolder={<MapPlaceHolder text={t("plan:loadingMap")} />}
         >
             {places.map((place, i) => (
                 <PlaceMarkerWithInfoWindow
@@ -55,6 +59,7 @@ const PlaceMarkerWithInfoWindow = ({
     place: Place;
     defaultVisible?: boolean;
 }) => {
+    const { t } = useTranslation();
     const [isInfoWindowVisible, setIsInfoWindowVisible] =
         useState(defaultVisible);
     const markerRef = useRef<Marker>(null);
@@ -109,7 +114,7 @@ const PlaceMarkerWithInfoWindow = ({
                                 as="button"
                                 onClick={() => setIsInfoWindowVisible(false)}
                             >
-                                閉じる
+                                {t("common:close")}
                             </Text>
                         </VStack>
                     </HStack>

--- a/src/view/plan/PlanCreatedDialog.tsx
+++ b/src/view/plan/PlanCreatedDialog.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import HappyNewsIcon from "src/view/assets/svg/happy_news.svg";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
-import {useTranslation} from "react-i18next";
 
 export type Props = {
     visible: boolean;
@@ -14,7 +14,7 @@ export function PlanCreatedDialog({
     onClickClose,
     visible,
 }: Props) {
-    const {t} = useTranslation();
+    const { t } = useTranslation();
     return (
         <FullscreenDialog onClickOutside={onClickClose} visible={visible}>
             <VStack

--- a/src/view/plan/PlanCreatedDialog.tsx
+++ b/src/view/plan/PlanCreatedDialog.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, VStack } from "@chakra-ui/react";
 import HappyNewsIcon from "src/view/assets/svg/happy_news.svg";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
+import {useTranslation} from "react-i18next";
 
 export type Props = {
     visible: boolean;
@@ -13,6 +14,7 @@ export function PlanCreatedDialog({
     onClickClose,
     visible,
 }: Props) {
+    const {t} = useTranslation();
     return (
         <FullscreenDialog onClickOutside={onClickClose} visible={visible}>
             <VStack
@@ -32,7 +34,7 @@ export function PlanCreatedDialog({
                     }}
                 />
                 <Text fontSize="24px" fontWeight="bold">
-                    プランが完成しました!
+                    {t("plan:planCreatedSuccessfullyTitle")}
                 </Text>
                 <VStack spacing="8px" w="100%">
                     <Box
@@ -46,7 +48,7 @@ export function PlanCreatedDialog({
                         fontSize="16px"
                         onClick={onClickCopyUrl}
                     >
-                        プランのURLをコピー
+                        {t("plan:copyPlanUrl")}
                     </Box>
                     <Box
                         as="button"
@@ -57,7 +59,7 @@ export function PlanCreatedDialog({
                         fontSize="16px"
                         onClick={onClickClose}
                     >
-                        とじる
+                        {t("common:close")}
                     </Box>
                 </VStack>
             </VStack>

--- a/src/view/plan/PlanGenerationFailure.tsx
+++ b/src/view/plan/PlanGenerationFailure.tsx
@@ -16,7 +16,7 @@ export const PlanGenerationFailure = ({ navBar }: Props) => {
         <FailurePage
             title="Sorry"
             navBar={navBar}
-            statusDescription={t("plan:failedToCreatePlan")}
+            statusDescription={t("plan:createPlanFailed")}
             image={
                 <Image
                     w="100%"

--- a/src/view/plan/PlanGenerationFailure.tsx
+++ b/src/view/plan/PlanGenerationFailure.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@chakra-ui/next-js";
 import { Image } from "@chakra-ui/react";
 import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { FailurePage } from "src/view/common/FailurePage";
 import { Routes } from "src/view/constants/router";
 import { RoundedButton } from "../common/RoundedButton";
@@ -10,11 +11,12 @@ type Props = {
 };
 
 export const PlanGenerationFailure = ({ navBar }: Props) => {
+    const { t } = useTranslation();
     return (
         <FailurePage
             title="Sorry"
             navBar={navBar}
-            statusDescription="プランを作成することができませんでした。"
+            statusDescription={t("plan:failedToCreatePlan")}
             image={
                 <Image
                     w="100%"
@@ -29,7 +31,7 @@ export const PlanGenerationFailure = ({ navBar }: Props) => {
                     w="100%"
                     _hover={{ textDecoration: "none" }}
                 >
-                    <RoundedButton>ホームに戻る</RoundedButton>
+                    <RoundedButton>{t("common:backToHome")}</RoundedButton>
                 </Link>
             }
         />

--- a/src/view/plan/PlanListUser.tsx
+++ b/src/view/plan/PlanListUser.tsx
@@ -1,4 +1,5 @@
 import { Text } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { Plan } from "src/domain/models/Plan";
 import { User } from "src/domain/models/User";
 import { PlanList } from "src/view/plan/PlanList";
@@ -10,6 +11,7 @@ type Props = {
 };
 
 export function PlanListUser({ user, plans, isLoading = false }: Props) {
+    const { t } = useTranslation();
     if (!user) return <></>;
 
     return (
@@ -23,7 +25,7 @@ export function PlanListUser({ user, plans, isLoading = false }: Props) {
                 textAlign="center"
                 py="16x"
             >
-                保存したプラン
+                {t("plan:savedPlans")}
             </Text>
         </PlanList>
     );

--- a/src/view/plan/PlanScreenShotComponent.tsx
+++ b/src/view/plan/PlanScreenShotComponent.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, VStack } from "@chakra-ui/react";
 import { MutableRefObject, forwardRef } from "react";
+import { useTranslation } from "react-i18next";
 import { Place } from "src/domain/models/Place";
 import { Plan } from "src/domain/models/Plan";
 import { hasValue } from "src/domain/util/null";
@@ -35,6 +36,7 @@ export const PlanScreenShotComponent = forwardRef<HTMLDivElement, Props>(
 );
 
 const PlaceListItem = ({ place }: { place: Place }) => {
+    const { t } = useTranslation();
     return (
         <VStack
             spacing={0}
@@ -46,7 +48,7 @@ const PlaceListItem = ({ place }: { place: Place }) => {
             <Text fontSize="16px">{place.name}</Text>
             {hasValue(place.address) && (
                 <Text fontSize="16px" color="#808080">
-                    住所 {place.address}
+                    {t("place:address")} {place.address}
                 </Text>
             )}
         </VStack>

--- a/src/view/plan/PlanSummary.tsx
+++ b/src/view/plan/PlanSummary.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { IconType } from "react-icons";
 import { MdCurrencyYen, MdSchedule } from "react-icons/md";
 import { DateHelper } from "src/domain/util/date";
-import { AppTrans } from "src/view/common/AppTrans";
+import { useAppTranslation } from "src/view/hooks/useAppTranslation";
 import styled from "styled-components";
 
 type Props = {
@@ -69,18 +69,14 @@ export const PlanSummaryBudget = ({
     minBudget: number;
     maxBudget: number;
 }) => {
-    const { t } = useTranslation();
+    const { t } = useAppTranslation();
     return (
         <PlanSummary title={t("common:budget")} icon={MdCurrencyYen}>
             <VStack alignItems="flex-start" w="100%" spacing={0}>
                 {minBudget > 0 && <Text>{`${minBudget}`}</Text>}
                 {maxBudget > 0 && (
                     <Text>
-                        ~
-                        <AppTrans
-                            i18nKey="common:priceLabel"
-                            values={{ price: maxBudget }}
-                        />
+                        `~${t("common:priceLabel", { price: maxBudget })}`
                     </Text>
                 )}
             </VStack>

--- a/src/view/plan/PlanSummary.tsx
+++ b/src/view/plan/PlanSummary.tsx
@@ -1,5 +1,6 @@
 import { Box, Icon, Text, VStack } from "@chakra-ui/react";
 import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { IconType } from "react-icons";
 import { MdCurrencyYen, MdSchedule } from "react-icons/md";
 import { DateHelper } from "src/domain/util/date";
@@ -45,12 +46,13 @@ export const PlanSummaryDuration = ({
 }: {
     durationInMinutes: number;
 }) => {
+    const { t } = useTranslation();
     const endPlanDate = DateHelper.add(
         new Date(),
         durationInMinutes * DateHelper.Minute
     );
     return (
-        <PlanSummary title="時間" icon={MdSchedule}>
+        <PlanSummary title={t("common:time")} icon={MdSchedule}>
             <VStack alignItems="flex-start" w="100%" spacing={0}>
                 <Text>{DateHelper.formatHHMM(durationInMinutes)}</Text>
                 <Text color="gray">~ {DateHelper.dateToHHMM(endPlanDate)}</Text>
@@ -66,8 +68,9 @@ export const PlanSummaryBudget = ({
     minBudget: number;
     maxBudget: number;
 }) => {
+    const { t } = useTranslation();
     return (
-        <PlanSummary title="予算" icon={MdCurrencyYen}>
+        <PlanSummary title={t("common:budget")} icon={MdCurrencyYen}>
             <VStack alignItems="flex-start" w="100%" spacing={0}>
                 {minBudget > 0 && <Text>{`${minBudget}`}</Text>}
                 {maxBudget > 0 && <Text>{`~${maxBudget}円`}</Text>}

--- a/src/view/plan/PlanSummary.tsx
+++ b/src/view/plan/PlanSummary.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { IconType } from "react-icons";
 import { MdCurrencyYen, MdSchedule } from "react-icons/md";
 import { DateHelper } from "src/domain/util/date";
+import { AppTrans } from "src/view/common/AppTrans";
 import styled from "styled-components";
 
 type Props = {
@@ -73,7 +74,15 @@ export const PlanSummaryBudget = ({
         <PlanSummary title={t("common:budget")} icon={MdCurrencyYen}>
             <VStack alignItems="flex-start" w="100%" spacing={0}>
                 {minBudget > 0 && <Text>{`${minBudget}`}</Text>}
-                {maxBudget > 0 && <Text>{`~${maxBudget}円`}</Text>}
+                {maxBudget > 0 && (
+                    <Text>
+                        ~
+                        <AppTrans
+                            i18nKey="common:priceLabel"
+                            values={{ price: maxBudget }}
+                        />
+                    </Text>
+                )}
             </VStack>
         </PlanSummary>
     );

--- a/src/view/plan/button/SavePlanAsImageButton.tsx
+++ b/src/view/plan/button/SavePlanAsImageButton.tsx
@@ -1,16 +1,18 @@
 import { Box } from "@chakra-ui/react";
 import html2canvas from "html2canvas";
 import { useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { MdOutlinePhotoCamera } from "react-icons/md";
 import { Plan } from "src/domain/models/Plan";
-import { PlanActionButton } from "src/view/plan/button/PlanActionButton";
 import { PlanScreenShotComponent } from "src/view/plan/PlanScreenShotComponent";
+import { PlanActionButton } from "src/view/plan/button/PlanActionButton";
 
 type Props = {
     plan: Plan;
 };
 
 export function SavePlanAsImageButton({ plan }: Props) {
+    const { t } = useTranslation();
     const plansRef = useRef<HTMLDivElement>();
 
     const handleOnClickSaveAsImage = async () => {
@@ -36,7 +38,7 @@ export function SavePlanAsImageButton({ plan }: Props) {
     return (
         <>
             <PlanActionButton
-                text="画像で保存する"
+                text={t("plan:saveAsImage")}
                 icon={MdOutlinePhotoCamera}
                 onClick={handleOnClickSaveAsImage}
             />

--- a/src/view/plan/button/SearchRouteByGoogleMapButton.tsx
+++ b/src/view/plan/button/SearchRouteByGoogleMapButton.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { useTranslation } from "react-i18next";
 import { GeoLocation } from "src/domain/models/GeoLocation";
 import { Plan } from "src/domain/models/Plan";
 import { generateGoogleMapUrl } from "src/domain/util/googleMap";
@@ -15,6 +16,7 @@ export function SearchRouteByGoogleMapButton({
     currentLocation,
     createdBasedOnCurrentLocation,
 }: Props) {
+    const { t } = useTranslation();
     const startLocationOfRoute =
         currentLocation && createdBasedOnCurrentLocation
             ? currentLocation
@@ -30,7 +32,7 @@ export function SearchRouteByGoogleMapButton({
             style={{ width: "100%" }}
         >
             <PlanActionButton
-                text="Google Mapで経路を調べる"
+                text={t("plan:searchRouteOnGoogleMaps")}
                 imageUrl="/images/google_map_logo.png"
             />
         </Link>

--- a/src/view/plan/candidate/AvailablePlaceSection.tsx
+++ b/src/view/plan/candidate/AvailablePlaceSection.tsx
@@ -1,4 +1,5 @@
 import { Grid, Text, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { Place } from "src/domain/models/Place";
 import { createArrayWithSize } from "src/domain/util/array";
 import { AvailablePlace } from "src/view/plan/candidate/AvailablePlace";
@@ -14,12 +15,13 @@ export function AvailablePlaceSection({
     isFetching,
     onClickPlace,
 }: Props) {
+    const { t } = useTranslation();
     if (!places && !isFetching) return <></>;
 
     return (
         <VStack w="100%" maxW="600px" alignItems="flex-start">
             <Text fontWeight="bold" fontSize="20px">
-                他の場所からプランを作る
+                {t("plan:createPlanFromOtherLocation")}
             </Text>
             <Grid
                 w="100%"

--- a/src/view/plan/candidate/GeneratingPlanDialog.tsx
+++ b/src/view/plan/candidate/GeneratingPlanDialog.tsx
@@ -1,11 +1,11 @@
 import { Box, Center, Text, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 import { LottiePlayer } from "src/view/common/LottiePlayer";
 import { RoundedButton } from "src/view/common/RoundedButton";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
 import animationDataCreating from "src/view/lottie/creating_map.json";
 import animationDataFailed from "src/view/lottie/fail.json";
-import {useTranslation} from "react-i18next";
 
 type Props = {
     onClose: () => void;
@@ -41,7 +41,7 @@ export function GeneratingPlanDialog({ visible, failed, onClose }: Props) {
 }
 
 function Generating() {
-    const {t} = useTranslation();
+    const { t } = useTranslation();
     return (
         <VStack>
             <Box position="relative" h="100px" w="100%" my="32px">
@@ -58,7 +58,7 @@ function Generating() {
 }
 
 function Failed({ onClose }: { onClose: () => void }) {
-    const {t} = useTranslation();
+    const { t } = useTranslation();
     return (
         <VStack spacing="16px">
             <VStack>
@@ -73,9 +73,7 @@ function Failed({ onClose }: { onClose: () => void }) {
                     {t("plan:planCreateFailedTitle")}
                 </Text>
             </VStack>
-            <RoundedButton onClick={onClose}>
-                {t("common:close")}
-            </RoundedButton>
+            <RoundedButton onClick={onClose}>{t("common:close")}</RoundedButton>
         </VStack>
     );
 }

--- a/src/view/plan/candidate/GeneratingPlanDialog.tsx
+++ b/src/view/plan/candidate/GeneratingPlanDialog.tsx
@@ -5,6 +5,7 @@ import { RoundedButton } from "src/view/common/RoundedButton";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
 import animationDataCreating from "src/view/lottie/creating_map.json";
 import animationDataFailed from "src/view/lottie/fail.json";
+import {useTranslation} from "react-i18next";
 
 type Props = {
     onClose: () => void;
@@ -40,6 +41,7 @@ export function GeneratingPlanDialog({ visible, failed, onClose }: Props) {
 }
 
 function Generating() {
+    const {t} = useTranslation();
     return (
         <VStack>
             <Box position="relative" h="100px" w="100%" my="32px">
@@ -49,13 +51,14 @@ function Generating() {
                 />
             </Box>
             <Text fontSize="24px" fontWeight="bold">
-                プランを作成しています
+                {t("plan:planCreatingTitle")}
             </Text>
         </VStack>
     );
 }
 
 function Failed({ onClose }: { onClose: () => void }) {
+    const {t} = useTranslation();
     return (
         <VStack spacing="16px">
             <VStack>
@@ -67,10 +70,12 @@ function Failed({ onClose }: { onClose: () => void }) {
                     />
                 </Box>
                 <Text fontSize="24px" fontWeight="bold">
-                    プランの作成に失敗しました
+                    {t("plan:planCreateFailedTitle")}
                 </Text>
             </VStack>
-            <RoundedButton onClick={onClose}>閉じる</RoundedButton>
+            <RoundedButton onClick={onClose}>
+                {t("common:close")}
+            </RoundedButton>
         </VStack>
     );
 }

--- a/src/view/plancandidate/DialogAddPlace.tsx
+++ b/src/view/plancandidate/DialogAddPlace.tsx
@@ -1,6 +1,7 @@
 import { Place } from "src/domain/models/Place";
 import { PlacesWithCategory } from "src/domain/models/PlacesWithCategory";
 import { Transition } from "src/domain/models/Transition";
+import { useAppTranslation } from "src/view/hooks/useAppTranslation";
 import { DialogRelatedPlaces } from "src/view/plancandidate/DialogRelatedPlaces";
 
 type Props = {
@@ -22,16 +23,17 @@ export function DialogAddPlace({
     onAddPlaceToPlan,
     onCloseDialog,
 }: Props) {
+    const { t } = useAppTranslation();
     return (
         <DialogRelatedPlaces
             visible={isDialogVisible}
-            titleConfirmScreen="この場所を追加しますか？"
-            titleSelectScreen="プランに新しい場所を追加する"
+            titleConfirmScreen={t("plan:addNewPlaceToPlanConfirmTitle")}
+            titleSelectScreen={t("plan:addNewPlaceToPlanTitle")}
             placesRecommended={placesRecommended}
             placesWithCategories={placesWithCategories}
             transitions={transitions}
             updating={isAddingPlace}
-            buttonLabelUpdatePlace="追加"
+            buttonLabelUpdatePlace={t("common:add")}
             onClose={onCloseDialog}
             onClickRelatedPlace={(placeId) =>
                 onAddPlaceToPlan({

--- a/src/view/plancandidate/DialogDeletePlace.tsx
+++ b/src/view/plancandidate/DialogDeletePlace.tsx
@@ -10,7 +10,9 @@ import {
 } from "@chakra-ui/react";
 import { ImageSizes, getImageSizeOf } from "src/domain/models/Image";
 import { Place } from "src/domain/models/Place";
+import { AppTrans } from "src/view/common/AppTrans";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
+import { useAppTranslation } from "src/view/hooks/useAppTranslation";
 
 type Props = {
     placeToDelete: Place | null;
@@ -27,6 +29,7 @@ export function DialogDeletePlace({
     onDelete,
     onClose,
 }: Props) {
+    const { t } = useAppTranslation();
     const image =
         placeToDelete && placeToDelete.images.length > 0
             ? placeToDelete.images[0]
@@ -92,12 +95,15 @@ export function DialogDeletePlace({
                                 )}
                             </Box>
                             <Text fontSize="18px">
-                                <b>「{placeToDelete.name}」</b>を削除しますか？
+                                <AppTrans
+                                    i18nKey="plan:deletePlaceFromPlanConfirmTitle"
+                                    values={{ name: placeToDelete.name }}
+                                />
                             </Text>
                         </VStack>
                         <HStack mt="auto" pb="48px">
                             <Button onClick={onClose} variant="text">
-                                キャンセル
+                                {t("common:cancel")}
                             </Button>
                             <Button
                                 onClick={() =>
@@ -107,7 +113,7 @@ export function DialogDeletePlace({
                                 }
                                 colorScheme="red"
                             >
-                                削除
+                                {t("common:delete")}
                             </Button>
                         </HStack>
                     </VStack>

--- a/src/view/plancandidate/DialogRelatedPlaces.tsx
+++ b/src/view/plancandidate/DialogRelatedPlaces.tsx
@@ -250,6 +250,7 @@ export function PlaceListItem({
     images: ImageType[];
     onClick: OnClickHandler;
 }) {
+    const { t } = useTranslation();
     return (
         <VStack spacing="16px">
             <AspectRatio
@@ -287,7 +288,9 @@ export function PlaceListItem({
                 </HStack>
                 {transition && (
                     <Text color="#686868">
-                        前の場所から{Math.round(transition.durationInMinutes)}分
+                        {t("plan:addNewPlaceToPlanMinuteFromPreviousPlace", {
+                            minute: Math.round(transition.durationInMinutes),
+                        })}
                     </Text>
                 )}
             </VStack>

--- a/src/view/plancandidate/DialogRelatedPlaces.tsx
+++ b/src/view/plancandidate/DialogRelatedPlaces.tsx
@@ -250,7 +250,7 @@ export function PlaceListItem({
     images: ImageType[];
     onClick: OnClickHandler;
 }) {
-    const { t } = useTranslation();
+    const { t } = useAppTranslation();
     return (
         <VStack spacing="16px">
             <AspectRatio

--- a/src/view/plancandidate/DialogRelatedPlaces.tsx
+++ b/src/view/plancandidate/DialogRelatedPlaces.tsx
@@ -17,6 +17,7 @@ import {
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { isMobile, isTablet } from "react-device-detect";
+import { useTranslation } from "react-i18next";
 import { MdClose } from "react-icons/md";
 import {
     ImageSizes,
@@ -31,6 +32,7 @@ import { copyObject } from "src/domain/util/object";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 import { ImageSliderPreview } from "src/view/common/ImageSliderPreview";
 import { RoundedButton } from "src/view/common/RoundedButton";
+import { useAppTranslation } from "src/view/hooks/useAppTranslation";
 import { getPlaceCategoryIcon } from "src/view/plan/PlaceCategoryIcon";
 import {
     PlaceChipActionGoogleMaps,
@@ -163,6 +165,7 @@ function SelectPlaceToUpdateScreen({
     onClickUpdate: (placeId: string) => void;
     onClose: () => void;
 }) {
+    const { t } = useTranslation();
     if (placesRecommended == null) return <LoadingScreen />;
 
     const isPC = !isMobile && !isTablet;
@@ -182,7 +185,7 @@ function SelectPlaceToUpdateScreen({
                         {dialogTitle}
                     </Text>
                     <Text color="#9F8D76" fontWeight="bold">
-                        気になった場所をタップ
+                        {t("place:relatedPlacesDescription")}
                     </Text>
                 </VStack>
                 <Box as="button" onClick={onClose}>
@@ -341,6 +344,7 @@ export function ConfirmToUpdateScreen({
     onClickUpdate: () => void;
     onCancel: () => void;
 }) {
+    const { t } = useAppTranslation();
     return (
         <VStack w="100%" h="100%" spacing="24px" maxW="600px">
             <VStack w="100%" pt="32px" spacing="24px" flex={1}>
@@ -388,7 +392,7 @@ export function ConfirmToUpdateScreen({
             </VStack>
             <HStack w="100%" pb="48px" px="20px">
                 <RoundedButton w="100%" outlined onClick={onCancel}>
-                    キャンセル
+                    {t("common:cancel")}
                 </RoundedButton>
                 <RoundedButton w="100%" onClick={onClickUpdate}>
                     {buttonLabelUpdatePlace}

--- a/src/view/plancandidate/DialogReplacePlace.tsx
+++ b/src/view/plancandidate/DialogReplacePlace.tsx
@@ -1,4 +1,5 @@
 import { Place } from "src/domain/models/Place";
+import { useAppTranslation } from "src/view/hooks/useAppTranslation";
 import { DialogRelatedPlaces } from "src/view/plancandidate/DialogRelatedPlaces";
 
 type Props = {
@@ -23,16 +24,19 @@ export function DialogReplacePlace({
     onReplacePlace,
     onCloseDialog,
 }: Props) {
+    const { t } = useAppTranslation();
     return (
         <DialogRelatedPlaces
             visible={isDialogVisible}
-            titleSelectScreen={`「${
-                placesInPlan.find((p) => p.id === placeIdToBeReplaced)?.name
-            }」に関連する場所`}
-            titleConfirmScreen="この場所と入れ替えますか？"
+            titleSelectScreen={t("place:relatedPlacesTitle", {
+                placeName: placesInPlan.find(
+                    (p) => p.id === placeIdToBeReplaced
+                )?.name,
+            })}
+            titleConfirmScreen={t("place:replacePlaceConfirmTitle")}
             placesRecommended={placesToReplace}
             updating={isReplacingPlace}
-            buttonLabelUpdatePlace="入れ替える"
+            buttonLabelUpdatePlace={t("place:replacePlace")}
             onClickRelatedPlace={(placeId) =>
                 placeIdToBeReplaced &&
                 onReplacePlace({

--- a/src/view/plancandidate/DialogUploadImage.tsx
+++ b/src/view/plancandidate/DialogUploadImage.tsx
@@ -9,6 +9,7 @@ import {
     VStack,
 } from "@chakra-ui/react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 import { OnClickHandler } from "src/view/types/handler";
 
@@ -75,6 +76,7 @@ const Confirm = ({
     onUpload: OnClickHandler;
     onClose: OnClickHandler;
 }) => {
+    const { t } = useTranslation();
     return (
         <VStack h="100%" w="100%" px="16px" py="16px">
             <VStack w="100%" flex={1} justifyContent="center" spacing="32px">
@@ -98,17 +100,15 @@ const Confirm = ({
                     ))}
                 </HStack>
                 <Text fontSize="20px" fontWeight="bold" color="#574836">
-                    {imageUrls.length === 1
-                        ? "こちらの画像をアップロードしますか？"
-                        : "これらの画像をアップロードしますか？"}
+                    {t("place:uploadPlacePhotoConfirmTitle")}
                 </Text>
             </VStack>
             <HStack mt="32px" pb="48px">
                 <Button onClick={onClose} variant="text">
-                    キャンセル
+                    {t("common:cancel")}
                 </Button>
                 <Button onClick={onUpload} colorScheme="red">
-                    アップロード
+                    {t("common:upload")}
                 </Button>
             </HStack>
         </VStack>

--- a/src/view/plancandidate/ReorderablePlaceList.tsx
+++ b/src/view/plancandidate/ReorderablePlaceList.tsx
@@ -34,6 +34,7 @@ import {
 import { RoundedDialog } from "src/view/common/RoundedDialog";
 import { Colors } from "src/view/constants/color";
 import { Padding } from "src/view/constants/padding";
+import { useAppTranslation } from "src/view/hooks/useAppTranslation";
 import { PlaceChipContextAction } from "src/view/plandetail/PlaceChipContextAction";
 import styled from "styled-components";
 
@@ -54,6 +55,7 @@ export function ReorderablePlaceDialog({
     onAutoReorderPlaces,
     onClose,
 }: Props) {
+    const { t } = useAppTranslation();
     return (
         <FullscreenDialog
             visible={visible}
@@ -70,7 +72,9 @@ export function ReorderablePlaceDialog({
                 >
                     <HStack w="100%">
                         <PlaceChipContextAction
-                            label="歩く距離を最短にする"
+                            label={t(
+                                "plan:reorderPlacesMinimizeWalkingDistance"
+                            )}
                             icon={MdDirectionsWalk}
                             onClick={onAutoReorderPlaces}
                         />
@@ -88,7 +92,7 @@ export function ReorderablePlaceDialog({
                         borderRadius={20}
                         onClick={onClose}
                     >
-                        とじる
+                        {t("common:close")}
                     </Button>
                 </VStack>
             </RoundedDialog>
@@ -233,6 +237,7 @@ export const PlaceListItem = forwardRef<
     { place, transitions, draggableAttributes, draggableListeners },
     ref
 ) {
+    const { t } = useAppTranslation();
     const transition = transitions.find((t) => t.toPlaceId === place.id);
     return (
         <HStack
@@ -262,9 +267,14 @@ export const PlaceListItem = forwardRef<
                     {transition && (
                         <Text fontSize="0.9rem" color="rgba(0,0,0,.6)">
                             {transition.fromPlaceId === null
-                                ? "出発地点"
-                                : "前の場所"}
-                            から {transition.durationInMinutes}分
+                                ? t(
+                                      "plan:reorderPlacesMinuteFromStartLocation",
+                                      { minute: transition.durationInMinutes }
+                                  )
+                                : t(
+                                      "plan:reorderPlacesMinuteFromPreviousPlace",
+                                      { minute: transition.durationInMinutes }
+                                  )}
                         </Text>
                     )}
                 </VStack>

--- a/src/view/plandetail/BindPreLoginStateConfirmationDialog.tsx
+++ b/src/view/plandetail/BindPreLoginStateConfirmationDialog.tsx
@@ -97,13 +97,9 @@ function Confirm({
         <>
             <VStack>
                 <Text textAlign="center" fontSize="24px" fontWeight="bold">
-                    <AppTrans
-                        i18nKey={"account:retainDataBeforeLoginTitle"}
-                    />
+                    <AppTrans i18nKey={"account:retainDataBeforeLoginTitle"} />
                 </Text>
-                <Text>
-                    {t("account:retainDataBeforeLoginDescription")}
-                </Text>
+                <Text>{t("account:retainDataBeforeLoginDescription")}</Text>
             </VStack>
             <Balloon
                 viewBox="0 0 571.75671 700.46347"

--- a/src/view/plandetail/BindPreLoginStateConfirmationDialog.tsx
+++ b/src/view/plandetail/BindPreLoginStateConfirmationDialog.tsx
@@ -1,5 +1,6 @@
 import { Button, Center, Spinner, Text, VStack } from "@chakra-ui/react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
     RequestStatus,
     RequestStatuses,
@@ -8,6 +9,7 @@ import Awesome from "src/view/assets/svg/awesome.svg";
 import Balloon from "src/view/assets/svg/balloons.svg";
 import Notify from "src/view/assets/svg/notify.svg";
 import Party from "src/view/assets/svg/party.svg";
+import { AppTrans } from "src/view/common/AppTrans";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 import { RoundedButton } from "src/view/common/RoundedButton";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
@@ -90,16 +92,17 @@ function Confirm({
     onClickYes?: () => void;
     onCanceled: () => void;
 }) {
+    const { t } = useTranslation();
     return (
         <>
             <VStack>
                 <Text textAlign="center" fontSize="24px" fontWeight="bold">
-                    ログイン前の状態を
-                    <br />
-                    引き継ぎますか？
+                    <AppTrans
+                        i18nKey={"account:promptRetainDataBeforeLoginTitle"}
+                    />
                 </Text>
                 <Text>
-                    「保存したプラン」や「いいね」した記録を引き継ぐことができます。
+                    {t("account:promptRetainDataBeforeLoginDescription")}
                 </Text>
             </VStack>
             <Balloon
@@ -109,9 +112,11 @@ function Confirm({
                 }}
             />
             <VStack w="100%">
-                <RoundedButton onClick={onClickYes}>引き継ぐ</RoundedButton>
+                <RoundedButton onClick={onClickYes}>
+                    {t("account:retainData")}
+                </RoundedButton>
                 <Button onClick={onCanceled} variant="text">
-                    キャンセル
+                    {t("common:cancel")}
                 </Button>
             </VStack>
         </>
@@ -119,14 +124,11 @@ function Confirm({
 }
 
 function Cancel({ onClose }: { onClose?: OnClickHandler }) {
+    const { t } = useTranslation();
     return (
         <>
             <Text textAlign="center" fontSize="24px" fontWeight="bold">
-                引き継ぎは
-                <br />
-                ログインメニューから
-                <br />
-                いつでもできます！
+                <AppTrans i18nKey={"account:retainDataCanceledMessage"} />
             </Text>
             <Awesome
                 viewBox="0 0 616.25771 629"
@@ -135,19 +137,18 @@ function Cancel({ onClose }: { onClose?: OnClickHandler }) {
                 }}
             />
             <RoundedButton outlined color="black" onClick={onClose}>
-                とじる
+                {t("common:close")}
             </RoundedButton>
         </>
     );
 }
 
 function Pending() {
+    const { t } = useTranslation();
     return (
         <>
             <Text textAlign="center" fontSize="24px" fontWeight="bold">
-                データを
-                <br />
-                引き継いでいます...
+                <AppTrans i18nKey={"account:retainingData"} />
             </Text>
             <Center h="200px">
                 <Spinner
@@ -158,16 +159,17 @@ function Pending() {
                     size="xl"
                 />
             </Center>
-            <Text>しばらくお待ちください！</Text>
+            <Text>{t("account:retainingDataWaitMessage")}</Text>
         </>
     );
 }
 
 function Success({ onClose }: { onClose?: OnClickHandler }) {
+    const { t } = useTranslation();
     return (
         <>
             <Text textAlign="center" fontSize="24px" fontWeight="bold">
-                引き継ぎが成功しました！
+                {t("account:retainDataSuccess")}
             </Text>
             <Party
                 viewBox="0 0 1001.27346 688.36187"
@@ -176,23 +178,22 @@ function Success({ onClose }: { onClose?: OnClickHandler }) {
                 }}
             />
             <RoundedButton outlined color="black" onClick={onClose}>
-                とじる
+                {t("common:close")}
             </RoundedButton>
         </>
     );
 }
 
 function Error({ onClose }: { onClose?: OnClickHandler }) {
+    const { t } = useTranslation();
     return (
         <>
             <VStack>
                 <Text textAlign="center" fontSize="24px" fontWeight="bold">
-                    引き継ぎに失敗しました
+                    {t("account:retainDataFailed")}
                 </Text>
                 <Text color="rgba(0,0,0,.65)">
-                    しばらく時間をおいて再度お試しください。
-                    <br />
-                    引き継ぎはログインメニューからいつでもできます！
+                    <AppTrans i18nKey={"account:retainDataRetryLaterMessage"} />
                 </Text>
             </VStack>
             <Notify
@@ -203,7 +204,7 @@ function Error({ onClose }: { onClose?: OnClickHandler }) {
                 }}
             />
             <RoundedButton outlined color="black" onClick={onClose}>
-                とじる
+                {t("common:close")}
             </RoundedButton>
         </>
     );

--- a/src/view/plandetail/BindPreLoginStateConfirmationDialog.tsx
+++ b/src/view/plandetail/BindPreLoginStateConfirmationDialog.tsx
@@ -98,11 +98,11 @@ function Confirm({
             <VStack>
                 <Text textAlign="center" fontSize="24px" fontWeight="bold">
                     <AppTrans
-                        i18nKey={"account:promptRetainDataBeforeLoginTitle"}
+                        i18nKey={"account:retainDataBeforeLoginTitle"}
                     />
                 </Text>
                 <Text>
-                    {t("account:promptRetainDataBeforeLoginDescription")}
+                    {t("account:retainDataBeforeLoginDescription")}
                 </Text>
             </VStack>
             <Balloon

--- a/src/view/plandetail/CollageTemplate.tsx
+++ b/src/view/plandetail/CollageTemplate.tsx
@@ -1,6 +1,8 @@
 import { Box, Divider, HStack, Image, Text, VStack } from "@chakra-ui/react";
 import { forwardRef } from "react";
+import { useTranslation } from "react-i18next";
 import Logo from "src/view/assets/svg/logo.svg";
+import { AppTrans } from "src/view/common/AppTrans";
 
 type CollagePlace = {
     name: string;
@@ -16,6 +18,7 @@ type CollageProps = {
 
 export const CollageTemplate = forwardRef<HTMLDivElement, CollageProps>(
     function CollageTemplateComponent({ title, places, introduction }, ref) {
+        const { t } = useTranslation();
         return (
             <VStack
                 ref={ref}
@@ -90,7 +93,11 @@ export const CollageTemplate = forwardRef<HTMLDivElement, CollageProps>(
                                     fontWeight="bold"
                                     fontSize="32px"
                                 >
-                                    滞在時間：{place.duration}分
+                                    {t("place:estimatedStayDuration")}：
+                                    <AppTrans
+                                        i18nKey={"common:minutesLabel"}
+                                        values={{ minutes: place.duration }}
+                                    />
                                 </Text>
                             </VStack>
                         </HStack>

--- a/src/view/plandetail/CreatePlanDialog.tsx
+++ b/src/view/plandetail/CreatePlanDialog.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, VStack } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Place } from "src/domain/models/Place";
 import { copyObject } from "src/domain/util/object";
 import {
@@ -21,6 +22,7 @@ export const CreatePlanDialog = ({
     onClickClose,
     onClickCreatePlan,
 }: Props) => {
+    const { t } = useTranslation();
     // ダイアログを閉じるときに、placeをnullにするとエラーになってしまうため
     // placeのキャッシュを作成し、それを表示する
     const [placeCache, setPlaceCache] = useState(place);
@@ -75,7 +77,7 @@ export const CreatePlanDialog = ({
                     </Box>
                     <VStack w="100%">
                         <RoundedButton onClick={() => onClickCreatePlan(place)}>
-                            この場所からプランを作る
+                            {t("plan:createPlanFromThisPlace")}
                         </RoundedButton>
                         <Button
                             w="100%"
@@ -86,7 +88,7 @@ export const CreatePlanDialog = ({
                                 backgroundColor: "none",
                             }}
                         >
-                            キャンセル
+                            {t("common:cancel")}
                         </Button>
                     </VStack>
                 </VStack>

--- a/src/view/plandetail/LoginCallMessage.tsx
+++ b/src/view/plandetail/LoginCallMessage.tsx
@@ -1,14 +1,14 @@
 import { Text, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import MobileLogin from "src/view/assets/svg/mobile_login.svg";
 import { RoundedButton } from "src/view/common/RoundedButton";
-import {useTranslation} from "react-i18next";
 
 type Props = {
     onLogin?: () => void;
 };
 
 export const LoginCallMessage = ({ onLogin }: Props) => {
-    const {t} = useTranslation();
+    const { t } = useTranslation();
     return (
         <VStack
             w="100%"

--- a/src/view/plandetail/LoginCallMessage.tsx
+++ b/src/view/plandetail/LoginCallMessage.tsx
@@ -1,12 +1,14 @@
 import { Text, VStack } from "@chakra-ui/react";
 import MobileLogin from "src/view/assets/svg/mobile_login.svg";
 import { RoundedButton } from "src/view/common/RoundedButton";
+import {useTranslation} from "react-i18next";
 
 type Props = {
     onLogin?: () => void;
 };
 
 export const LoginCallMessage = ({ onLogin }: Props) => {
+    const {t} = useTranslation();
     return (
         <VStack
             w="100%"
@@ -34,15 +36,15 @@ export const LoginCallMessage = ({ onLogin }: Props) => {
                 />
                 <VStack w="100%" spacing={0} alignItems="flex-start">
                     <Text fontSize="1.2rem" fontWeight="bold">
-                        あなただけのプランを、いつもそばに
+                        {t("plan:loginRecommendationTitle")}
                     </Text>
                     <Text flex={1}>
-                        ログインすると、お気に入りのプランや場所をkomichiが覚えていてくれます。
+                        {t("plan:loginRecommendationDescription")}
                     </Text>
                 </VStack>
             </VStack>
             <RoundedButton color="#BF756E" onClick={onLogin}>
-                ログイン
+                {t("account:login")}
             </RoundedButton>
         </VStack>
     );

--- a/src/view/plandetail/PlaceChipContextAction.tsx
+++ b/src/view/plandetail/PlaceChipContextAction.tsx
@@ -152,7 +152,7 @@ export const PlaceChipActionCamera = ({
             >
                 <Icon w="16px" h="16px" as={MdOutlineCameraAlt} />
                 <Text fontSize="0.8rem" whiteSpace="nowrap">
-                    {t("place:uploadPhoto")}
+                    {t("place:uploadPlacePhoto")}
                 </Text>
             </HStack>
             <input

--- a/src/view/plandetail/PlaceChipContextAction.tsx
+++ b/src/view/plandetail/PlaceChipContextAction.tsx
@@ -2,6 +2,7 @@ import { Link } from "@chakra-ui/next-js";
 import { HStack, Icon, Text } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { IconType } from "react-icons";
 import {
     MdOutlineCameraAlt,
@@ -71,6 +72,7 @@ export const PlaceChipActionInstagram = ({
 }: {
     placeName: string;
 }) => {
+    const { t } = useTranslation();
     return (
         <Link
             href={`https://www.instagram.com/explore/tags/${encodeURIComponent(
@@ -86,7 +88,7 @@ export const PlaceChipActionInstagram = ({
             }
         >
             <PlaceChipContextAction
-                label="Instagramで検索"
+                label={t("place:searchByInstagram")}
                 icon={SiInstagram}
             />
         </Link>
@@ -102,6 +104,7 @@ export const PlaceChipActionGoogleMaps = ({
     googlePlaceId: string;
     onClick?: OnClickHandler;
 }) => {
+    const { t } = useTranslation();
     const url = new URL("https://www.google.com/maps/search/");
     url.searchParams.set("api", "1");
     url.searchParams.set("query", placeName);
@@ -118,7 +121,7 @@ export const PlaceChipActionGoogleMaps = ({
             }
         >
             <PlaceChipContextAction
-                label="Google Mapsで検索"
+                label={t("place:searchByGoogleMaps")}
                 icon={SiGooglemaps}
             />
         </Link>
@@ -133,6 +136,7 @@ export const PlaceChipActionCamera = ({
     placeId,
     onFileChanged,
 }: PlaceChipActionCameraProps) => {
+    const { t } = useTranslation();
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     return (
@@ -148,7 +152,7 @@ export const PlaceChipActionCamera = ({
             >
                 <Icon w="16px" h="16px" as={MdOutlineCameraAlt} />
                 <Text fontSize="0.8rem" whiteSpace="nowrap">
-                    写真をアップロード
+                    {t("place:uploadPhoto")}
                 </Text>
             </HStack>
             <input

--- a/src/view/plandetail/PlaceChipContextAction.tsx
+++ b/src/view/plandetail/PlaceChipContextAction.tsx
@@ -58,9 +58,10 @@ export const PlaceChipActionShowRelatedPlaces = ({
 }: {
     onClick: OnClickHandler;
 }) => {
+    const { t } = useTranslation();
     return (
         <PlaceChipContextAction
-            label="関連した場所を表示"
+            label={t("place:relatedPlacesShow")}
             icon={MdOutlineFindReplace}
             onClick={onClick}
         />

--- a/src/view/plandetail/PlaceChipContextAction.tsx
+++ b/src/view/plandetail/PlaceChipContextAction.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-icons/md";
 import { SiGooglemaps, SiInstagram } from "react-icons/si";
 import { AnalyticsEvents } from "src/view/constants/analytics";
+import { useAppTranslation } from "src/view/hooks/useAppTranslation";
 import { UploadPlaceImageProps } from "src/view/hooks/useUploadPlaceImage";
 import { OnClickHandler } from "src/view/types/handler";
 
@@ -44,9 +45,10 @@ export const PlaceChipActionDelete = ({
 }: {
     onClick: OnClickHandler;
 }) => {
+    const { t } = useAppTranslation();
     return (
         <PlaceChipContextAction
-            label="削除"
+            label={t("common:delete")}
             icon={MdOutlineDeleteOutline}
             onClick={onClick}
         />

--- a/src/view/plandetail/PlaceInfoTab.tsx
+++ b/src/view/plandetail/PlaceInfoTab.tsx
@@ -1,5 +1,6 @@
 import { Box, Center, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { ReactNode, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { IconType } from "react-icons";
 import { MdCurrencyYen, MdSchedule } from "react-icons/md";
 import { PlaceCategory } from "src/domain/models/PlaceCategory";
@@ -26,6 +27,7 @@ export const PlaceInfoTab = ({
     tabHSpaacing,
     estimatedStayDuration,
 }: Props) => {
+    const { t } = useTranslation();
     const [activeTab, setActiveTab] = useState<PlaceInfoTab>(
         PlaceInfoTabs.Information
     );
@@ -36,7 +38,7 @@ export const PlaceInfoTab = ({
                 <Tab
                     active={activeTab === PlaceInfoTabs.Information}
                     tab={PlaceInfoTabs.Information}
-                    label="情報"
+                    label={t("common:info")}
                     onClick={setActiveTab}
                 />
             </HStack>
@@ -114,6 +116,7 @@ const TabPanelInformation = ({
     priceRange: PriceRange | null;
     estimatedStayDuration: number;
 }) => {
+    const { t } = useTranslation();
     const isEstimatedStayDurationEmpty = estimatedStayDuration === 0;
     const isCategoryEmpty = categories.length === 0;
     const isPriceRangeEmpty = !priceRange || priceRange.max === 0;
@@ -149,7 +152,7 @@ const TabPanelInformation = ({
                         key="category"
                         icon={getPlaceCategoryIcon(categories[0])}
                         value={categories[0].displayName}
-                        label="カテゴリ"
+                        label={t("place:category")}
                     />
                 )}
                 {!isPriceRangeEmpty && (
@@ -157,7 +160,7 @@ const TabPanelInformation = ({
                         key="priceRange"
                         icon={MdCurrencyYen}
                         value={`${priceRange.min}~${priceRange.max} 円`}
-                        label="価格帯"
+                        label={t("place:priceRange")}
                     />
                 )}
                 {!isEstimatedStayDurationEmpty && (
@@ -165,7 +168,7 @@ const TabPanelInformation = ({
                         key="estimatedStayDuration"
                         icon={MdSchedule}
                         value={DateHelper.formatHHMM(estimatedStayDuration)}
-                        label="予想滞在時間"
+                        label={t("place:estimatedStayDuration")}
                     />
                 )}
             </HStack>

--- a/src/view/plandetail/PlaceInfoTab.tsx
+++ b/src/view/plandetail/PlaceInfoTab.tsx
@@ -124,7 +124,7 @@ const TabPanelInformation = ({
     if (isCategoryEmpty && isPriceRangeEmpty && isEstimatedStayDurationEmpty) {
         return (
             <Center w="100%" h="100%">
-                <Text color="#574836">情報がありません</Text>
+                <Text color="#574836">{t("place:noInformation")}</Text>
             </Center>
         );
     }

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -13,6 +13,7 @@ import {
 } from "@chakra-ui/react";
 import * as process from "process";
 import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { MdLink, MdOutlineCameraAlt, MdOutlineInfo } from "react-icons/md";
 import { ImageSize } from "src/domain/models/Image";
 import { Plan } from "src/domain/models/Plan";
@@ -44,6 +45,7 @@ export function PlanDetailPageHeader({
     onUpdateLikePlace,
     onCopyPlanUrl,
 }: Props) {
+    const { t } = useTranslation();
     const [currentPage, setCurrentPage] = useState(0);
     const [isLargerThanHeaderWidth] = useMediaQuery(
         `(min-width: ${Size.PlanDetailHeader.maxW})`
@@ -142,7 +144,7 @@ export function PlanDetailPageHeader({
                         opacity={activeTab === PlanHeaderTabs.Info ? 1 : 0.3}
                         leftIcon={<Icon as={MdOutlineInfo} />}
                     >
-                        情報
+                        {t("common:info")}
                     </Button>
                     <Button
                         onClick={() => setActiveTab(PlanHeaderTabs.Collage)}
@@ -152,7 +154,7 @@ export function PlanDetailPageHeader({
                         opacity={activeTab === PlanHeaderTabs.Collage ? 1 : 0.3}
                         leftIcon={<Icon as={MdOutlineCameraAlt} />}
                     >
-                        アルバム
+                        {t("plan:album")}
                     </Button>
                 </HStack>
             )}

--- a/src/view/plandetail/header/PlanInfoTag.tsx
+++ b/src/view/plandetail/header/PlanInfoTag.tsx
@@ -1,8 +1,10 @@
 import { Box, Center, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { IconType } from "react-icons";
 import { MdCurrencyYen, MdSchedule } from "react-icons/md";
 import { DateHelper } from "src/domain/util/date";
+import { useAppTranslation } from "src/view/hooks/useAppTranslation";
 
 type Props = {
     title: string;
@@ -43,12 +45,13 @@ export const PlanInfoTagDuration = ({
 }: {
     durationInMinutes: number;
 }) => {
+    const { t } = useTranslation();
     const endPlanDate = DateHelper.add(
         new Date(),
         durationInMinutes * DateHelper.Minute
     );
     return (
-        <PlanInfoTag title="時間" icon={MdSchedule}>
+        <PlanInfoTag title={t("common:time")} icon={MdSchedule}>
             <Text>
                 {DateHelper.formatHHMM(durationInMinutes)}(~{" "}
                 {DateHelper.dateToHHMM(endPlanDate)})
@@ -64,11 +67,14 @@ export const PlanInfoTagBudget = ({
     minBudget: number;
     maxBudget: number;
 }) => {
+    const { t } = useAppTranslation();
     return (
-        <PlanInfoTag title="予算" icon={MdCurrencyYen}>
+        <PlanInfoTag title={t("common:budget")} icon={MdCurrencyYen}>
             <HStack alignItems="flex-start" w="100%" spacing={0}>
                 {minBudget > 0 && <Text>{`${minBudget}`}</Text>}
-                {maxBudget > 0 && <Text>{`~${maxBudget}円`}</Text>}
+                {maxBudget > 0 && (
+                    <Text>{`~${t("common:priceLabel", { price: maxBudget })}`}</Text>
+                )}
             </HStack>
         </PlanInfoTag>
     );

--- a/src/view/top/CreatePlanSection.tsx
+++ b/src/view/top/CreatePlanSection.tsx
@@ -6,8 +6,10 @@ import { AnalyticsEvents } from "src/view/constants/analytics";
 import { Routes } from "src/view/constants/router";
 import styled from "styled-components";
 import { CreatePlanButton } from "./CreatePlanButton";
+import {useTranslation} from "react-i18next";
 
 export function CreatePlanSection() {
+    const {t} = useTranslation();
     return (
         <Center
             w="100%"
@@ -32,7 +34,7 @@ export function CreatePlanSection() {
                         fontSize="24px"
                         zIndex="10"
                     >
-                        暇つぶしプランを作ろう
+                        {t("home:promptCreatePlan")}
                     </Text>
                     <Grid
                         w="100%"
@@ -42,7 +44,7 @@ export function CreatePlanSection() {
                         transform="translateZ(0px)"
                     >
                         <CreatePlanButton
-                            title="現在地から"
+                            title={t("home:fromCurrentLocation")}
                             icon={MdOutlineLocationOn}
                             link={Routes.plans.interest()}
                             onClick={() =>
@@ -54,7 +56,7 @@ export function CreatePlanSection() {
                             }
                         />
                         <CreatePlanButton
-                            title="好きな場所から"
+                            title={t("home:fromFavoritePlace")}
                             icon={MdOutlineMap}
                             link={Routes.places.search({
                                 skipCurrentLocation: true,

--- a/src/view/top/CreatePlanSection.tsx
+++ b/src/view/top/CreatePlanSection.tsx
@@ -34,7 +34,7 @@ export function CreatePlanSection() {
                         fontSize="24px"
                         zIndex="10"
                     >
-                        {t("home:promptCreatePlan")}
+                        {t("home:createPlanTitle")}
                     </Text>
                     <Grid
                         w="100%"
@@ -44,7 +44,7 @@ export function CreatePlanSection() {
                         transform="translateZ(0px)"
                     >
                         <CreatePlanButton
-                            title={t("home:fromCurrentLocation")}
+                            title={t("home:createPlanFromCurrentLocation")}
                             icon={MdOutlineLocationOn}
                             link={Routes.plans.interest()}
                             onClick={() =>
@@ -56,7 +56,7 @@ export function CreatePlanSection() {
                             }
                         />
                         <CreatePlanButton
-                            title={t("home:fromFavoritePlace")}
+                            title={t("home:createPlanFromFavoritePlace")}
                             icon={MdOutlineMap}
                             link={Routes.places.search({
                                 skipCurrentLocation: true,

--- a/src/view/top/CreatePlanSection.tsx
+++ b/src/view/top/CreatePlanSection.tsx
@@ -1,15 +1,15 @@
 import { Box, Center, Grid, Text, VStack } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
+import { useTranslation } from "react-i18next";
 import { MdOutlineLocationOn, MdOutlineMap } from "react-icons/md";
 import HangOut from "src/view/assets/svg/hangout.svg";
 import { AnalyticsEvents } from "src/view/constants/analytics";
 import { Routes } from "src/view/constants/router";
 import styled from "styled-components";
 import { CreatePlanButton } from "./CreatePlanButton";
-import {useTranslation} from "react-i18next";
 
 export function CreatePlanSection() {
-    const {t} = useTranslation();
+    const { t } = useTranslation();
     return (
         <Center
             w="100%"

--- a/src/view/top/LocationUnavailable.tsx
+++ b/src/view/top/LocationUnavailable.tsx
@@ -1,4 +1,5 @@
 import { Switch, Text, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import MapIcon from "src/view/assets/svg/map.svg";
 import {
     LocationPermission,
@@ -11,11 +12,13 @@ type Props = {
     onClickSwitch: () => void;
 };
 
+// TODO: search ディレクトリに移動する
 export function LocationUnavailable({
     locationPermission,
     isUpdating,
     onClickSwitch,
 }: Props) {
+    const { t } = useTranslation();
     const handleOnClickSwitch = () => {
         if (locationPermission === LocationPermissions.GRANTED) return;
         onClickSwitch();
@@ -32,11 +35,11 @@ export function LocationUnavailable({
             />
             <Text fontWeight="bold" fontSize="20px">
                 {locationPermission === LocationPermissions.GRANTED
-                    ? "近くのプランを探しています..."
+                    ? t("plan:promptSearchingNearbyPlans")
                     : locationPermission === LocationPermissions.DENIED
                       ? // TODO: iOSの場合は許可方法を伝えるページを作る
-                        "位置情報を許可すると、近くのプランを探すことができます。"
-                      : "位置情報をオンにしてプランを取得"}
+                        t("plan:promptLocationPermissionDenied")
+                      : t("plan:promptLocationPermissionNotGranted")}
             </Text>
             <Switch
                 size="lg"

--- a/src/view/top/LocationUnavailable.tsx
+++ b/src/view/top/LocationUnavailable.tsx
@@ -35,11 +35,11 @@ export function LocationUnavailable({
             />
             <Text fontWeight="bold" fontSize="20px">
                 {locationPermission === LocationPermissions.GRANTED
-                    ? t("plan:promptSearchingNearbyPlans")
+                    ? t("plan:searchNearbyPlansInProgress")
                     : locationPermission === LocationPermissions.DENIED
                       ? // TODO: iOSの場合は許可方法を伝えるページを作る
-                        t("plan:promptLocationPermissionDenied")
-                      : t("plan:promptLocationPermissionNotGranted")}
+                        t("plan:searchNearbyPlansLocationPermissionDenied")
+                      : t("plan:searchNearbyPlansLocationPermissionNotGranted")}
             </Text>
             <Switch
                 size="lg"

--- a/src/view/top/NearbyPlansNotFound.tsx
+++ b/src/view/top/NearbyPlansNotFound.tsx
@@ -1,10 +1,13 @@
 import { Link } from "@chakra-ui/next-js";
 import { Text, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import IconTraveling from "src/view/assets/svg/traveling.svg";
 import { RoundedButton } from "src/view/common/RoundedButton";
 import { Routes } from "src/view/constants/router";
 
 export const NearbyPlansNotFound = () => {
+    const { t } = useTranslation();
+
     return (
         <VStack w="100%" spacing="32px">
             <IconTraveling
@@ -16,14 +19,14 @@ export const NearbyPlansNotFound = () => {
             />
             <VStack spacing={0}>
                 <Text fontSize="12px" color="rgba(0,0,0,.6)">
-                    近くで作成されたプランはありませんでした
+                    {t("plan:nearbyPlansEmptyTitle")}
                 </Text>
                 <Text fontSize="20px" fontWeight="bold">
-                    最初のプランを作ってみませんか？
+                    {t("plan:nearbyPlansEmptyDescription")}
                 </Text>
             </VStack>
             <Link href={Routes.plans.interest()} w="100%" maxW="400px">
-                <RoundedButton>プランを作成する</RoundedButton>
+                <RoundedButton>{t("plan:createPlan")}</RoundedButton>
             </Link>
         </VStack>
     );

--- a/src/view/top/PwaInstallDialog.tsx
+++ b/src/view/top/PwaInstallDialog.tsx
@@ -1,7 +1,9 @@
 import { Box, Button, Center, HStack, Text, VStack } from "@chakra-ui/react";
 import Image from "next/image";
 import { CSSProperties } from "react";
+import { useTranslation } from "react-i18next";
 import { Transition, TransitionStatus } from "react-transition-group";
+import { AppTrans } from "src/view/common/AppTrans";
 import { RoundedButton } from "src/view/common/RoundedButton";
 import { Size } from "src/view/constants/size";
 
@@ -26,6 +28,7 @@ export function PwaInstallDialog({
     onClickInstall,
     onClickCancel,
 }: Props) {
+    const { t } = useTranslation();
     return (
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -69,9 +72,9 @@ export function PwaInstallDialog({
                                     fontWeight="bold"
                                     color="#45413E"
                                 >
-                                    komichiを
-                                    <br />
-                                    ホームに追加しますか?
+                                    <AppTrans
+                                        i18nKey={"pwa:promptAddToHomeScreen"}
+                                    />
                                 </Text>
                             </HStack>
                             <HStack
@@ -84,14 +87,14 @@ export function PwaInstallDialog({
                                     variant="link"
                                     onClick={onClickCancel}
                                 >
-                                    キャンセル
+                                    {t("common:cancel")}
                                 </Button>
                                 <Box flex={1}>
                                     <RoundedButton
                                         onClick={onClickInstall}
                                         color="#BF756E"
                                     >
-                                        ホームに追加
+                                        {t("pwa:addToHomeScreen")}
                                     </RoundedButton>
                                 </Box>
                             </HStack>

--- a/src/view/top/PwaIosInstruction.tsx
+++ b/src/view/top/PwaIosInstruction.tsx
@@ -8,12 +8,12 @@ import {
 } from "@chakra-ui/react";
 import { useEffect, useRef, useState } from "react";
 import { isIPad13 } from "react-device-detect";
+import { useTranslation } from "react-i18next";
 import { FullscreenDialog } from "src/view/common/FullscreenDialog";
 import { RoundedButton } from "src/view/common/RoundedButton";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
 import { Asset } from "src/view/constants/asset";
 import { Padding } from "src/view/constants/padding";
-import {useTranslation} from "react-i18next";
 
 type Props = {
     visible: boolean;
@@ -37,7 +37,7 @@ export function PwaIosInstruction({
     onClose,
     onClickAlreadyInstalled,
 }: Props) {
-    const {t} = useTranslation();
+    const { t } = useTranslation();
     const [currentTab, setCurrentTab] = useState<InstructionTab>(defaultTab);
     const videoRef = useRef<HTMLVideoElement>(null);
 

--- a/src/view/top/PwaIosInstruction.tsx
+++ b/src/view/top/PwaIosInstruction.tsx
@@ -13,6 +13,7 @@ import { RoundedButton } from "src/view/common/RoundedButton";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
 import { Asset } from "src/view/constants/asset";
 import { Padding } from "src/view/constants/padding";
+import {useTranslation} from "react-i18next";
 
 type Props = {
     visible: boolean;
@@ -36,6 +37,7 @@ export function PwaIosInstruction({
     onClose,
     onClickAlreadyInstalled,
 }: Props) {
+    const {t} = useTranslation();
     const [currentTab, setCurrentTab] = useState<InstructionTab>(defaultTab);
     const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -60,7 +62,7 @@ export function PwaIosInstruction({
                     spacing="16px"
                 >
                     <Text px={Padding.p16} fontSize="24px">
-                        ホーム画面への追加方法
+                        {t("pwa:addToHomeScreenInstructionTitle")}
                     </Text>
                     <VStack w="100%" flex={1}>
                         <Center w="100%" px={Padding.p16}>
@@ -121,10 +123,12 @@ export function PwaIosInstruction({
                                 colorScheme="blue"
                                 onClick={onClickAlreadyInstalled}
                             >
-                                すでにホームに追加されています
+                                {t("pwa:alreadyAddedToHomeScreen")}
                             </Button>
                         )}
-                        <RoundedButton onClick={onClose}>とじる</RoundedButton>
+                        <RoundedButton onClick={onClose}>
+                            {t("common:close")}
+                        </RoundedButton>
                     </VStack>
                 </VStack>
             </RoundedDialog>

--- a/src/view/user/NavBarUserDialog.tsx
+++ b/src/view/user/NavBarUserDialog.tsx
@@ -1,6 +1,7 @@
 import { Box, HStack, Icon, VStack } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { IconType } from "react-icons";
 import { MdLogin, MdLogout, MdOutlineBackup } from "react-icons/md";
 import { User } from "src/domain/models/User";
@@ -59,10 +60,11 @@ export function NavBarUserDialog({
 }
 
 export function NavBarNonLoginUserDialog({ onLogin }: { onLogin: () => void }) {
+    const { t } = useTranslation();
     return (
         <NavBarUserDialogContainer>
             <DialogItem icon={MdLogin} onClick={onLogin}>
-                ログイン
+                {t("account:login")}
             </DialogItem>
         </NavBarUserDialogContainer>
     );
@@ -75,6 +77,7 @@ export function NavBarLoginUserDialog({
     onLogout: OnClickHandler;
     onBindPreLoginState: OnClickHandler;
 }) {
+    const { t } = useTranslation();
     return (
         <NavBarUserDialogContainer>
             {hasValue(onBindPreLoginState) && (
@@ -82,11 +85,11 @@ export function NavBarLoginUserDialog({
                     icon={MdOutlineBackup}
                     onClick={onBindPreLoginState}
                 >
-                    ログイン前のデータを引き継ぐ
+                    {t("account:retainDataBeforeLogin")}
                 </DialogItem>
             )}
             <DialogItem icon={MdLogout} onClick={onLogout}>
-                ログアウト
+                {t("account:logout")}
             </DialogItem>
         </NavBarUserDialogContainer>
     );


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- コンポーネントに表示される日本語文字列をi18nextライブラリで管理するようにした

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #728
- #727  

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 英語対応するため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] `[ぁ-んァ-ン一-龥]+`で正規表現検索を行い、日本語リソースがコンポーネントに残っていないことを確認（この条件にヒットしないものもある）
- [x] `src/locales/i18n.ts`を以下のように変更したときに、 画面に日本語が表示されなくなることを確認
```ts
i18n.use(initReactI18next).init({
    resources,
    lng: "",
    fallbackLng: "",
    interpolation: {
        escapeValue: false,
    },
});
```

```shell
# poroto
export BRANCH_POROTO=featur/i18_resources
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````