### PR TITLE
WebではnextjsのRouterが利用されるようにする

### DIFF
--- a/src/hooks/useAppRouter.native.ts
+++ b/src/hooks/useAppRouter.native.ts
@@ -9,5 +9,6 @@ export const useAppRouter = (): AppRouter => {
             router.push(url, as, transitionOptions);
         },
         reload: async () => reloadAsync(),
+        back: () => router.back(),
     };
 };

--- a/src/hooks/useAppRouter.ts
+++ b/src/hooks/useAppRouter.ts
@@ -8,5 +8,6 @@ export const useAppRouter = (): AppRouter => {
             await router.push(url, as, transitionOptions);
         },
         reload: async () => router.reload(),
+        back: () => router.back(),
     };
 };

--- a/src/hooks/useCreatePlanCategory.ts
+++ b/src/hooks/useCreatePlanCategory.ts
@@ -1,11 +1,11 @@
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useEffect, useState } from "react";
-import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { Routes } from "src/constant/router";
 import { CreatePlanPlaceCategory } from "src/domain/models/CreatePlanPlaceCategory";
 import { GeoLocation } from "src/domain/models/GeoLocation";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
+import { useAppRouter } from "src/hooks/useAppRouter";
 import {
     createPlanByCategory,
     reduxPlanCandidateSelector,
@@ -15,7 +15,7 @@ import { useAppDispatch } from "src/redux/redux";
 
 export const useCreatePlanCategory = () => {
     const dispatch = useAppDispatch();
-    const router = useRouter();
+    const router = useAppRouter();
     const [category, setCategory] = useState<CreatePlanPlaceCategory>(null);
     const [
         isCreatePlanCategoryRangeDialogVisible,
@@ -79,9 +79,12 @@ export const useCreatePlanCategory = () => {
             createPlanSession &&
             createPlanByCategoryRequestStatus === RequestStatuses.FULFILLED
         ) {
-            router.push(Routes.plans.planCandidate.index(createPlanSession));
-            setIsCreatingPlanFromCategory(false);
-            dispatch(resetCreatePlanByCategoryRequestStatus());
+            router
+                .push(Routes.plans.planCandidate.index(createPlanSession))
+                .then(() => {
+                    setIsCreatingPlanFromCategory(false);
+                    dispatch(resetCreatePlanByCategoryRequestStatus());
+                });
         }
     }, [createPlanSession, createPlanByCategoryRequestStatus]);
 

--- a/src/hooks/useCreatePlanFromSavedPlan.ts
+++ b/src/hooks/useCreatePlanFromSavedPlan.ts
@@ -1,10 +1,10 @@
 import { useToast } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
 import { useEffect, useState } from "react";
-import { useRouter } from "solito/router";
 import { Routes } from "src/constant/router";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { hasValue } from "src/domain/util/null";
+import { useAppRouter } from "src/hooks/useAppRouter";
 import {
     createPlanFromSavedPlan as createPlanFromSavedPlanAction,
     reduxPlanCandidateSelector,
@@ -14,7 +14,7 @@ import { useAppDispatch } from "src/redux/redux";
 
 export const useCreatePlanFromSavedPlan = () => {
     const dispatch = useAppDispatch();
-    const router = useRouter();
+    const router = useAppRouter();
     const { t } = useTranslation();
     const [isCreatingPlanFromSavedPlan, setIsCreatingPlanFromSavedPlan] =
         useState(false);
@@ -28,18 +28,18 @@ export const useCreatePlanFromSavedPlan = () => {
             createPlanFromSavedPlanRequestStatus === RequestStatuses.FULFILLED
         ) {
             dispatch(resetCreatePlanFromSavedPlanRequestStatus());
-            router.push(Routes.plans.planCandidate.index(createPlanSession));
-
-            // TODO: 遷移が終了したタイミングでモーダルが閉じるようにする
-            return () => {
-                setIsCreatingPlanFromSavedPlan(false);
-                toast({
-                    title: t("plan:customizePlanCreated"),
-                    status: "success",
-                    duration: 3000,
-                    isClosable: true,
+            router
+                .push(Routes.plans.planCandidate.index(createPlanSession))
+                .then(() => {
+                    // 遷移が終了したタイミングでモーダルが閉じるようにする
+                    setIsCreatingPlanFromSavedPlan(false);
+                    toast({
+                        title: t("plan:customizePlanCreated"),
+                        status: "success",
+                        duration: 3000,
+                        isClosable: true,
+                    });
                 });
-            };
         }
     }, [createPlanSession, createPlanFromSavedPlanRequestStatus]);
 

--- a/src/hooks/useCreatePlanInterest.ts
+++ b/src/hooks/useCreatePlanInterest.ts
@@ -1,13 +1,13 @@
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useEffect, useState } from "react";
 import { createParam } from "solito";
-import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { LocalStorageKeys } from "src/constant/localStorageKey";
 import { Routes } from "src/constant/router";
 import { GeoLocation } from "src/domain/models/GeoLocation";
 import { LocationCategory } from "src/domain/models/LocationCategory";
 import { LocationCategoryWithPlace } from "src/domain/models/LocationCategoryWithPlace";
+import { useAppRouter } from "src/hooks/useAppRouter";
 import { useLocation } from "src/hooks/useLocation";
 import { reduxAuthSelector } from "src/redux/auth";
 import {
@@ -32,7 +32,7 @@ const { useParams } = createParam<{
 
 export const useCreatePlanInterest = () => {
     const dispatch = useAppDispatch();
-    const router = useRouter();
+    const router = useAppRouter();
 
     const {
         categoryCandidates,

--- a/src/hooks/useLikePlaces.ts
+++ b/src/hooks/useLikePlaces.ts
@@ -1,10 +1,10 @@
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useEffect } from "react";
-import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { Routes } from "src/constant/router";
 import { Place } from "src/domain/models/Place";
 import { hasValue } from "src/domain/util/null";
+import { useAppRouter } from "src/hooks/useAppRouter";
 import { reduxAuthSelector } from "src/redux/auth";
 import { setSearchLocation } from "src/redux/location";
 import { reduxPlaceSelector, setLikePlaces } from "src/redux/place";
@@ -13,7 +13,7 @@ import { useAppDispatch } from "src/redux/redux";
 import { fetchUser } from "src/redux/user";
 
 export const useLikePlaces = () => {
-    const router = useRouter();
+    const router = useAppRouter();
     const dispatch = useAppDispatch();
     const { likePlaces } = reduxPlaceSelector();
     const { user, firebaseIdToken } = reduxAuthSelector();

--- a/src/hooks/usePlan.ts
+++ b/src/hooks/usePlan.ts
@@ -1,12 +1,12 @@
 import { getAnalytics, logEvent } from "@firebase/analytics";
 import { useEffect } from "react";
-import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { Routes } from "src/constant/router";
 import { Place } from "src/domain/models/Place";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { User } from "src/domain/models/User";
 import { hasValue } from "src/domain/util/null";
+import { useAppRouter } from "src/hooks/useAppRouter";
 import { setSearchLocation } from "src/redux/location";
 import {
     fetchPlacesNearbyPlanLocation,
@@ -28,7 +28,7 @@ export const usePlan = ({
     fetchNearbyPlanSize?: number;
 }) => {
     const dispatch = useAppDispatch();
-    const router = useRouter();
+    const router = useAppRouter();
 
     const {
         preview: plan,

--- a/src/hooks/usePlanCandidateGalleryPageAutoScroll.ts
+++ b/src/hooks/usePlanCandidateGalleryPageAutoScroll.ts
@@ -1,5 +1,5 @@
+import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
-import { useRouter } from "solito/router";
 
 export const usePlanCandidateGalleryPageAutoScroll = ({
     planCandidateId,
@@ -146,8 +146,7 @@ export const usePlanCandidateGalleryPageAutoScroll = ({
                     top: 0,
                     behavior: "smooth",
                 });
-                // TODO: fix me!
-                // router.events.emit("routeChangeComplete", router.asPath);
+                router.events.emit("routeChangeComplete", router.asPath);
                 e.preventDefault();
             }
         };

--- a/src/hooks/usePlanCreate.ts
+++ b/src/hooks/usePlanCreate.ts
@@ -1,8 +1,8 @@
 import { getAuth } from "@firebase/auth";
 import { useEffect, useState } from "react";
-import { useRouter } from "solito/router";
 import { Routes } from "src/constant/router";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
+import { useAppRouter } from "src/hooks/useAppRouter";
 import { setShowPlanCreatedModal } from "src/redux/plan";
 import {
     reduxPlanCandidateSelector,
@@ -18,7 +18,7 @@ type Props = {
 
 export const usePlanCreate = ({ planCandidateSetId, planId }: Props) => {
     const dispatch = useAppDispatch();
-    const router = useRouter();
+    const router = useAppRouter();
     const { preview: plan, savePlanFromCandidateRequestStatus } =
         reduxPlanCandidateSelector();
     const [isCreatingPlan, setIsCreatingPlan] = useState(false);
@@ -40,14 +40,12 @@ export const usePlanCreate = ({ planCandidateSetId, planId }: Props) => {
     useEffect(() => {
         if (!plan) return;
         if (savePlanFromCandidateRequestStatus === RequestStatuses.FULFILLED) {
-            router.push(Routes.plans.plan(plan.id));
-            dispatch(setShowPlanCreatedModal(true));
-            // TODO: 遷移が終了したタイミングでモーダルが閉じるようにする
-            return () => {
+            router.push(Routes.plans.plan(plan.id)).then(() => {
+                dispatch(setShowPlanCreatedModal(true));
                 setIsCreatingPlan(false);
                 // 戻ったときに再リダイレクトされないようにする
                 dispatch(resetPlanCandidates());
-            };
+            });
         }
     }, [planId, savePlanFromCandidateRequestStatus]);
 

--- a/src/pages/places/search.tsx
+++ b/src/pages/places/search.tsx
@@ -5,7 +5,6 @@ import Head from "next/head";
 import { useEffect, useState } from "react";
 import { MdDone, MdOutlineTouchApp } from "react-icons/md";
 import { createParam } from "solito";
-import { useRouter } from "solito/router";
 import { AnalyticsEvents } from "src/constant/analytics";
 import { locationSinjukuStation } from "src/constant/location";
 import { PageMetaData } from "src/constant/meta";
@@ -14,6 +13,7 @@ import { Size } from "src/constant/size";
 import { zIndex } from "src/constant/zIndex";
 import { GeoLocation } from "src/data/graphql/generated";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
+import { useAppRouter } from "src/hooks/useAppRouter";
 import { useAppTranslation } from "src/hooks/useAppTranslation";
 import { useGooglePlaceSearch } from "src/hooks/useGooglePlaceSearch";
 import { useLocation } from "src/hooks/useLocation";
@@ -52,7 +52,7 @@ export default function Page() {
 }
 
 function PlaceSearchPage() {
-    const router = useRouter();
+    const router = useAppRouter();
     const [skipCurrentLocation] = useParam(RouteParams.SkipCurrentLocation);
     const isSkipFetchCurrentLocation = skipCurrentLocation === "true";
     const { t } = useAppTranslation();

--- a/src/pages/plans/select/[sessionId]/index.tsx
+++ b/src/pages/plans/select/[sessionId]/index.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, Center, Text, VStack } from "@chakra-ui/react";
 import { useRef, useState } from "react";
 import { createParam } from "solito";
-import { useRouter } from "solito/router";
 import { Colors } from "src/constant/color";
 import { Size } from "src/constant/size";
 import { isPC } from "src/constant/userAgent";
@@ -55,7 +54,6 @@ const SelectPlanPage = () => {
     const { t } = useAppTranslation();
     const dispatch = useAppDispatch();
 
-    const router = useRouter();
     const { sessionId } = useParams().params;
     const [selectedPlanIndex, setSelectedPlanIndex] = useState(0);
     const refPlanCandidateGallery = useRef<HTMLDivElement>(null);

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -11,4 +11,5 @@ export type AppRouter = {
         }
     ) => Promise<void>;
     reload: () => Promise<void>;
+    back: () => void;
 };

--- a/src/view/navigation/NavBar.tsx
+++ b/src/view/navigation/NavBar.tsx
@@ -1,5 +1,5 @@
 import { usePathname } from "solito/navigation";
-import { useRouter } from "solito/router";
+import { useAppRouter } from "src/hooks/useAppRouter";
 import { useAuth } from "src/hooks/useAuth";
 import { useBindPreLoginState } from "src/hooks/useBindPreLoginState";
 import { reduxHistorySelector } from "src/redux/history";
@@ -9,7 +9,7 @@ import { NavBarComponent } from "src/view/navigation/NavBarComponent";
 import { NavBarUser } from "src/view/navigation/NavBarUser";
 
 export const NavBar = ({ canGoBack, defaultPath }: NavBarProps) => {
-    const router = useRouter();
+    const router = useAppRouter();
     const { historyStack } = reduxHistorySelector();
     const { user, signInWithGoogle, logout } = useAuth();
     const {


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- 解決した問題：solitoのrouterは遷移の完了を待つ非同期処理ができないため、遷移が完了する前にプラン作成中のダイアログ等が閉じられてしまうことがあった
- webの場合は、nextjsのrouterが利用され、nativeの場合はsolitoのrouterが利用されるようになるuseAppRouterに置き換えることで解決した

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認
- [x] カテゴリからプランを作成したとき、作成が完了するまでモーダルが表示される
- [x] 保存されたプランをカスタムするとき、カスタム用プランが作成されるまでモーダルが表示される 
- [x] プラン候補一覧画面 -> プラン詳細画面に移動し、戻るボタンを押すと、プラン一覧画面に戻る（適切な位置にならなくても、前の画面に直接戻らなければ良い） 

```shell
# poroto
export BRANCH_POROTO=feature/native_next_router
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````