### PR TITLE
[fix] セクションタイトルの余白が正しく指定されるように修正

### DIFF
--- a/src/pages/plans/[id].tsx
+++ b/src/pages/plans/[id].tsx
@@ -219,7 +219,7 @@ export default function PlanPage() {
                     sectionHeader={
                         <SectionTitle
                             title={t("plan:planInfo")}
-                            px={Size.PlanDetail.px + "px"}
+                            px={Size.PlanDetail.px}
                         />
                     }
                 >
@@ -235,7 +235,7 @@ export default function PlanPage() {
                     sectionHeader={
                         <SectionTitle
                             title={t("plan:plan")}
-                            px={Size.PlanDetail.px + "px"}
+                            px={Size.PlanDetail.px}
                         />
                     }
                 >
@@ -253,7 +253,7 @@ export default function PlanPage() {
                         <SectionTitle
                             title={t("plan:placesInPlan")}
                             description={t("plan:clickMarkerToShowPlaceDetail")}
-                            px={Size.PlanDetail.px + "px"}
+                            px={Size.PlanDetail.px}
                         />
                     }
                 >
@@ -278,7 +278,7 @@ export default function PlanPage() {
                                 <PlanListSectionTitle
                                     title={t("plan:nearbyPlans")}
                                     icon={MdOutlineNearMe}
-                                    px={Size.PlanDetail.px + "px"}
+                                    px={Size.PlanDetail.px}
                                 />
                             }
                         >
@@ -303,7 +303,7 @@ export default function PlanPage() {
                             <PlanListSectionTitle
                                 title={t("plan:createNewPlanTitle")}
                                 icon={MdOutlineExplore}
-                                px={Size.PlanDetail.px + "px"}
+                                px={Size.PlanDetail.px}
                             />
                         }
                     >

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -346,7 +346,7 @@ function PlanDetailPage({
                         sectionHeader={
                             <SectionTitle
                                 title={t("plan:planInfo")}
-                                px={Size.PlanDetail.px + "px"}
+                                px={Size.PlanDetail.px}
                             />
                         }
                     >
@@ -362,7 +362,7 @@ function PlanDetailPage({
                         sectionHeader={
                             <SectionTitle
                                 title={t("plan:plan")}
-                                px={Size.PlanDetail.px + "px"}
+                                px={Size.PlanDetail.px}
                             />
                         }
                     >
@@ -393,7 +393,7 @@ function PlanDetailPage({
                                 description={t(
                                     "plan:clickMarkerToShowPlaceDetail"
                                 )}
-                                px={Size.PlanDetail.px + "px"}
+                                px={Size.PlanDetail.px}
                             />
                         }
                     >
@@ -418,7 +418,7 @@ function PlanDetailPage({
                                         "plan:createPlanFromOtherLocation"
                                     )}
                                     icon={MdOutlineNearMe}
-                                    px={Size.PlanDetail.px + "px"}
+                                    px={Size.PlanDetail.px}
                                     pt={0}
                                 />
                             }

--- a/src/view/account/LikePlacesList.tsx
+++ b/src/view/account/LikePlacesList.tsx
@@ -27,7 +27,7 @@ export function LikePlacesList({
     return (
         <VStack w="100%">
             <PlanListSectionTitle
-                px={Padding.p16 + "px"}
+                px={Padding.p16}
                 title={t("place:favoritePlaces")}
                 icon={MdOutlineFavoriteBorder}
             />

--- a/src/view/account/UsersPlan.tsx
+++ b/src/view/account/UsersPlan.tsx
@@ -62,7 +62,7 @@ export function UsersPlan({ plans, isLoading }: Props) {
                             <PlanListSectionTitle
                                 title={t("plan:savedPlans")}
                                 icon={MdOutlineBookmarkBorder}
-                                px={Padding.p16 + "px"}
+                                px={Padding.p16}
                             />
                         </PlanList>
                     </Box>

--- a/src/view/common/SectionTitle.tsx
+++ b/src/view/common/SectionTitle.tsx
@@ -5,11 +5,16 @@ type Props = {
     title: string;
     description?: string;
     icon?: IconType;
-    px?: string | number;
+    px?: number;
 };
 export function SectionTitle({ title, description, icon, px }: Props) {
     return (
-        <VStack alignItems="flex-start" px={px} spacing="4px" color="#3E3E3E">
+        <VStack
+            alignItems="flex-start"
+            px={px + "px"}
+            spacing="4px"
+            color="#3E3E3E"
+        >
             <HStack>
                 {icon && <Icon w="24px" h="24px" as={icon} fontSize="20px" />}
                 <Text fontWeight="bold" fontSize="20px">

--- a/src/view/top/PlanListSectionTitle.tsx
+++ b/src/view/top/PlanListSectionTitle.tsx
@@ -5,21 +5,27 @@ import { Size } from "src/constant/size";
 type Props = {
     title: string;
     icon: IconType;
-    px?: string | number;
-    pt?: string | number;
-    pb?: string | number;
+    px?: number;
+    pt?: number;
+    pb?: number;
 };
 
 export function PlanListSectionTitle({
     title,
     icon,
-    px = Size.top.SectionTitle.px + "px",
-    pt = "32px",
-    pb = "32px",
+    px = Size.top.SectionTitle.px,
+    pt = 32,
+    pb = 32,
 }: Props) {
     return (
         <VStack w="100%" alignItems="flex-start">
-            <VStack pt={pt} pb={pb} px={px} alignItems="flex-start" spacing={4}>
+            <VStack
+                pt={pt + "px"}
+                pb={pb + "px"}
+                px={px + "px"}
+                alignItems="flex-start"
+                spacing={4}
+            >
                 <HStack color="#3E3E3E">
                     <Icon w="32px" h="32px" as={icon} />
                     <Text


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

|before| after |
|---|-------|
|![image](https://github.com/user-attachments/assets/e534019d-d790-46dc-8e59-64af557ec286)|![image](https://github.com/user-attachments/assets/b9882e79-6e24-4014-a518-37f9cbae8968)|

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->
- #797 

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] 探すページのセクションタイトルの余白が適切に入っていることを確認

```shell
# poroto
export BRANCH_POROTO=feature/fix_padding_in_px
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````