### PR TITLE
興味選択画面に戻ったときに、選択した場所が反映されない不具合を修正

### DIFF
--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -145,7 +145,12 @@ function PlaceSearchPage() {
                 searchPlaceId: placeSelected.placeId,
             })
         );
-        await router.push(Routes.plans.interest(true));
+        await router.push(
+            Routes.plans.interest({
+                location: placeSelected.location,
+                googlePlaceId: placeSelected.placeId,
+            })
+        );
     };
 
     if (fetchCurrentLocationStatus && !location)

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -108,7 +108,12 @@ export default function PlanPage() {
         );
         // ダイアログの背景固定を解除するためにモーダルを閉じる
         dispatch(setPlaceIdToCreatePlan(null));
-        await router.push(Routes.plans.interest(true));
+        await router.push(
+            Routes.plans.interest({
+                location: place.location,
+                googlePlaceId: place.googlePlaceId,
+            })
+        );
     };
 
     useEffect(() => {

--- a/src/pages/plans/interest.tsx
+++ b/src/pages/plans/interest.tsx
@@ -1,38 +1,18 @@
-import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useTranslation } from "next-i18next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode } from "react";
 import { LocationCategory } from "src/domain/models/LocationCategory";
 import { LocationCategoryWithPlace } from "src/domain/models/LocationCategoryWithPlace";
 import {
     RequestStatus,
     RequestStatuses,
 } from "src/domain/models/RequestStatus";
-import { reduxAuthSelector } from "src/redux/auth";
-import {
-    reduxLocationSelector,
-    setCurrentLocation,
-    setSearchLocation,
-} from "src/redux/location";
-import {
-    createPlanFromLocation,
-    fetchNearbyPlaceCategories,
-    pushAcceptedCategory,
-    pushRejectedCategory,
-    reduxPlanCandidateSelector,
-    resetInterest,
-    setCreatedPlans,
-} from "src/redux/planCandidate";
-import { useAppDispatch } from "src/redux/redux";
 import { ErrorPage } from "src/view/common/ErrorPage";
 import { LoadingModal } from "src/view/common/LoadingModal";
-import { AnalyticsEvents } from "src/view/constants/analytics";
-import { LocalStorageKeys } from "src/view/constants/localStorageKey";
 import { PageMetaData } from "src/view/constants/meta";
-import { Routes } from "src/view/constants/router";
 import { useAppTranslation } from "src/view/hooks/useAppTranslation";
-import { useLocation } from "src/view/hooks/useLocation";
+import { useCreatePlanInterest } from "src/view/hooks/useCreatePlanInterest";
 import { CategorySelect } from "src/view/interest/CategorySelect";
 import { CouldNotFindAnyPlace } from "src/view/interest/CouldNotFindAnyPlace";
 import { FetchLocationDialog } from "src/view/location/FetchLocationDialog";
@@ -61,135 +41,19 @@ export default function Page() {
 }
 
 function PlanInterestPage() {
-    const dispatch = useAppDispatch();
-    const router = useRouter();
     const { t } = useAppTranslation();
-    const { getCurrentLocation, location, fetchCurrentLocationStatus } =
-        useLocation();
-    const [currentCategory, setCurrentCategory] =
-        useState<LocationCategoryWithPlace | null>(null);
-    const [matchInterestRequestId, setMatchInterestRequestId] = useState<
-        string | null
-    >(null);
     const {
         categoryCandidates,
-        createPlanSession,
+        currentCategory,
         fetchLocationCategoryRequestId,
-        fetchNearbyPlaceCategoriesRequestStatus: matchInterestRequestStatus,
-    } = reduxPlanCandidateSelector();
-    const { searchLocation, searchPlaceId } = reduxLocationSelector();
-    const { user } = reduxAuthSelector();
-
-    useEffect(() => {
-        dispatch(resetInterest());
-        setMatchInterestRequestId(null);
-
-        // 2回目以降、プランを作成するときに、前回の結果が残らないようにする
-        dispatch(
-            setCreatedPlans({
-                plans: null,
-                session: null,
-                createdBasedOnCurrentLocation: null,
-            })
-        );
-
-        return () => {
-            // 前回の結果をリセット
-            // MEMO: 戻るボタンで遷移してきたときに、状態が残っていると/plans/selectに自動的に遷移してしまう
-            dispatch(resetInterest());
-            setCurrentCategory(null);
-            setMatchInterestRequestId(null);
-
-            // 場所を指定してプラン作成 -> 現在地からプラン作成
-            // を行うと、指定した場所の情報が残り、そこからプランを作成してしまうためリセットする
-            dispatch(
-                setSearchLocation({ searchLocation: null, searchPlaceId: null })
-            );
-        };
-    }, []);
-
-    // 検索する場所が指定されていない場合は、現在地を取得する
-    useEffect(() => {
-        if (!searchLocation) {
-            getCurrentLocation().then();
-        }
-    }, [searchLocation]);
-
-    // 現在地を取得したら、それをもとに検索
-    useEffect(() => {
-        if (!location) return;
-        const currentLocation = location;
-        dispatch(setCurrentLocation({ currentLocation }));
-        dispatch(
-            setSearchLocation({
-                searchLocation: currentLocation,
-                searchPlaceId: null,
-            })
-        );
-    }, [location]);
-
-    // 検索する場所が指定されたら、興味を持つ場所を検索
-    useEffect(() => {
-        if (searchLocation) {
-            const requestId = Date.now().toString();
-            setMatchInterestRequestId(requestId);
-            dispatch(
-                fetchNearbyPlaceCategories({
-                    location: searchLocation,
-                    requestId,
-                })
-            );
-        }
-    }, [searchLocation]);
-
-    useEffect(() => {
-        if (!categoryCandidates) return;
-        if (
-            categoryCandidates.length === 0 &&
-            searchLocation &&
-            createPlanSession
-        ) {
-            dispatch(
-                createPlanFromLocation({
-                    location: searchLocation,
-                    googlePlaceId: searchPlaceId,
-                })
-            );
-
-            // TODO: hooksに処理を移す
-            // 作成したプラン候補を保存
-            if (!user) {
-                const createdPlanCandidates: string[] = JSON.parse(
-                    localStorage.getItem(LocalStorageKeys.PlanCandidate) ?? "[]"
-                );
-                createdPlanCandidates.push(createPlanSession);
-                localStorage.setItem(
-                    LocalStorageKeys.PlanCandidate,
-                    JSON.stringify(createdPlanCandidates)
-                );
-            }
-
-            router
-                .push(Routes.plans.planCandidate.index(createPlanSession))
-                .then();
-            return;
-        }
-        setCurrentCategory(categoryCandidates[0]);
-    }, [
-        categoryCandidates?.length,
+        matchInterestRequestStatus,
+        matchInterestRequestId,
         searchLocation,
-        searchPlaceId,
-        createPlanSession,
-    ]);
-
-    const handleAcceptCategory = (category: LocationCategory) => {
-        logEvent(getAnalytics(), AnalyticsEvents.Interests.SelectCategory);
-        dispatch(pushAcceptedCategory({ category }));
-    };
-
-    const handleRejectCategory = (category: LocationCategory) => {
-        dispatch(pushRejectedCategory({ category }));
-    };
+        fetchCurrentLocationStatus,
+        handleAcceptCategory,
+        handleRejectCategory,
+        getCurrentLocation,
+    } = useCreatePlanInterest();
 
     if (!searchLocation)
         return (

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -27,7 +27,7 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     const sitemap = generateSiteMap({
         pages: [
             { url: `${baseUrl}/` },
-            { url: `${baseUrl}${Routes.plans.interest()}` },
+            { url: `${baseUrl}${Routes.plans.interest({})}` },
             {
                 url: `${baseUrl}${Routes.places.search({
                     skipCurrentLocation: false,

--- a/src/redux/placeSearch.ts
+++ b/src/redux/placeSearch.ts
@@ -26,8 +26,6 @@ type SearchPlacesByQueryProps = {
 export const searchPlacesByQuery = createAsyncThunk(
     "placeSearch/searchPlacesByQuery",
     async ({ query }: SearchPlacesByQueryProps, { dispatch, getState }) => {
-        console.log("Search Places By Query", { query });
-
         if (query === "") {
             dispatch(resetPlaceSearchResults());
             return;

--- a/src/redux/planCandidate.ts
+++ b/src/redux/planCandidate.ts
@@ -440,6 +440,7 @@ export const slice = createSlice({
 
         resetInterest: (state) => {
             state.fetchLocationCategoryRequestId = null;
+            state.categoryCandidates = null;
         },
 
         resetPlanCandidates: (state) => {

--- a/src/stories/place/MapPinSelecter.stories.tsx
+++ b/src/stories/place/MapPinSelecter.stories.tsx
@@ -16,7 +16,6 @@ const Template: StoryFn<typeof MapPinSelector> = (args) => {
             pinnedLocation={location}
             onSelectLocation={(location) => {
                 setLocation(location);
-                console.log(location);
             }}
         />
     );

--- a/src/view/constants/router.ts
+++ b/src/view/constants/router.ts
@@ -1,3 +1,5 @@
+import { GeoLocation } from "src/domain/models/GeoLocation";
+
 export const RouteParams = {
     SkipCurrentLocation: "skipCurrentLocation",
 };
@@ -9,9 +11,29 @@ export const Routes = {
     account: "/account",
     plans: {
         plan: (id: string) => `/plans/${id}`,
-        interest: (byLocation?: boolean) => {
+        interest: ({
+            location,
+            googlePlaceId,
+        }: {
+            location?: GeoLocation;
+            googlePlaceId?: string;
+        }) => {
             let url = "/plans/interest";
-            if (byLocation) url += "?location=true";
+            const urlParams = new URLSearchParams();
+
+            if (location) {
+                urlParams.append("lat", location.latitude.toString());
+                urlParams.append("lng", location.longitude.toString());
+            }
+
+            if (googlePlaceId) {
+                urlParams.append("googlePlaceId", googlePlaceId);
+            }
+
+            if (urlParams.toString()) {
+                url += `?${urlParams.toString()}`;
+            }
+
             return url;
         },
         planCandidate: {

--- a/src/view/hooks/useCreatePlanInterest.ts
+++ b/src/view/hooks/useCreatePlanInterest.ts
@@ -106,7 +106,7 @@ export const useCreatePlanInterest = () => {
         };
     }, []);
 
-    // 付近の場所のカテゴリが検索されたときと、カテゴリが選択されたときに、次のカテゴリを選択する
+    // 選択画面に表示するカテゴリを更新
     useEffect(() => {
         if (!categoryCandidates) return;
 
@@ -145,17 +145,18 @@ export const useCreatePlanInterest = () => {
         );
     }, [location]);
 
-    // 検索する場所が指定されたら、興味を持つ場所を検索
+    // 付近のカテゴリを取得
     useEffect(() => {
         // 重複してリクエストを送信しない
         if (matchInterestRequestId) return;
 
-        if (paramGeoLocation || searchLocation) {
+        const locationToSearch = paramGeoLocation ?? searchLocation;
+        if (locationToSearch) {
             const requestId = Date.now().toString();
             setMatchInterestRequestId(requestId);
             dispatch(
                 fetchNearbyPlaceCategories({
-                    location: paramGeoLocation ?? searchLocation,
+                    location: locationToSearch,
                     requestId,
                 })
             );

--- a/src/view/hooks/useCreatePlanInterest.ts
+++ b/src/view/hooks/useCreatePlanInterest.ts
@@ -1,0 +1,207 @@
+import { getAnalytics, logEvent } from "@firebase/analytics";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { GeoLocation } from "src/domain/models/GeoLocation";
+import { LocationCategory } from "src/domain/models/LocationCategory";
+import { LocationCategoryWithPlace } from "src/domain/models/LocationCategoryWithPlace";
+import { reduxAuthSelector } from "src/redux/auth";
+import {
+    reduxLocationSelector,
+    setCurrentLocation,
+    setSearchLocation,
+} from "src/redux/location";
+import {
+    createPlanFromLocation,
+    fetchNearbyPlaceCategories,
+    pushAcceptedCategory,
+    pushRejectedCategory,
+    reduxPlanCandidateSelector,
+    resetInterest,
+    setCreatedPlans,
+} from "src/redux/planCandidate";
+import { useAppDispatch } from "src/redux/redux";
+import { AnalyticsEvents } from "src/view/constants/analytics";
+import { LocalStorageKeys } from "src/view/constants/localStorageKey";
+import { Routes } from "src/view/constants/router";
+import { useLocation } from "src/view/hooks/useLocation";
+
+export const useCreatePlanInterest = () => {
+    const dispatch = useAppDispatch();
+    const router = useRouter();
+
+    const {
+        categoryCandidates,
+        createPlanSession,
+        fetchLocationCategoryRequestId,
+        fetchNearbyPlaceCategoriesRequestStatus: matchInterestRequestStatus,
+    } = reduxPlanCandidateSelector();
+    const { user } = reduxAuthSelector();
+
+    // クエリ
+    const {
+        lat: paramLat,
+        lng: paramLng,
+        googlePlaceId: paramGooglePlaceId,
+    } = router.query;
+    const paramGeoLocation = parseGeoLocationFromQuery({
+        lat: paramLat as string,
+        lng: paramLng as string,
+    });
+    const { searchLocation, searchPlaceId } = reduxLocationSelector();
+
+    // 現在地取得
+    const { getCurrentLocation, location, fetchCurrentLocationStatus } =
+        useLocation();
+
+    // カテゴリ選択
+    const [currentCategory, setCurrentCategory] =
+        useState<LocationCategoryWithPlace | null>(null);
+    const [matchInterestRequestId, setMatchInterestRequestId] = useState<
+        string | null
+    >(null);
+
+    const handleAcceptCategory = (category: LocationCategory) => {
+        logEvent(getAnalytics(), AnalyticsEvents.Interests.SelectCategory);
+        dispatch(pushAcceptedCategory({ category }));
+    };
+
+    const handleRejectCategory = (category: LocationCategory) => {
+        dispatch(pushRejectedCategory({ category }));
+    };
+
+    // 状態のリセット
+    useEffect(() => {
+        dispatch(resetInterest());
+        setMatchInterestRequestId(null);
+
+        // 2回目以降、プランを作成するときに、前回の結果が残らないようにする
+        dispatch(
+            setCreatedPlans({
+                plans: null,
+                session: null,
+                createdBasedOnCurrentLocation: null,
+            })
+        );
+
+        return () => {
+            // 前回の結果をリセット
+            // MEMO: 戻るボタンで遷移してきたときに、状態が残っていると/plans/selectに自動的に遷移してしまう
+            dispatch(resetInterest());
+            setCurrentCategory(null);
+            setMatchInterestRequestId(null);
+
+            // 場所を指定してプラン作成 -> 現在地からプラン作成
+            // を行うと、指定した場所の情報が残り、そこからプランを作成してしまうためリセットする
+            dispatch(
+                setSearchLocation({ searchLocation: null, searchPlaceId: null })
+            );
+        };
+    }, []);
+
+    // 検索する場所が指定されていない場合は、現在地を取得する
+    useEffect(() => {
+        if (!searchLocation && !paramGeoLocation) {
+            getCurrentLocation().then();
+        }
+    }, [searchLocation, paramGeoLocation]);
+
+    // 現在地を取得したら、それをもとに検索
+    useEffect(() => {
+        if (!location) return;
+        const currentLocation = location;
+        dispatch(setCurrentLocation({ currentLocation }));
+        dispatch(
+            setSearchLocation({
+                searchLocation: currentLocation,
+                searchPlaceId: null,
+            })
+        );
+    }, [location]);
+
+    // 検索する場所が指定されたら、興味を持つ場所を検索
+    useEffect(() => {
+        // 重複してリクエストを送信しない
+        if (matchInterestRequestId) return;
+
+        if (paramGeoLocation || searchLocation) {
+            const requestId = Date.now().toString();
+            setMatchInterestRequestId(requestId);
+            dispatch(
+                fetchNearbyPlaceCategories({
+                    location: paramGeoLocation ?? searchLocation,
+                    requestId,
+                })
+            );
+        }
+    }, [searchLocation, matchInterestRequestId]);
+
+    // 付近の場所のカテゴリが選択されたら
+    useEffect(() => {
+        // TODO: hooks 内で管理する
+        if (categoryCandidates && categoryCandidates.length > 0) {
+            setCurrentCategory(categoryCandidates[0]);
+        }
+    }, [categoryCandidates?.length]);
+
+    // カテゴリが最後まで選択されたら、プランを作成する
+    useEffect(() => {
+        if (
+            categoryCandidates &&
+            categoryCandidates.length === 0 &&
+            searchLocation &&
+            createPlanSession
+        ) {
+            const googlePlaceId =
+                (paramGooglePlaceId ? (paramGooglePlaceId as string) : null) ??
+                searchPlaceId;
+
+            dispatch(
+                createPlanFromLocation({
+                    location: searchLocation,
+                    googlePlaceId,
+                })
+            );
+
+            // 作成したプラン候補を保存
+            if (!user) {
+                const createdPlanCandidates: string[] = JSON.parse(
+                    localStorage.getItem(LocalStorageKeys.PlanCandidate) ?? "[]"
+                );
+                createdPlanCandidates.push(createPlanSession);
+                localStorage.setItem(
+                    LocalStorageKeys.PlanCandidate,
+                    JSON.stringify(createdPlanCandidates)
+                );
+            }
+
+            router
+                .push(Routes.plans.planCandidate.index(createPlanSession))
+                .then();
+        }
+    }, [
+        categoryCandidates?.length,
+        searchLocation,
+        searchPlaceId,
+        paramGooglePlaceId,
+        createPlanSession,
+    ]);
+
+    return {
+        categoryCandidates,
+        currentCategory,
+        fetchLocationCategoryRequestId,
+        matchInterestRequestStatus,
+        matchInterestRequestId,
+        searchLocation: paramGeoLocation ?? searchLocation,
+        fetchCurrentLocationStatus,
+        handleAcceptCategory,
+        handleRejectCategory,
+        getCurrentLocation,
+    };
+};
+
+const parseGeoLocationFromQuery = ({ lat, lng }): GeoLocation | null => {
+    const latitude = lat ? parseFloat(lat as string) : null;
+    const longitude = lng ? parseFloat(lng as string) : null;
+    return latitude && longitude ? { latitude, longitude } : null;
+};

--- a/src/view/hooks/useLikePlaces.ts
+++ b/src/view/hooks/useLikePlaces.ts
@@ -35,7 +35,14 @@ export const useLikePlaces = () => {
         );
         // ダイアログの背景固定を解除するためにモーダルを閉じる
         dispatch(setPlaceIdToCreatePlan(null));
-        router.push(Routes.plans.interest(true)).then();
+        router
+            .push(
+                Routes.plans.interest({
+                    location: place.location,
+                    googlePlaceId: place.googlePlaceId,
+                })
+            )
+            .then();
     };
 
     useEffect(() => {

--- a/src/view/hooks/usePlanCandidateGalleryPageAutoScroll.ts
+++ b/src/view/hooks/usePlanCandidateGalleryPageAutoScroll.ts
@@ -123,10 +123,6 @@ export const usePlanCandidateGalleryPageAutoScroll = ({
         };
 
         const handlePopState = (e: PopStateEvent) => {
-            console.log({
-                event: "POP",
-                shouldScrollToPlanDetailPage,
-            });
             if (shouldScrollToPlanDetailPage) {
                 window.scrollTo({
                     top: 0,

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -82,6 +82,7 @@ function Fetching({
     );
 }
 
+// TODO: i18n
 function Failed({
     skipLocationLabel,
     onClickReFetch,

--- a/src/view/plan/button/SavePlanAsImageButton.tsx
+++ b/src/view/plan/button/SavePlanAsImageButton.tsx
@@ -28,7 +28,6 @@ export function SavePlanAsImageButton({ plan }: Props) {
             downloadLink.download = `${plan.id}.jpg`;
             document.body.append(downloadLink);
             downloadLink.click();
-            console.log(downloadLink);
             document.body.removeChild(downloadLink);
         } else {
             window.open(targetImageUri);

--- a/src/view/plandetail/CollageContainer.tsx
+++ b/src/view/plandetail/CollageContainer.tsx
@@ -13,20 +13,11 @@ export function CollageContainer({ children }: Props) {
 
     useEffect(() => {
         const handleResize = () => {
-            // console.log({
-            //     collageContainerRef: collageContainerRef.current,
-            //     collageRef: collageRef.current,
-            // })
             if (collageContainerRef.current && collageRef.current) {
                 const containerHeight =
                     collageContainerRef.current.clientHeight;
                 const collageHeight = collageRef.current.clientHeight;
                 const scaleValue = containerHeight / collageHeight;
-                console.log({
-                    containerHeight,
-                    collageHeight,
-                    scaleValue,
-                });
                 setScale(scaleValue);
             }
         };

--- a/src/view/top/CreatePlanSection.tsx
+++ b/src/view/top/CreatePlanSection.tsx
@@ -46,7 +46,7 @@ export function CreatePlanSection() {
                         <CreatePlanButton
                             title={t("home:createPlanFromCurrentLocation")}
                             icon={MdOutlineLocationOn}
-                            link={Routes.plans.interest()}
+                            link={Routes.plans.interest({})}
                             onClick={() =>
                                 logEvent(
                                     getAnalytics(),

--- a/src/view/top/NearbyPlansNotFound.tsx
+++ b/src/view/top/NearbyPlansNotFound.tsx
@@ -25,7 +25,7 @@ export const NearbyPlansNotFound = () => {
                     {t("plan:nearbyPlansEmptyDescription")}
                 </Text>
             </VStack>
-            <Link href={Routes.plans.interest()} w="100%" maxW="400px">
+            <Link href={Routes.plans.interest({})} w="100%" maxW="400px">
                 <RoundedButton>{t("plan:createPlan")}</RoundedButton>
             </Link>
         </VStack>


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- before: 戻るボタンで興味選択画面に戻ると、指定した場所が反映されない（現在地から作成される）
- after 戻るボタンで興味選択画面に戻ると、そのときに指定した場所付近のカテゴリが表示される

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #739 
- #743 

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 戻るボタンの挙動とアプリケーションの動作を一致させるため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 現在地からプランを作成したときに、興味選択画面が正しく表示されることを確認
- [x] 場所を指定してプランを作成したときに、興味選択画面が正しく表示されることを確認
- [x] 戻るボタンで興味選択画面に戻ったときに、選択した場所の状態が残っていることを確認
- [x] 以下の操作をし、戻るボタンで興味選択画面に戻ったときに、それぞれ選択した場所が反映されていることを確認 
  1. 場所を選択してプランを作成 
  2. 「komichi」ロゴタップでホームに戻る 
  3.  別の場所を作成してプランを作成
```shell
# poroto
export BRANCH_POROTO=feature/back_to_interest_page
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````