### PR TITLE
プラン詳細画面で戻るボタンを押したときに、プラン一覧画面にスクロールする

### DIFF
--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -52,9 +52,6 @@ const SelectPlanPage = () => {
     const { sessionId } = router.query;
     const [selectedPlanIndex, setSelectedPlanIndex] = useState(0);
     const refPlanCandidateGallery = useRef<HTMLDivElement>(null);
-    const { isPlanFooterVisible, planDetailPageRef, scrollToPlanDetailPage } =
-        usePlanCandidateGalleryPageAutoScroll();
-
     const {
         plansCreated,
         placesAvailableForPlan,
@@ -72,6 +69,10 @@ const SelectPlanPage = () => {
             refPlanCandidateGallery.current?.scrollIntoView();
         },
     });
+    const { isPlanFooterVisible, planDetailPageRef, scrollToPlanDetailPage } =
+        usePlanCandidateGalleryPageAutoScroll({
+            planCandidateId: sessionId as string,
+        });
 
     if (!plansCreated) {
         // ページ読み込み直後


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- プラン候補ページ内のプラン詳細画面で戻るボタンを押したときに、プラン一覧画面までスクロールするようにした。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #415 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- プラン一覧画面とプラン詳細画面が分かれているというユーザーに与える印象と、ナビゲーションの動作を一致させるため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] プラン詳細画面で戻るボタンを押すと、一覧画面までスクロールすることを確認
- [x] 一覧画面 -> プランA詳細画面 -> 一覧画面 ->プランB詳細画面  としても同様の動作をすることを確認（戻るボタンで一覧ページに移動するのは一度だけで、一覧ページに移動した分だけ戻るボタンを押す必要がないことを確認）
- [x] 一覧画面から直接戻るボタンを押すと、その前のページに戻ることを確認
- [x] 一覧画面 -> 詳細画面 -> プラン保存 -> 保存画面から新たにプラン作成 -> プラン一覧画面から詳細画面に移動 しても同様に動作することを確認（別のプランページに移動しても動作することを確認） 

```shell
# poroto
export BRANCH_POROTO=feature/back_to_plan_candidate_list
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````