### PR TITLE
カテゴリの画像がNext/Imageで表示されるようにする

### DIFF
--- a/src/view/category/CreatePlanCategory.tsx
+++ b/src/view/category/CreatePlanCategory.tsx
@@ -1,6 +1,8 @@
-import { Box, Image, Text, VStack } from "@chakra-ui/react";
+import { Box, Skeleton, Text, VStack } from "@chakra-ui/react";
+import Image from "next/image";
+import { useState } from "react";
 import { CreatePlanPlaceCategory } from "src/domain/models/CreatePlanPlaceCategory";
-import { isPC } from "src/view/constants/userAgent";
+import { Size } from "src/view/constants/size";
 
 type Props = {
     category: CreatePlanPlaceCategory;
@@ -8,23 +10,33 @@ type Props = {
 };
 
 export function CreatePlanCategory({ category, onClick }: Props) {
-    const width = isPC ? 300 : 200;
-    const height = isPC ? 200 : 100;
+    const [isImageLoading, setIsImageLoading] = useState(true);
     return (
         <Box
-            minW={width}
-            w={width}
-            h={height}
+            minW={Size.CreatePlanCategory.CategoryImage.width}
+            w={Size.CreatePlanCategory.CategoryImage.width}
+            h={Size.CreatePlanCategory.CategoryImage.height}
             overflow="hidden"
             borderRadius="10px"
             position="relative"
             onClick={onClick}
         >
+            <Skeleton
+                position="absolute"
+                top={0}
+                right={0}
+                bottom={0}
+                left={0}
+                transition="opacity .3s"
+                opacity={isImageLoading ? 1 : 0}
+            />
             <Image
-                w={width}
-                h={height}
-                objectFit="cover"
+                width={Size.CreatePlanCategory.CategoryImage.width}
+                height={Size.CreatePlanCategory.CategoryImage.height}
                 src={category.imageUrl}
+                alt={category.displayName}
+                style={{ objectFit: "cover" }}
+                onLoad={() => setIsImageLoading(false)}
             />
             <VStack
                 userSelect="none"

--- a/src/view/constants/size.ts
+++ b/src/view/constants/size.ts
@@ -9,6 +9,12 @@ export const Size = {
             px: Padding.p24,
         },
     },
+    CreatePlanCategory: {
+        CategoryImage: {
+            width: 300,
+            height: 200,
+        },
+    },
     PlaceCardPaddingH: Padding.p16,
     NavBar: {
         height: "50px",


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- トップページのカテゴリ一覧の画像を next/image コンポーネントで表示されるようにした
- https://nextjs.org/docs/pages/api-reference/components/image

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 表示パフォーマンスを改善するため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] 画像が表示されることを確認

```shell
# poroto
export BRANCH_POROTO=feature/category_next_image
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````