### PR TITLE
Link, useRouter をsolitoに置き換え

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -5,7 +5,11 @@ import {DefinePlugin} from "webpack";
 
 const config: StorybookConfig = {
     "stories": ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
-    "addons": ["@storybook/addon-links", "@storybook/addon-essentials", "@storybook/addon-interactions"],
+    "addons": [
+        "@storybook/addon-links",
+        "@storybook/addon-essentials",
+        "@storybook/addon-interactions",
+    ],
     framework: {
         name: "@storybook/nextjs",
         options: {}
@@ -43,6 +47,7 @@ const config: StorybookConfig = {
             // tamagui
             // https://github.com/ralphwaked/tamagui-storybook-example/
             const projectRoot = path.resolve(__dirname, "..");
+            config.resolve.extensions.unshift('.web.js');
             config.resolve.alias = {
                 ...config.resolve.alias,
                 'react-native$': 'react-native-web',
@@ -63,9 +68,7 @@ const config: StorybookConfig = {
                     }
                 ],
             });
-            config.plugins.push(new DefinePlugin({
-                'process.env.TAMAGUI_TARGET': '"web"',
-            }))
+            config.plugins.push(new DefinePlugin({'process.env.TAMAGUI_TARGET': '"web"'}))
         }
         return config
     },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,7 @@ import pwa from "next-pwa";
 import runtimeCaching from 'next-pwa/cache.js';
 import remarkUnwrapImages from 'remark-unwrap-images';
 import {withTamagui as tamagui} from '@tamagui/next-plugin';
+import withPlugins from 'next-compose-plugins';
 
 const withPWA = pwa({
     dest: 'public',
@@ -102,4 +103,8 @@ const nextConfig = {
     },
 };
 
-export default withPWA(withMDX(withTamagui(nextConfig)));
+export default withPlugins([
+    [withPWA],
+    [withMDX],
+    [withTamagui],
+], nextConfig);

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-redux": "^9.1.0",
     "react-transition-group": "^4.4.5",
     "remark-unwrap-images": "^4.0.0",
+    "solito": "^4.2.2",
     "styled-components": "^6.1.8",
     "tamagui": "^1.104.2",
     "uuid": "^10.0.0"
@@ -115,6 +116,7 @@
     "eslint-config-next": "13.4.10",
     "eslint-config-prettier": "^9.1.0",
     "jest": "^29.7.0",
+    "next-compose-plugins": "^2.2.1",
     "playwright": "^1.45.0",
     "prettier-plugin-organize-imports": "^4.0.0",
     "storybook": "^8.1.3",

--- a/src/hooks/useCreatePlanCategory.ts
+++ b/src/hooks/useCreatePlanCategory.ts
@@ -1,6 +1,6 @@
 import { getAnalytics, logEvent } from "@firebase/analytics";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { Routes } from "src/constant/router";
 import { CreatePlanPlaceCategory } from "src/domain/models/CreatePlanPlaceCategory";
@@ -79,12 +79,9 @@ export const useCreatePlanCategory = () => {
             createPlanSession &&
             createPlanByCategoryRequestStatus === RequestStatuses.FULFILLED
         ) {
-            router
-                .push(Routes.plans.planCandidate.index(createPlanSession))
-                .then(() => {
-                    setIsCreatingPlanFromCategory(false);
-                    dispatch(resetCreatePlanByCategoryRequestStatus());
-                });
+            router.push(Routes.plans.planCandidate.index(createPlanSession));
+            setIsCreatingPlanFromCategory(false);
+            dispatch(resetCreatePlanByCategoryRequestStatus());
         }
     }, [createPlanSession, createPlanByCategoryRequestStatus]);
 

--- a/src/hooks/useCreatePlanFromSavedPlan.ts
+++ b/src/hooks/useCreatePlanFromSavedPlan.ts
@@ -1,7 +1,7 @@
 import { useToast } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useRouter } from "solito/router";
 import { Routes } from "src/constant/router";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { hasValue } from "src/domain/util/null";
@@ -28,17 +28,18 @@ export const useCreatePlanFromSavedPlan = () => {
             createPlanFromSavedPlanRequestStatus === RequestStatuses.FULFILLED
         ) {
             dispatch(resetCreatePlanFromSavedPlanRequestStatus());
-            router
-                .push(Routes.plans.planCandidate.index(createPlanSession))
-                .then(() => {
-                    setIsCreatingPlanFromSavedPlan(false);
-                    toast({
-                        title: t("plan:customizePlanCreated"),
-                        status: "success",
-                        duration: 3000,
-                        isClosable: true,
-                    });
+            router.push(Routes.plans.planCandidate.index(createPlanSession));
+
+            // TODO: 遷移が終了したタイミングでモーダルが閉じるようにする
+            return () => {
+                setIsCreatingPlanFromSavedPlan(false);
+                toast({
+                    title: t("plan:customizePlanCreated"),
+                    status: "success",
+                    duration: 3000,
+                    isClosable: true,
                 });
+            };
         }
     }, [createPlanSession, createPlanFromSavedPlanRequestStatus]);
 

--- a/src/hooks/useCreatePlanInterest.ts
+++ b/src/hooks/useCreatePlanInterest.ts
@@ -1,6 +1,7 @@
 import { getAnalytics, logEvent } from "@firebase/analytics";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { createParam } from "solito";
+import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { LocalStorageKeys } from "src/constant/localStorageKey";
 import { Routes } from "src/constant/router";
@@ -23,6 +24,12 @@ import {
 } from "src/redux/planCandidate";
 import { useAppDispatch } from "src/redux/redux";
 
+const { useParams } = createParam<{
+    lat: string;
+    lng: string;
+    googlePlaceId: string;
+}>();
+
 export const useCreatePlanInterest = () => {
     const dispatch = useAppDispatch();
     const router = useRouter();
@@ -40,7 +47,7 @@ export const useCreatePlanInterest = () => {
         lat: paramLat,
         lng: paramLng,
         googlePlaceId: paramGooglePlaceId,
-    } = router.query;
+    } = useParams().params;
     const paramGeoLocation = parseGeoLocationFromQuery({
         lat: paramLat as string,
         lng: paramLng as string,
@@ -202,9 +209,7 @@ export const useCreatePlanInterest = () => {
                 );
             }
 
-            router
-                .push(Routes.plans.planCandidate.index(createPlanSession))
-                .then();
+            router.push(Routes.plans.planCandidate.index(createPlanSession));
         }
     }, [
         categoryCandidates?.length,

--- a/src/hooks/useLikePlaces.ts
+++ b/src/hooks/useLikePlaces.ts
@@ -1,6 +1,6 @@
 import { getAnalytics, logEvent } from "@firebase/analytics";
-import { useRouter } from "next/router";
 import { useEffect } from "react";
+import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { Routes } from "src/constant/router";
 import { Place } from "src/domain/models/Place";
@@ -35,14 +35,12 @@ export const useLikePlaces = () => {
         );
         // ダイアログの背景固定を解除するためにモーダルを閉じる
         dispatch(setPlaceIdToCreatePlan(null));
-        router
-            .push(
-                Routes.plans.interest({
-                    location: place.location,
-                    googlePlaceId: place.googlePlaceId,
-                })
-            )
-            .then();
+        router.push(
+            Routes.plans.interest({
+                location: place.location,
+                googlePlaceId: place.googlePlaceId,
+            })
+        );
     };
 
     useEffect(() => {

--- a/src/hooks/usePlanCandidateGalleryPageAutoScroll.ts
+++ b/src/hooks/usePlanCandidateGalleryPageAutoScroll.ts
@@ -1,5 +1,5 @@
-import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
+import { useRouter } from "solito/router";
 
 export const usePlanCandidateGalleryPageAutoScroll = ({
     planCandidateId,
@@ -146,7 +146,8 @@ export const usePlanCandidateGalleryPageAutoScroll = ({
                     top: 0,
                     behavior: "smooth",
                 });
-                router.events.emit("routeChangeComplete", router.asPath);
+                // TODO: fix me!
+                // router.events.emit("routeChangeComplete", router.asPath);
                 e.preventDefault();
             }
         };

--- a/src/hooks/usePlanCreate.ts
+++ b/src/hooks/usePlanCreate.ts
@@ -1,6 +1,6 @@
 import { getAuth } from "@firebase/auth";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useRouter } from "solito/router";
 import { Routes } from "src/constant/router";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { setShowPlanCreatedModal } from "src/redux/plan";
@@ -40,13 +40,14 @@ export const usePlanCreate = ({ planCandidateSetId, planId }: Props) => {
     useEffect(() => {
         if (!plan) return;
         if (savePlanFromCandidateRequestStatus === RequestStatuses.FULFILLED) {
-            router.push(Routes.plans.plan(plan.id)).then(() => {
-                // 遷移が終了したタイミングでモーダルが閉じるようにする
+            router.push(Routes.plans.plan(plan.id));
+            dispatch(setShowPlanCreatedModal(true));
+            // TODO: 遷移が終了したタイミングでモーダルが閉じるようにする
+            return () => {
                 setIsCreatingPlan(false);
                 // 戻ったときに再リダイレクトされないようにする
                 dispatch(resetPlanCandidates());
-            });
-            dispatch(setShowPlanCreatedModal(true));
+            };
         }
     }, [planId, savePlanFromCandidateRequestStatus]);
 

--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -2,9 +2,10 @@ import { Box, Center, VStack } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useTranslation } from "next-i18next";
 import Head from "next/head";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { MdDone, MdOutlineTouchApp } from "react-icons/md";
+import { createParam } from "solito";
+import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { locationSinjukuStation } from "src/constant/location";
 import { PageMetaData } from "src/constant/meta";
@@ -31,6 +32,8 @@ import { PlaceRecommendationDialog } from "src/view/place/PlaceRecommendationDia
 import { PlaceSearch } from "src/view/place/PlaceSearch";
 import { ShowPlaceRecommendationButton } from "src/view/place/ShowPlaceRecommendationButton";
 
+const { useParam } = createParam();
+
 export default function Page() {
     const { t } = useTranslation();
     return (
@@ -49,8 +52,8 @@ export default function Page() {
 
 function PlaceSearchPage() {
     const router = useRouter();
-    const isSkipFetchCurrentLocation =
-        router.query[RouteParams.SkipCurrentLocation] === "true";
+    const [skipCurrentLocation] = useParam(RouteParams.SkipCurrentLocation);
+    const isSkipFetchCurrentLocation = skipCurrentLocation === "true";
     const { t } = useTranslation();
     const dispatch = useAppDispatch();
     const [searchQuery, setSearchQuery] = useState<string>("");

--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -2,9 +2,10 @@ import { Box, Button, Center, useToast, VStack } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useTranslation } from "next-i18next";
 import Head from "next/head";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { MdOutlineExplore, MdOutlineNearMe } from "react-icons/md";
+import { createParam } from "solito";
+import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { Colors } from "src/constant/color";
 import { Padding } from "src/constant/padding";
@@ -50,9 +51,11 @@ import { PlanInfoSection } from "src/view/plandetail/PlanInfoSection";
 import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
 import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
 
+const { useParam } = createParam<{ id: string }>();
+
 export default function PlanPage() {
     const { t } = useTranslation();
-    const { id } = useRouter().query;
+    const [id] = useParam("id");
     const dispatch = useAppDispatch();
     const router = useRouter();
     const toast = useToast();

--- a/src/pages/plans/interest.tsx
+++ b/src/pages/plans/interest.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "next-i18next";
 import Head from "next/head";
-import { useRouter } from "next/router";
 import { ReactNode } from "react";
+import { createParam } from "solito";
 import { PageMetaData } from "src/constant/meta";
 import { LocationCategory } from "src/domain/models/LocationCategory";
 import { LocationCategoryWithPlace } from "src/domain/models/LocationCategoryWithPlace";
@@ -19,15 +19,18 @@ import { FetchLocationDialog } from "src/view/location/FetchLocationDialog";
 import { NavBar } from "src/view/navigation/NavBar";
 import { MatchInterestPageTemplate } from "src/view/plan/MatchInterestPageTemplate";
 
+const { useParams } = createParam<{ location?: string }>();
+
 export default function Page() {
-    const router = useRouter();
     const { t } = useTranslation();
+    const { params } = useParams();
+
     return (
         <>
             <Head>
                 <title>
                     {PageMetaData(t).plans.interest.title(
-                        router.query["location"] !== "true"
+                        params.location !== "true"
                     )}
                 </title>
                 <meta

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -1,8 +1,9 @@
 import { Box, Button, Center, Text, VStack } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
-import { useRouter } from "next/router";
 import { useRef, useState } from "react";
 import { MdOutlineNearMe } from "react-icons/md";
+import { createParam } from "solito";
+import { useRouter } from "solito/router";
 import { Colors } from "src/constant/color";
 import { Size } from "src/constant/size";
 import { isPC } from "src/constant/userAgent";
@@ -49,12 +50,14 @@ import { PlanPlaceList } from "src/view/plandetail/PlanPlaceList";
 import { PlanDetailPageHeader } from "src/view/plandetail/header/PlanDetailPageHeader";
 import { PlanListSectionTitle } from "src/view/top/PlanListSectionTitle";
 
+const { useParams } = createParam<{ sessionId?: string }>();
+
 const SelectPlanPage = () => {
     const { t } = useTranslation();
     const dispatch = useAppDispatch();
 
     const router = useRouter();
-    const { sessionId } = router.query;
+    const { sessionId } = useParams().params;
     const [selectedPlanIndex, setSelectedPlanIndex] = useState(0);
     const refPlanCandidateGallery = useRef<HTMLDivElement>(null);
     const {

--- a/src/view/common/ErrorPage.tsx
+++ b/src/view/common/ErrorPage.tsx
@@ -1,7 +1,7 @@
-import { Link } from "@chakra-ui/next-js";
 import { Button } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
+import { Link } from "solito/link";
 import { Colors } from "src/constant/color";
 import { Routes } from "src/constant/router";
 import Notify from "src/view/assets/svg/notify.svg";
@@ -50,8 +50,7 @@ export function ErrorPage({ navBar }: Props) {
                     </Button>
                     <Link
                         href={Routes.home}
-                        w="100%"
-                        _hover={{ textDecoration: "none" }}
+                        viewProps={{ style: { width: "100%"  } }}
                     >
                         <RoundedButton>{t("common:backToHome")}</RoundedButton>
                     </Link>

--- a/src/view/common/ErrorPage.tsx
+++ b/src/view/common/ErrorPage.tsx
@@ -17,6 +17,7 @@ export function ErrorPage({ navBar }: Props) {
     const { t } = useTranslation();
 
     const handleReload = () => {
+        // TODO: native対応
         router.reload();
     };
 
@@ -50,7 +51,7 @@ export function ErrorPage({ navBar }: Props) {
                     </Button>
                     <Link
                         href={Routes.home}
-                        viewProps={{ style: { width: "100%"  } }}
+                        viewProps={{ style: { width: "100%" } }}
                     >
                         <RoundedButton>{t("common:backToHome")}</RoundedButton>
                     </Link>

--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -1,7 +1,7 @@
-import { Link } from "@chakra-ui/next-js";
 import { Splide, SplideSlide } from "@splidejs/react-splide";
 import "@splidejs/splide/css";
 import { ReactNode } from "react";
+import { Link } from "solito/link";
 import {
     ImageSize,
     ImageSizes,
@@ -124,7 +124,7 @@ function LinkWrapper({
 }) {
     if (href)
         return (
-            <Link href={href} w="100%" h="100%">
+            <Link href={href} viewProps={{ style: { width: "100%", height:"100%" } }}>
                 {children}
             </Link>
         );

--- a/src/view/common/ImageSliderPreview.tsx
+++ b/src/view/common/ImageSliderPreview.tsx
@@ -124,7 +124,10 @@ function LinkWrapper({
 }) {
     if (href)
         return (
-            <Link href={href} viewProps={{ style: { width: "100%", height:"100%" } }}>
+            <Link
+                href={href}
+                viewProps={{ style: { width: "100%", height: "100%" } }}
+            >
                 {children}
             </Link>
         );

--- a/src/view/common/NotFound.tsx
+++ b/src/view/common/NotFound.tsx
@@ -1,6 +1,6 @@
-import { Link } from "@chakra-ui/next-js";
 import { Image } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
+import { Link } from "solito/link";
 import { Routes } from "src/constant/router";
 import { FailurePage } from "src/view/common/FailurePage";
 import { RoundedButton } from "./RoundedButton";
@@ -28,8 +28,7 @@ export const NotFound = ({ navBar }: Props) => {
             actions={
                 <Link
                     href={Routes.home}
-                    w="100%"
-                    _hover={{ textDecoration: "none" }}
+                    viewProps={{ style: { width: "100%" } }}
                 >
                     <RoundedButton>{t("common:backToHome")}</RoundedButton>
                 </Link>

--- a/src/view/interest/CouldNotFindAnyPlace.tsx
+++ b/src/view/interest/CouldNotFindAnyPlace.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@chakra-ui/next-js";
+import { Link } from "solito/link";
 import { Routes } from "src/constant/router";
 import Lost from "src/view/assets/svg/lost.svg";
 import { FailurePage } from "src/view/common/FailurePage";
@@ -26,8 +26,7 @@ export function CouldNotFindAnyPlace({ navBar }: Props) {
             actions={
                 <Link
                     href={Routes.home}
-                    w="100%"
-                    _hover={{ textDecoration: "none" }}
+                    viewProps={{ style: { width: "100%" } }}
                 >
                     <RoundedButton>ホームに戻る</RoundedButton>
                 </Link>

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Text, VStack } from "@chakra-ui/react";
 import { Link } from "solito/link";
+import { Padding } from "src/constant/padding";
 import { Routes } from "src/constant/router";
 import {
     RequestStatus,
@@ -11,7 +12,6 @@ import { LottiePlayer } from "src/view/common/LottiePlayer";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
 import animationDataFailedLocation from "src/view/lottie/location-failed.json";
 import animationDataLoadingLocation from "src/view/lottie/location-loading.json";
-import {Padding} from "src/constant/padding";
 
 type Props = {
     fetchLocationRequestStatus: RequestStatus | null;

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -1,5 +1,5 @@
-import { Link } from "@chakra-ui/next-js";
 import { Box, Button, Text, VStack } from "@chakra-ui/react";
+import { Link } from "solito/link";
 import { Routes } from "src/constant/router";
 import {
     RequestStatus,
@@ -11,6 +11,7 @@ import { LottiePlayer } from "src/view/common/LottiePlayer";
 import { RoundedDialog } from "src/view/common/RoundedDialog";
 import animationDataFailedLocation from "src/view/lottie/location-failed.json";
 import animationDataLoadingLocation from "src/view/lottie/location-loading.json";
+import {Padding} from "src/constant/padding";
 
 type Props = {
     fetchLocationRequestStatus: RequestStatus | null;
@@ -73,7 +74,7 @@ function Fetching({
             {isSkipCurrentLocationVisible && (
                 <Link
                     href={Routes.places.search({ skipCurrentLocation: true })}
-                    mt="16px"
+                    viewProps={{ style: { marginTop: Padding.p16 } }}
                 >
                     <Text color="blue.600">{skipLocationLabel}</Text>
                 </Link>

--- a/src/view/location/FetchLocationDialog.tsx
+++ b/src/view/location/FetchLocationDialog.tsx
@@ -108,7 +108,7 @@ function Failed({
             <VStack w="100%" py="16px">
                 <Link
                     href={Routes.places.search({ skipCurrentLocation: true })}
-                    style={{ width: "100%" }}
+                    viewProps={{ style: { width: "100%" } }}
                 >
                     <Button
                         w="100%"

--- a/src/view/mdx/MdxLinkCard.tsx
+++ b/src/view/mdx/MdxLinkCard.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, Image, Text, VStack } from "@chakra-ui/react";
 import axios from "axios";
-import Link from "next/link";
 import { useEffect, useState } from "react";
+import { Link } from "solito/link";
 import { Response as OpenGraphResponse } from "src/pages/api/v1/openGraph";
 
 type Props = {
@@ -40,7 +40,12 @@ export function MdxLinkCard({ href }: Props) {
             });
     }, []);
 
-    if (!ogData) return <Link href={href} />;
+    if (!ogData)
+        return (
+            <Link href={href}>
+                <Text>{href}</Text>
+            </Link>
+        );
 
     return (
         <Link href={href}>

--- a/src/view/navigation/BottomNavigation.tsx
+++ b/src/view/navigation/BottomNavigation.tsx
@@ -1,8 +1,8 @@
-import { Link } from "@chakra-ui/next-js";
 import { Center, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
 import { IconType } from "react-icons";
 import { MdAccountCircle, MdHome, MdSearch } from "react-icons/md";
+import { Link } from "solito/link";
 import { Routes } from "src/constant/router";
 import { Size } from "src/constant/size";
 
@@ -66,7 +66,7 @@ export function NavigationItem({
     isActive: boolean;
 }) {
     return (
-        <Link href={link} flex={1}>
+        <Link href={link} viewProps={{ style: { flex: 1 } }}>
             <VStack color={isActive ? "#BF756F" : "#6A6A6A"} spacing={0}>
                 <Icon w="24px" h="24px" as={icon} />
                 <Text fontSize="0.625rem">{label}</Text>

--- a/src/view/navigation/NavBar.tsx
+++ b/src/view/navigation/NavBar.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, Icon } from "@chakra-ui/react";
-import Link from "next/link";
 import { ReactNode } from "react";
 import { MdArrowBack } from "react-icons/md";
+import { Link } from "solito/link";
 import { usePathname } from "solito/navigation";
 import { useRouter } from "solito/router";
 import { Padding } from "src/constant/padding";
@@ -128,7 +128,7 @@ const Container = styled.div`
 
 const AppLogo = () => {
     return (
-        <Link href={Routes.home} style={{ height: "100%" }}>
+        <Link href={Routes.home} viewProps={{ style: { height: "100%" } }}>
             <Box h="100%">
                 <AppLogoImage
                     viewBox={

--- a/src/view/navigation/NavBar.tsx
+++ b/src/view/navigation/NavBar.tsx
@@ -1,8 +1,9 @@
 import { Box, HStack, Icon } from "@chakra-ui/react";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { ReactNode } from "react";
 import { MdArrowBack } from "react-icons/md";
+import { usePathname } from "solito/navigation";
+import { useRouter } from "solito/router";
 import { Padding } from "src/constant/padding";
 import { Routes } from "src/constant/router";
 import { Size } from "src/constant/size";
@@ -34,17 +35,18 @@ export const NavBar = ({ canGoBack, defaultPath }: Props) => {
     } = useBindPreLoginState();
 
     const handleOnBack = async () => {
-        const isHome = router.pathname === "/";
+        const pathname = usePathname();
+        const isHome = pathname === "/";
         if (isHome) return;
 
         // 一つ前のページがporotoのページでない
         if (historyStack.length <= 1) {
-            if (defaultPath) await router.push(defaultPath);
-            else await router.push("/");
+            if (defaultPath) router.push(defaultPath);
+            else router.push("/");
             return;
         }
 
-        await router.back();
+        router.back();
     };
 
     return (

--- a/src/view/plan/PlanGenerationFailure.tsx
+++ b/src/view/plan/PlanGenerationFailure.tsx
@@ -1,7 +1,7 @@
-import { Link } from "@chakra-ui/next-js";
 import { Image } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
 import { ReactNode } from "react";
+import { Link } from "solito/link";
 import { Routes } from "src/constant/router";
 import { FailurePage } from "src/view/common/FailurePage";
 import { RoundedButton } from "../common/RoundedButton";
@@ -28,8 +28,7 @@ export const PlanGenerationFailure = ({ navBar }: Props) => {
             actions={
                 <Link
                     href={Routes.home}
-                    w="100%"
-                    _hover={{ textDecoration: "none" }}
+                    viewProps={{ style: { width: "100%" } }}
                 >
                     <RoundedButton>{t("common:backToHome")}</RoundedButton>
                 </Link>

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -1,6 +1,6 @@
-import { Link } from "@chakra-ui/next-js";
 import { Avatar, HStack, Text, VStack } from "@chakra-ui/react";
 import { ReactNode } from "react";
+import { Link } from "solito/link";
 import { Plan } from "src/domain/models/Plan";
 import { PlanThumbnail } from "src/view/plan/PlanThumbnail";
 import styled from "styled-components";
@@ -92,7 +92,7 @@ function LinkWrapper({
 }) {
     if (href)
         return (
-            <Link href={href} w="100%">
+            <Link href={href} viewProps={{style:{width:"100%"}}}>
                 {children}
             </Link>
         );

--- a/src/view/plan/PlanPreview.tsx
+++ b/src/view/plan/PlanPreview.tsx
@@ -92,7 +92,7 @@ function LinkWrapper({
 }) {
     if (href)
         return (
-            <Link href={href} viewProps={{style:{width:"100%"}}}>
+            <Link href={href} viewProps={{ style: { width: "100%" } }}>
                 {children}
             </Link>
         );

--- a/src/view/plan/button/SearchRouteByGoogleMapButton.tsx
+++ b/src/view/plan/button/SearchRouteByGoogleMapButton.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "next-i18next";
-import Link from "next/link";
+import { Link } from "solito/link";
 import { GeoLocation } from "src/domain/models/GeoLocation";
 import { Plan } from "src/domain/models/Plan";
 import { generateGoogleMapUrl } from "src/domain/util/googleMap";
@@ -29,7 +29,7 @@ export function SearchRouteByGoogleMapButton({
                 startLocation: startLocationOfRoute,
             })}
             target="_blank"
-            style={{ width: "100%" }}
+            viewProps={{ style: { width: "100%" } }}
         >
             <PlanActionButton
                 text={t("plan:searchRouteOnGoogleMaps")}

--- a/src/view/plandetail/PlaceChipContextAction.tsx
+++ b/src/view/plandetail/PlaceChipContextAction.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@chakra-ui/next-js";
 import { HStack, Icon, Text } from "@chakra-ui/react";
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useTranslation } from "next-i18next";
@@ -10,6 +9,7 @@ import {
     MdOutlineFindReplace,
 } from "react-icons/md";
 import { SiGooglemaps, SiInstagram } from "react-icons/si";
+import { Link } from "solito/link";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { useAppTranslation } from "src/hooks/useAppTranslation";
 import { UploadPlaceImageProps } from "src/hooks/useUploadPlaceImage";

--- a/src/view/plandetail/PlaceReview.tsx
+++ b/src/view/plandetail/PlaceReview.tsx
@@ -1,5 +1,5 @@
 import { Avatar, HStack, Text, VStack } from "@chakra-ui/react";
-import Link from "next/link";
+import { Link } from "solito/link";
 
 export type Props = {
     authorName: string;

--- a/src/view/top/CreatePlanButton.tsx
+++ b/src/view/top/CreatePlanButton.tsx
@@ -11,7 +11,11 @@ type Props = {
 
 export function CreatePlanButton({ title, icon, link, onClick }: Props) {
     return (
-        <Link href={link} viewProps={{ style: { width: "100%"}}} onClick={onClick}>
+        <Link
+            href={link}
+            viewProps={{ style: { width: "100%" } }}
+            onClick={onClick}
+        >
             <VStack
                 borderRadius="20px"
                 backgroundColor="#FFF8F3"

--- a/src/view/top/CreatePlanButton.tsx
+++ b/src/view/top/CreatePlanButton.tsx
@@ -1,6 +1,6 @@
-import { Link } from "@chakra-ui/next-js";
 import { Icon, Text, VStack } from "@chakra-ui/react";
 import { IconType } from "react-icons";
+import { Link } from "solito/link";
 
 type Props = {
     title: string;
@@ -11,7 +11,7 @@ type Props = {
 
 export function CreatePlanButton({ title, icon, link, onClick }: Props) {
     return (
-        <Link href={link} w="100%" onClick={onClick}>
+        <Link href={link} viewProps={{ style: { width: "100%"}}} onClick={onClick}>
             <VStack
                 borderRadius="20px"
                 backgroundColor="#FFF8F3"

--- a/src/view/top/NearbyPlansNotFound.tsx
+++ b/src/view/top/NearbyPlansNotFound.tsx
@@ -25,7 +25,10 @@ export const NearbyPlansNotFound = () => {
                     {t("plan:nearbyPlansEmptyDescription")}
                 </Text>
             </VStack>
-            <Link href={Routes.plans.interest({})} viewProps={{style:{ width: "100%" ,maxWidth:400}}}>
+            <Link
+                href={Routes.plans.interest({})}
+                viewProps={{ style: { width: "100%", maxWidth: 400 } }}
+            >
                 <RoundedButton>{t("plan:createPlan")}</RoundedButton>
             </Link>
         </VStack>

--- a/src/view/top/NearbyPlansNotFound.tsx
+++ b/src/view/top/NearbyPlansNotFound.tsx
@@ -1,6 +1,6 @@
-import { Link } from "@chakra-ui/next-js";
 import { Text, VStack } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
+import { Link } from "solito/link";
 import { Routes } from "src/constant/router";
 import IconTraveling from "src/view/assets/svg/traveling.svg";
 import { RoundedButton } from "src/view/common/RoundedButton";
@@ -25,7 +25,7 @@ export const NearbyPlansNotFound = () => {
                     {t("plan:nearbyPlansEmptyDescription")}
                 </Text>
             </VStack>
-            <Link href={Routes.plans.interest({})} w="100%" maxW="400px">
+            <Link href={Routes.plans.interest({})} viewProps={{style:{ width: "100%" ,maxWidth:400}}}>
                 <RoundedButton>{t("plan:createPlan")}</RoundedButton>
             </Link>
         </VStack>

--- a/yarn.lock
+++ b/yarn.lock
@@ -18547,6 +18547,11 @@ nested-error-stacks@~2.0.1:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz#d2cc9fc5235ddb371fc44d506234339c8e4b0a4b"
   integrity sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==
 
+next-compose-plugins@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz#020fc53f275a7e719d62521bef4300fbb6fde5ab"
+  integrity sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==
+
 next-i18next@^15.3.0:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/next-i18next/-/next-i18next-15.3.0.tgz#b4530c80573854d00f95229af405e1e5beedbf18"
@@ -21334,6 +21339,13 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
+solito@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/solito/-/solito-4.2.2.tgz#c94b2da6993d8d6974e8e875a0fe0d38c3c6345b"
+  integrity sha512-VjuAZDEM5QJG2CVCpi94oFxXQKuYp1CP/VS8PzraMX7MVa3T6zwV6Ev4n4wMajv5LvRg9nwh5JNPasxQhS7IVA==
+  dependencies:
+    typescript "^5.0.4"
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -22678,6 +22690,11 @@ typedarray.prototype.slice@^1.0.3:
     es-errors "^1.3.0"
     typed-array-buffer "^1.0.2"
     typed-array-byte-offset "^1.0.2"
+
+typescript@^5.0.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 typescript@^5.5.2:
   version "5.5.2"


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- ナビゲーション系のコンポーネントや関数をwebとnativeのどちらにも対応したライブラリであるsolitoのものに置き換えた
- **この修正で発生するデグレ**：`router.push`関数がページ遷移完了まで待ってくれないため、ページ遷移が終わる前にロード画面が閉じることなどがある。

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- close #788 

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->
- ルーティングをwebとnativeで共通化させるため

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認

```shell
# poroto
export BRANCH_POROTO=feature/solito
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````