### PR TITLE
カテゴリから作成するとき、現在地から調べられるようにする

### DIFF
--- a/src/locales/en/location.ts
+++ b/src/locales/en/location.ts
@@ -2,4 +2,5 @@ import { LocationTranslationKeys } from "src/locales/type";
 
 export const LocationTranslationEn: LocationTranslationKeys = {
     fetchCurrentLocationInProgress: "Fetching current location...",
+    fetchCurrentLocationFailed: "Failed to get current location.",
 };

--- a/src/locales/en/plan.ts
+++ b/src/locales/en/plan.ts
@@ -33,6 +33,8 @@ export const PlanTranslationEn: PlanTranslationKeys = {
         "Let's create a plan from your current mood!",
     createPlanByCategorySelectRangeTitle: "How far are you going?",
     createPlanByCategory: "Create a plan within the selected range",
+    createPlanByCategorySelectLocationTitle: "Tap to select a location",
+    createPlanByCategoryLocationNotSelectedError: "Location is not selected.",
 
     customizePlan: "Customize this plan",
     customizePlanCreated: "The plan for customization is ready!",

--- a/src/locales/ja/location.ts
+++ b/src/locales/ja/location.ts
@@ -2,4 +2,5 @@ import { LocationTranslationKeys } from "src/locales/type";
 
 export const LocationTranslationJa: LocationTranslationKeys = {
     fetchCurrentLocationInProgress: "位置情報を取得しています...",
+    fetchCurrentLocationFailed: "現在地の取得に失敗しました。",
 };

--- a/src/locales/ja/plan.ts
+++ b/src/locales/ja/plan.ts
@@ -33,6 +33,8 @@ export const PlanTranslationJa: PlanTranslationKeys = {
         "今の気分からお任せでプランを作ってみましょう！",
     createPlanByCategorySelectRangeTitle: "どこまで行く？",
     createPlanByCategory: "選択した範囲でプランを作成",
+    createPlanByCategorySelectLocationTitle: "タップして場所を選択",
+    createPlanByCategoryLocationNotSelectedError: "場所が選択されていません。",
 
     customizePlan: "このプランをカスタマイズする",
     customizePlanCreated: "カスタマイズ用のプランの準備ができました！",

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -124,6 +124,8 @@ export type PlanTranslationKeys = {
     createPlanByCategoryDescription: string;
     createPlanByCategorySelectRangeTitle: string;
     createPlanByCategory: string;
+    createPlanByCategorySelectLocationTitle: string;
+    createPlanByCategoryLocationNotSelectedError: string;
 
     customizePlan: string;
     customizePlanCreated: string;

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -74,6 +74,7 @@ export type HomeTranslationKeys = {
 
 export type LocationTranslationKeys = {
     fetchCurrentLocationInProgress: string;
+    fetchCurrentLocationFailed: string;
 };
 
 export type NavigationTranslationKeys = {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, VStack } from "@chakra-ui/react";
+import { Text, VStack } from "@chakra-ui/react";
 import { GetStaticProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { PlannerGraphQlApi } from "src/data/graphql/PlannerGraphQlApi";
@@ -20,8 +20,6 @@ import {
     BottomNavigationPages,
 } from "src/view/navigation/BottomNavigation";
 import { NavBar } from "src/view/navigation/NavBar";
-import { PlaceSearchBar } from "src/view/place/PlaceSearchBar";
-import { PlaceSearchResults } from "src/view/place/PlaceSearchResults";
 import { CreatePlanSection } from "src/view/top/CreatePlanSection";
 import { PwaInstallDialog } from "src/view/top/PwaInstallDialog";
 import { PwaIosInstruction } from "src/view/top/PwaIosInstruction";
@@ -108,35 +106,9 @@ const IndexPage = (props: Props) => {
                     visible={isCreatePlanCategoryRangeDialogVisible}
                     onClose={onCloseCreatePlanCategoryRangeDialog}
                     onConfirm={onSelectCreatePlanRange}
-                    googlePlaceSearchBar={
-                        <VStack
-                            px={Padding.p8}
-                            py={Padding.p16}
-                            top={0}
-                            left={0}
-                            right={0}
-                            position="relative"
-                        >
-                            <PlaceSearchBar
-                                onSearch={searchGooglePlacesByQuery}
-                            />
-                            <Box
-                                w="100%"
-                                backgroundColor="white"
-                                borderRadius={5}
-                                boxShadow={
-                                    placeSearchResults &&
-                                    placeSearchResults.length !== 0 &&
-                                    "0px 5px 20px 0px rgb(0 0 0 / 10%)"
-                                }
-                            >
-                                <PlaceSearchResults
-                                    places={placeSearchResults}
-                                    onClickPlace={onSelectedSearchResult}
-                                />
-                            </Box>
-                        </VStack>
-                    }
+                    googlePlaceSearchResults={placeSearchResults}
+                    onSearchGooglePlacesByQuery={searchGooglePlacesByQuery}
+                    onClickGooglePlaceSearchResult={onSelectedSearchResult}
                 />
                 {isCreatingPlanFromCategory && (
                     <LoadingModal title={t("plan:createPlanInProgressTitle")} />

--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -28,8 +28,7 @@ import { FetchLocationDialog } from "src/view/location/FetchLocationDialog";
 import { NavBar } from "src/view/navigation/NavBar";
 import { MapPinSelector } from "src/view/place/MapPinSelector";
 import { PlaceRecommendationDialog } from "src/view/place/PlaceRecommendationDialog";
-import { PlaceSearchBar } from "src/view/place/PlaceSearchBar";
-import { PlaceSearchResults } from "src/view/place/PlaceSearchResults";
+import { PlaceSearch } from "src/view/place/PlaceSearch";
 import { ShowPlaceRecommendationButton } from "src/view/place/ShowPlaceRecommendationButton";
 
 export default function Page() {
@@ -179,42 +178,25 @@ function PlaceSearchPage() {
                         pinnedLocation={placeSelected?.location}
                     />
                 </Box>
-                <VStack
+                <Box
                     w="100%"
                     maxW={Size.mainContentWidth}
                     pt="24px"
                     px="8px"
-                    spacing={4}
-                    position="relative"
                     zIndex={10}
+                    position="relative"
                 >
-                    <Box w="100%">
-                        <PlaceSearchBar
-                            defaultValue={searchQuery}
-                            onSearch={searchGooglePlacesByQuery}
-                        />
-                    </Box>
-                    {isPlaceRecommendationButtonVisible && (
-                        <ShowPlaceRecommendationButton
-                            onClick={onOpenPlaceRecommendationDialog}
-                        />
-                    )}
-                    <Box
-                        w="100%"
-                        backgroundColor="white"
-                        borderRadius={5}
-                        boxShadow={
-                            placeSearchResults &&
-                            placeSearchResults.length !== 0 &&
-                            "0px 5px 20px 0px rgb(0 0 0 / 10%)"
+                    <PlaceSearch
+                        googlePlaceSearchResults={placeSearchResults}
+                        onSearchGooglePlacesByQuery={searchGooglePlacesByQuery}
+                        onClickGooglePlaceSearchResult={onSelectedSearchResult}
+                        placeSearchActions={
+                            <ShowPlaceRecommendationButton
+                                onClick={onOpenPlaceRecommendationDialog}
+                            />
                         }
-                    >
-                        <PlaceSearchResults
-                            places={placeSearchResults}
-                            onClickPlace={onSelectedSearchResult}
-                        />
-                    </Box>
-                </VStack>
+                    />
+                </Box>
                 {/*
             MEMO:
             `space-between` で余白をつけようとすると、その部分を選択できなくなってしまうため、

--- a/src/view/category/CreatePlanRangeDialog.tsx
+++ b/src/view/category/CreatePlanRangeDialog.tsx
@@ -12,12 +12,13 @@ import {
     VStack,
 } from "@chakra-ui/react";
 import { Circle, Marker } from "@react-google-maps/api";
-import { CSSProperties, ReactElement, useEffect, useState } from "react";
+import { CSSProperties, useEffect, useState } from "react";
 import { IconType } from "react-icons";
 import {
     MdArrowBack,
     MdDirectionsCar,
     MdDirectionsWalk,
+    MdLocationOn,
     MdTouchApp,
 } from "react-icons/md";
 import { RiPinDistanceFill } from "react-icons/ri";
@@ -36,6 +37,8 @@ import { locationSinjukuStation } from "src/view/constants/location";
 import { Padding } from "src/view/constants/padding";
 import { isPC } from "src/view/constants/userAgent";
 import { useAppTranslation } from "src/view/hooks/useAppTranslation";
+import { useLocation } from "src/view/hooks/useLocation";
+import { PlaceSearch, PlaceSearchProps } from "src/view/place/PlaceSearch";
 
 type Props = {
     visible: boolean;
@@ -43,16 +46,18 @@ type Props = {
     defaultMapCenter?: GeoLocation;
     onClose: () => void;
     onConfirm: (props: { rangeInKm: number; location: GeoLocation }) => void;
-    googlePlaceSearchBar?: ReactElement;
-};
+} & PlaceSearchProps;
 
 export function CreatePlanRangeDialog({
     visible,
     defaultMapCenter,
     minRangeInKm = 2,
-    googlePlaceSearchBar,
     onClose,
     onConfirm,
+
+    googlePlaceSearchResults,
+    onSearchGooglePlacesByQuery,
+    onClickGooglePlaceSearchResult,
 }: Props) {
     const { t } = useAppTranslation();
     const toast = useToast();
@@ -61,6 +66,7 @@ export function CreatePlanRangeDialog({
         locationSinjukuStation
     );
     const [location, setLocation] = useState<GeoLocation>(null);
+    const { location: currentLocation, getCurrentLocation } = useLocation();
 
     const calcDirectionWalkTime = (distanceInKm: number) => {
         const walkSpeed = 4;
@@ -187,7 +193,24 @@ export function CreatePlanRangeDialog({
                                     }}
                                 />
                             )}
-                            {googlePlaceSearchBar && googlePlaceSearchBar}
+                            <Box w="100%" position="relative">
+                                <PlaceSearch
+                                    onSearchGooglePlacesByQuery={
+                                        onSearchGooglePlacesByQuery
+                                    }
+                                    onClickGooglePlaceSearchResult={
+                                        onClickGooglePlaceSearchResult
+                                    }
+                                    googlePlaceSearchResults={
+                                        googlePlaceSearchResults
+                                    }
+                                    placeSearchActions={
+                                        <SetByCurrentLocationButton
+                                            onClick={getCurrentLocation}
+                                        />
+                                    }
+                                />
+                            </Box>
                             <VStack
                                 w="170px"
                                 justifyContent="center"
@@ -317,5 +340,22 @@ function TapMapOverlay() {
                 </Center>
             )}
         </Transition>
+    );
+}
+
+function SetByCurrentLocationButton({ onClick }: { onClick: () => void }) {
+    return (
+        <HStack
+            as="button"
+            backgroundColor="white"
+            color="#2D59C9"
+            borderRadius="50px"
+            px={Padding.p8}
+            py={Padding.p4}
+            onClick={onClick}
+        >
+            <Icon as={MdLocationOn} />
+            <Text>現在地を中心にする</Text>
+        </HStack>
     );
 }

--- a/src/view/category/CreatePlanRangeDialog.tsx
+++ b/src/view/category/CreatePlanRangeDialog.tsx
@@ -343,7 +343,7 @@ function TapMapOverlay() {
             {(state) => (
                 <Center
                     style={transitionStyles[state]}
-                    backgroundColor="rgba(0,0,0,.5)"
+                    backgroundColor="rgba(0,0,0,.2)"
                     onClick={() => setIsFirstTap(false)}
                     transition="opacity 0.3s"
                     position="absolute"

--- a/src/view/category/CreatePlanRangeDialog.tsx
+++ b/src/view/category/CreatePlanRangeDialog.tsx
@@ -330,7 +330,7 @@ function TapMapOverlay() {
 
     const transitionStyles: { [key in TransitionStatus]: CSSProperties } = {
         unmounted: { opacity: 0, visibility: "hidden" },
-        entering: { opacity: 0, visibility: "visible" },
+        entering: { opacity: 1, visibility: "visible" },
         entered: { opacity: 1, visibility: "visible" },
         exiting: { opacity: 0, visibility: "visible" },
         exited: { opacity: 0, visibility: "hidden" },
@@ -343,7 +343,7 @@ function TapMapOverlay() {
             {(state) => (
                 <Center
                     style={transitionStyles[state]}
-                    backgroundColor="rgba(0,0,0,.7)"
+                    backgroundColor="rgba(0,0,0,.5)"
                     onClick={() => setIsFirstTap(false)}
                     transition="opacity 0.3s"
                     position="absolute"

--- a/src/view/common/FullscreenDialog.tsx
+++ b/src/view/common/FullscreenDialog.tsx
@@ -96,29 +96,33 @@ export function FullscreenDialog({
                 exit: 200,
             }}
         >
-            {(state) => (
-                <FullscreenDialogWrapper
-                    style={{
-                        ...transitionStyles[state],
-                    }}
-                >
-                    <Container position={position}>
-                        {/* MEMO: FullscreenDialogWrapper にonClick属性をつけて、zIndex:9999 にしても、childrenに触れたときにonClickOutsideが発火してしまう*/}
-                        <TouchDetector onClick={onClickOutside} />
-                        <Box
-                            zIndex={9999}
-                            px={paddingX ?? padding}
-                            py={paddingY ?? padding}
-                            w={width}
-                            h={height}
-                            maxW={maxWidth}
-                            maxH={maxHeight}
-                        >
-                            {children}
-                        </Box>
-                    </Container>
-                </FullscreenDialogWrapper>
-            )}
+            {(state) =>
+                state === "exited" || state === "unmounted" ? (
+                    <></>
+                ) : (
+                    <FullscreenDialogWrapper
+                        style={{
+                            ...transitionStyles[state],
+                        }}
+                    >
+                        <Container position={position}>
+                            {/* MEMO: FullscreenDialogWrapper にonClick属性をつけて、zIndex:9999 にしても、childrenに触れたときにonClickOutsideが発火してしまう*/}
+                            <TouchDetector onClick={onClickOutside} />
+                            <Box
+                                zIndex={9999}
+                                px={paddingX ?? padding}
+                                py={paddingY ?? padding}
+                                w={width}
+                                h={height}
+                                maxW={maxWidth}
+                                maxH={maxHeight}
+                            >
+                                {children}
+                            </Box>
+                        </Container>
+                    </FullscreenDialogWrapper>
+                )
+            }
         </Transition>
     );
 }

--- a/src/view/place/PlaceSearch.tsx
+++ b/src/view/place/PlaceSearch.tsx
@@ -1,0 +1,43 @@
+import { Box, VStack } from "@chakra-ui/react";
+import { ReactNode } from "react";
+import { PlaceSearchResult } from "src/domain/models/PlaceSearchResult";
+import { PlaceSearchBar } from "src/view/place/PlaceSearchBar";
+import { PlaceSearchResults } from "src/view/place/PlaceSearchResults";
+
+export type PlaceSearchProps = {
+    googlePlaceSearchResults?: PlaceSearchResult[];
+    placeSearchActions?: ReactNode;
+    onSearchGooglePlacesByQuery: (query: string) => void;
+    onClickGooglePlaceSearchResult: (searchResult: PlaceSearchResult) => void;
+};
+
+export function PlaceSearch({
+    placeSearchActions,
+    googlePlaceSearchResults,
+    onSearchGooglePlacesByQuery,
+    onClickGooglePlaceSearchResult,
+}: PlaceSearchProps) {
+    const isEmptySearchResults =
+        !googlePlaceSearchResults || googlePlaceSearchResults.length === 0;
+    return (
+        <VStack spacing={4}>
+            <PlaceSearchBar onSearch={onSearchGooglePlacesByQuery} />
+            {isEmptySearchResults && placeSearchActions && placeSearchActions}
+            <Box
+                w="100%"
+                backgroundColor="white"
+                borderRadius={5}
+                boxShadow={
+                    !isEmptySearchResults && "0px 5px 20px 0px rgb(0 0 0 / 10%)"
+                }
+            >
+                <PlaceSearchResults
+                    places={googlePlaceSearchResults}
+                    onClickPlace={(place) =>
+                        onClickGooglePlaceSearchResult(place)
+                    }
+                />
+            </Box>
+        </VStack>
+    );
+}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

- カテゴリから作成するときに表示されるダイアログに、「中心を現在地にする」ボタンを追加
- 初回表示のときに、「タップして中心位置を指定する」ように促すオーバーレイを表示

|before| after |
|---|-------|
|![image](https://github.com/poroto-app/poroto/assets/55840281/7f8fd3ed-4df8-43e9-a987-c230bfe4ff48)|![image](https://github.com/poroto-app/poroto/assets/55840281/4f2b64c1-0339-49d8-894f-d23112b80d2c)|
||![image](https://github.com/poroto-app/poroto/assets/55840281/ab2ed9bd-5547-4e8f-808b-7355528b7837)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- 場所の指定をより簡単にできるようにするため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] 「現在地を中心にする」 ボタンを押すと、現在地が取得され中心になることを確認
- [x] 場所を検索する機能が利用可能なことを確認
- [x] 地図をタップしても指定できることを確認
- [x] 場所を指定していない状態でプランを作成するとトーストが表示されることを確認  
- [x] 好きな場所からプランを作成するページが正常に動作することを確認（影響範囲）

```shell
# poroto
export BRANCH_POROTO=https://github.com/poroto-app/poroto/pull/762#issue-2393899103
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````