### PR TITLE
Next/Imageを利用しない

### DIFF
--- a/src/view/category/CreatePlanCategory.tsx
+++ b/src/view/category/CreatePlanCategory.tsx
@@ -1,4 +1,4 @@
-import { Box, Skeleton, Text, VStack, Image } from "@chakra-ui/react";
+import { Box, Image, Text, VStack } from "@chakra-ui/react";
 import { useState } from "react";
 import { CreatePlanPlaceCategory } from "src/domain/models/CreatePlanPlaceCategory";
 import { Size } from "src/view/constants/size";
@@ -31,8 +31,8 @@ export function CreatePlanCategory({ category, onClick }: Props) {
             {/*    opacity={isImageLoading ? 1 : 0}*/}
             {/*/>*/}
             <Image
-                width={Size.CreatePlanCategory.CategoryImage.width+"px"}
-                height={Size.CreatePlanCategory.CategoryImage.height+"px"}
+                width={Size.CreatePlanCategory.CategoryImage.width + "px"}
+                height={Size.CreatePlanCategory.CategoryImage.height + "px"}
                 src={category.imageUrl}
                 alt={category.displayName}
                 style={{ objectFit: "cover" }}

--- a/src/view/category/CreatePlanCategory.tsx
+++ b/src/view/category/CreatePlanCategory.tsx
@@ -1,5 +1,4 @@
-import { Box, Skeleton, Text, VStack } from "@chakra-ui/react";
-import Image from "next/image";
+import { Box, Skeleton, Text, VStack, Image } from "@chakra-ui/react";
 import { useState } from "react";
 import { CreatePlanPlaceCategory } from "src/domain/models/CreatePlanPlaceCategory";
 import { Size } from "src/view/constants/size";
@@ -31,8 +30,8 @@ export function CreatePlanCategory({ category, onClick }: Props) {
                 opacity={isImageLoading ? 1 : 0}
             />
             <Image
-                width={Size.CreatePlanCategory.CategoryImage.width}
-                height={Size.CreatePlanCategory.CategoryImage.height}
+                width={Size.CreatePlanCategory.CategoryImage.width+"px"}
+                height={Size.CreatePlanCategory.CategoryImage.height+"px"}
                 src={category.imageUrl}
                 alt={category.displayName}
                 style={{ objectFit: "cover" }}

--- a/src/view/category/CreatePlanCategory.tsx
+++ b/src/view/category/CreatePlanCategory.tsx
@@ -20,15 +20,16 @@ export function CreatePlanCategory({ category, onClick }: Props) {
             position="relative"
             onClick={onClick}
         >
-            <Skeleton
-                position="absolute"
-                top={0}
-                right={0}
-                bottom={0}
-                left={0}
-                transition="opacity .3s"
-                opacity={isImageLoading ? 1 : 0}
-            />
+            {/*TDOO：もとにもどす*/}
+            {/*<Skeleton*/}
+            {/*    position="absolute"*/}
+            {/*    top={0}*/}
+            {/*    right={0}*/}
+            {/*    bottom={0}*/}
+            {/*    left={0}*/}
+            {/*    transition="opacity .3s"*/}
+            {/*    opacity={isImageLoading ? 1 : 0}*/}
+            {/*/>*/}
             <Image
                 width={Size.CreatePlanCategory.CategoryImage.width+"px"}
                 height={Size.CreatePlanCategory.CategoryImage.height+"px"}

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -10,9 +10,9 @@ import {
     Skeleton,
     Text,
     VStack,
+    Image,
 } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
-import Image from "next/image";
 import * as process from "process";
 import { useRef, useState } from "react";
 import {
@@ -322,9 +322,8 @@ function SchedulePlaceCard({
                 <Image
                     src={place.images[0].small}
                     alt={place.name}
-                    width={Size.PlanDetailHeader.Schedule.Place.width}
-                    height={Size.PlanDetailHeader.Schedule.Place.height}
-                    quality={30}
+                    width={Size.PlanDetailHeader.Schedule.Place.width+"px"}
+                    height={Size.PlanDetailHeader.Schedule.Place.height+"px"}
                     style={{
                         width: "100%",
                         height: "100%",

--- a/src/view/plandetail/header/PlanDetailPageHeader.tsx
+++ b/src/view/plandetail/header/PlanDetailPageHeader.tsx
@@ -7,10 +7,10 @@ import {
     Flex,
     HStack,
     Icon,
+    Image,
     Skeleton,
     Text,
     VStack,
-    Image,
 } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
 import * as process from "process";
@@ -322,8 +322,8 @@ function SchedulePlaceCard({
                 <Image
                     src={place.images[0].small}
                     alt={place.name}
-                    width={Size.PlanDetailHeader.Schedule.Place.width+"px"}
-                    height={Size.PlanDetailHeader.Schedule.Place.height+"px"}
+                    width={Size.PlanDetailHeader.Schedule.Place.width + "px"}
+                    height={Size.PlanDetailHeader.Schedule.Place.height + "px"}
                     style={{
                         width: "100%",
                         height: "100%",

--- a/src/view/user/UserAvatar.tsx
+++ b/src/view/user/UserAvatar.tsx
@@ -1,5 +1,4 @@
-import { Avatar, Center, Skeleton } from "@chakra-ui/react";
-import Image from "next/image";
+import { Avatar, Center, Skeleton, Image } from "@chakra-ui/react";
 import { User } from "src/domain/models/User";
 import { Size } from "src/view/constants/size";
 import { zIndex } from "src/view/constants/zIndex";
@@ -33,8 +32,8 @@ export function UserAvatar({ user, onClick }: Props) {
                             left="0"
                         />
                         <Image
-                            height={33}
-                            width={33}
+                            height={33+"px"}
+                            width={33+"px"}
                             alt="avatar image"
                             src={user.avatarImage}
                             style={{ zIndex: zIndex.navBarAvatarIcon }}

--- a/src/view/user/UserAvatar.tsx
+++ b/src/view/user/UserAvatar.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Center, Skeleton, Image } from "@chakra-ui/react";
+import { Avatar, Center, Image, Skeleton } from "@chakra-ui/react";
 import { User } from "src/domain/models/User";
 import { Size } from "src/view/constants/size";
 import { zIndex } from "src/view/constants/zIndex";
@@ -32,8 +32,8 @@ export function UserAvatar({ user, onClick }: Props) {
                             left="0"
                         />
                         <Image
-                            height={33+"px"}
-                            width={33+"px"}
+                            height={33 + "px"}
+                            width={33 + "px"}
                             alt="avatar image"
                             src={user.avatarImage}
                             style={{ zIndex: zIndex.navBarAvatarIcon }}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
<!--
|before| after |
|---|-------|
|||
-->
- Google App Engineだと、next/imagesが利用できないため、一時的にchakraのImageを利用するように修正

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [ ] プランが表示されていることを確認
- [ ] プランが作成できることを確認
- [ ] プランが保存できることを確認
- [ ]

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````