### PR TITLE
Native起動時にフォントが読み込まれるようにする

### DIFF
--- a/src/expo/_layout.tsx
+++ b/src/expo/_layout.tsx
@@ -1,5 +1,7 @@
 import { DefaultTheme, ThemeProvider } from "@react-navigation/native";
+import { useFonts } from "expo-font";
 import { getLocales } from "expo-localization";
+import { SplashScreen } from "expo-router";
 import { Stack } from "expo-router/stack";
 import i18n from "i18next";
 import { useEffect, useState } from "react";
@@ -13,10 +15,17 @@ import { AppToastProvider } from "src/view/provider/AppToastProvider";
 import { ScreenSizeProvider } from "src/view/provider/ScreenSizeProvider.native";
 import { TamaguiProvider } from "tamagui";
 
+SplashScreen.preventAutoHideAsync();
+
 export default function RootLayout() {
     const [languageLoaded, setLanguageLoaded] = useState(false);
     const [language, setLanguage] = useState<string | null>();
+    const [interLoaded, interError] = useFonts({
+        Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
+        InterBold: require("@tamagui/font-inter/otf/Inter-Bold.otf"),
+    });
 
+    // 端末の言語設定を取得
     useEffect(() => {
         const getSystemLanguageAndSet = async () => {
             return getLocales()?.[0]?.languageTag ?? "en";
@@ -27,6 +36,7 @@ export default function RootLayout() {
         });
     }, []);
 
+    // i18nの初期化
     useEffect(() => {
         if (!language) return;
 
@@ -37,7 +47,14 @@ export default function RootLayout() {
         setLanguageLoaded(true);
     }, [language]);
 
-    if (!languageLoaded) {
+    // フォントと端末の言語設定取得が完了したらスプラッシュスクリーンを非表示にする
+    useEffect(() => {
+        if (interLoaded || interError || languageLoaded) {
+            SplashScreen.hideAsync();
+        }
+    }, [interLoaded, interError]);
+
+    if (!interLoaded || !languageLoaded) {
         return <></>;
     }
 


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->

- tamaguiが利用するinterフォントがnative内で直接利用できないため、警告が出てしまうのを修正

|before|
|---|
| ![image](https://github.com/user-attachments/assets/74f544fa-fe03-4557-8b0c-89a84155b806) | 

### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
- [x] Native起動時に、フォントに関する警告が出ないことを確認

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````