### PR TITLE
プラン候補一覧をネイティブ対応

### DIFF
--- a/src/domain/models/Image.ts
+++ b/src/domain/models/Image.ts
@@ -25,11 +25,19 @@ export function getImageSizeOf(size: ImageSize, image: Image): string {
     }
 }
 
-export const getDefaultPlaceImage = (): Image => {
+export const getDefaultPlaceImage = ({
+    isWeb = true,
+}: {
+    isWeb?: boolean;
+}): Image => {
+    const defaultImage = isWeb
+        ? "/images/NotFound.jpg"
+        : "https://komichi.app/images/NotFound.jpg";
+
     return {
         isGoogleImage: false,
-        default: "/images/NotFound.jpg",
-        small: "/images/NotFound.jpg",
-        large: "/images/NotFound.jpg",
+        default: defaultImage,
+        small: defaultImage,
+        large: defaultImage,
     };
 };

--- a/src/expo/plans/select/[sessionId].tsx
+++ b/src/expo/plans/select/[sessionId].tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { createParam } from "solito";
 import { RequestStatuses } from "src/domain/models/RequestStatus";
 import { useAppTranslation } from "src/hooks/useAppTranslation";

--- a/src/expo/plans/select/[sessionId].tsx
+++ b/src/expo/plans/select/[sessionId].tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { createParam } from "solito";
+import { RequestStatuses } from "src/domain/models/RequestStatus";
+import { useAppTranslation } from "src/hooks/useAppTranslation";
+import { usePlanCandidateSet } from "src/hooks/usePlanCandidateSet";
+import { ErrorPage } from "src/view/common/ErrorPage";
+import { LoadingModal } from "src/view/common/LoadingModal";
+import { NotFound } from "src/view/common/NotFound";
+import { PlanCandidatesGallery } from "src/view/plancandidate/PlanCandidatesGallery";
+import { YStack } from "tamagui";
+
+const { useParams } = createParam<{ sessionId?: string }>();
+
+export default function PlanCandidatePage() {
+    const { sessionId } = useParams().params;
+
+    const { t } = useAppTranslation();
+    const [selectedPlanIndex, setSelectedPlanIndex] = useState(0);
+    const {
+        plansCreated,
+        placesAvailableForPlan,
+        isCreatingPlan,
+        createPlanFromPlaceRequestStatus,
+        createPlanFromLocationRequestStatus,
+        fetchAvailablePlacesForPlanRequestStatus,
+        fetchCachedCreatedPlansRequestStatus,
+        createPlanCandidateFromPlace,
+    } = usePlanCandidateSet({
+        planCandidateSetId: sessionId as string,
+        onCreatedPlanFromPlace: ({ plansCreated }) => {
+            // プラン作成完了後、ページトップに移動し、作成されたプランを中央に表示
+            setSelectedPlanIndex(plansCreated.length - 1);
+            // TODO: ページトップに移動
+        },
+    });
+
+    if (!plansCreated) {
+        // ページ読み込み直後
+        const isLoadingPlan =
+            !fetchCachedCreatedPlansRequestStatus &&
+            !createPlanFromLocationRequestStatus;
+        // プラン作成中
+        const isCreatingPlanFromLocation =
+            createPlanFromLocationRequestStatus === RequestStatuses.PENDING;
+        // プラン候補取得中
+        const isFetchingPlanCandidate =
+            fetchCachedCreatedPlansRequestStatus === RequestStatuses.PENDING;
+
+        if (
+            isLoadingPlan ||
+            isCreatingPlanFromLocation ||
+            isFetchingPlanCandidate
+        )
+            return <LoadingModal title={t("plan:createPlanInProgressTitle")} />;
+
+        // プラン候補取得失敗
+        if (fetchCachedCreatedPlansRequestStatus === RequestStatuses.REJECTED)
+            return <ErrorPage navBar={false} />;
+
+        // プラン候補が存在しない
+        return <NotFound navBar={false} />;
+    }
+
+    return (
+        <YStack w="100%" h="100%">
+            <PlanCandidatesGallery planCandidates={plansCreated} />
+        </YStack>
+    );
+}

--- a/src/expo/plans/select/_layout.tsx
+++ b/src/expo/plans/select/_layout.tsx
@@ -1,0 +1,11 @@
+import { Stack } from "expo-router/stack";
+
+export default function RootLayout() {
+    return (
+        <Stack
+            screenOptions={{
+                headerShown: false,
+            }}
+        />
+    );
+}

--- a/src/redux/planCandidate.ts
+++ b/src/redux/planCandidate.ts
@@ -16,6 +16,7 @@ import {
 } from "src/domain/models/RequestStatus";
 import { PlannerApi } from "src/domain/plan/PlannerApi";
 import { RootState } from "src/redux/redux";
+import { isWeb } from "tamagui";
 
 export type PlanCandidateState = {
     createPlanSession: string | null;
@@ -159,9 +160,12 @@ type CreatePlanByCategoryProps = {
 export const createPlanByCategory = createAsyncThunk(
     "planCandidate/createPlanByCategory",
     async ({ categoryId, location, rangeInKm }: CreatePlanByCategoryProps) => {
-        logEvent(getAnalytics(), AnalyticsEvents.CreatePlan.Create, {
-            category: categoryId,
-        });
+        // TODO: native対応
+        if (isWeb) {
+            logEvent(getAnalytics(), AnalyticsEvents.CreatePlan.Create, {
+                category: categoryId,
+            });
+        }
 
         const plannerApi: PlannerApi = new PlannerGraphQlApi();
         const response = await plannerApi.createPlanByCategory({

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -82,3 +82,13 @@ export type RotateTransitionProps = {
     duration?: number;
     children?: ReactNode;
 };
+
+export type StoryImagePreviewProps = {
+    images: ImageType[];
+    imageSize?: ImageSize;
+    tapControl?: boolean;
+    slideable?: boolean;
+    onActiveIndexChange?: (index: number) => void;
+    onClickLastItem?: () => void;
+    onClickFirstItem?: () => void;
+};

--- a/src/view/interest/CategorySelect.tsx
+++ b/src/view/interest/CategorySelect.tsx
@@ -26,6 +26,7 @@ import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
 import { SelectButton } from "src/view/interest/SelectButton";
 import { PlaceCategoryIcon } from "src/view/place/PlaceCategoryIcon";
 import { styled } from "styled-components";
+import { isWeb } from "tamagui";
 
 /**
  * @param interactiveAnimation trueの場合、スライドして切り替わることを示すためのアニメーションを表示する
@@ -260,7 +261,9 @@ function PlaceThumbnail({
     imageSize: ImageSize;
 }) {
     const placeImage =
-        place.images.length > 0 ? place.images[0] : getDefaultPlaceImage();
+        place.images.length > 0
+            ? place.images[0]
+            : getDefaultPlaceImage({ isWeb });
     return (
         <Box w="100%" h="100%" position="relative">
             <ImageWithSkeleton

--- a/src/view/plan/PlanThumbnail.tsx
+++ b/src/view/plan/PlanThumbnail.tsx
@@ -5,7 +5,7 @@ import {
     ImageSizes,
 } from "src/domain/models/Image";
 import { ImageSliderPreview } from "src/view/common/ImageSliderPreview";
-import { XStack } from "tamagui";
+import { isWeb, XStack } from "tamagui";
 
 type Props = {
     images: Image[];
@@ -23,7 +23,7 @@ export const PlanThumbnail = ({
     draggable,
 }: Props) => {
     if (images.length === 0) {
-        images.push(getDefaultPlaceImage());
+        images.push(getDefaultPlaceImage({ isWeb }));
     }
 
     return (

--- a/src/view/plancandidate/PlanCandidatesGallery.native.tsx
+++ b/src/view/plancandidate/PlanCandidatesGallery.native.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from "react";
+import {
+    FlatList,
+    NativeScrollEvent,
+    NativeSyntheticEvent,
+} from "react-native";
+import { Padding } from "src/constant/padding";
+import { Size } from "src/constant/size";
+import { Time } from "src/constant/time";
+import { Plan } from "src/domain/models/Plan";
+import { reduxNativeSelector } from "src/redux/native";
+import {
+    PlanCandidateGalleryCard,
+    PlanCandidateGalleryCardPlaceHolder,
+} from "src/view/plancandidate/PlanCandidatesGalleryCard";
+import { YStack } from "tamagui";
+
+export type Props = {
+    planCandidates: Plan[];
+    defaultActivePlanIndex?: number;
+    activePlanIndex?: number;
+    isCreating?: boolean;
+    onActiveIndexChange?: (index: number) => void;
+};
+
+export function PlanCandidatesGallery({
+    planCandidates,
+    defaultActivePlanIndex = 0,
+    activePlanIndex,
+    isCreating = false,
+    onActiveIndexChange,
+}: Props) {
+    const flatListRef = useRef<FlatList>();
+    const [activeIndex, setActiveIndex] = useState(defaultActivePlanIndex);
+    const { screenWidth } = reduxNativeSelector();
+
+    const onClickCard = (i: number) => {
+        flatListRef.current?.scrollToIndex({ index: i });
+    };
+
+    const onClickFirstItem = (i: number) => {
+        setTimeout(() => {
+            const prevActiveIndex =
+                (i - 1 + planCandidates.length) % planCandidates.length;
+            onClickCard(prevActiveIndex);
+        }, 50);
+    };
+
+    const onClickLastItem = (i: number) => {
+        // カードタップによるこのカードへの移動処理と
+        // カード中の最後の画像タップによる次のカードへの移動処理が重ならないように
+        // 次のカードへの移動処理を遅延させる
+        setTimeout(() => {
+            const nextActiveIndex = (i + 1) % planCandidates.length;
+            onClickCard(nextActiveIndex);
+        }, Time.PlanCandidateGallery.lastItemTransitionDelay);
+    };
+
+    const onScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+        const contentOffsetX = event.nativeEvent.contentOffset.x;
+        const index = Math.round(
+            contentOffsetX / (Size.PlanCandidatesGallery.Card.w + Padding.p32)
+        );
+        setActiveIndex(index);
+    };
+
+    useEffect(() => {
+        if (!activePlanIndex) return;
+        if (activePlanIndex === activeIndex) return;
+        setActiveIndex(activePlanIndex);
+        // 指定されたページに移動
+    }, [activePlanIndex]);
+
+    useEffect(() => {
+        onActiveIndexChange?.(activeIndex);
+    }, [activeIndex]);
+
+    return (
+        <YStack w="100%" h="100%" justifyContent="center" alignItems="center">
+            <FlatList
+                ref={flatListRef}
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                scrollEventThrottle={16}
+                snapToInterval={Size.PlanCandidatesGallery.Card.w + Padding.p32}
+                snapToAlignment="start"
+                decelerationRate="fast"
+                initialNumToRender={planCandidates.length}
+                initialScrollIndex={0}
+                contentContainerStyle={{
+                    alignItems: "center",
+                    // 画面中央に表示
+                    paddingHorizontal:
+                        (screenWidth - Size.PlanCandidatesGallery.Card.w) / 2,
+                }}
+                onScroll={onScroll}
+                data={isCreating ? [...planCandidates, null] : planCandidates}
+                keyExtractor={(item, index) => index.toString()}
+                getItemLayout={(data, index) => ({
+                    index,
+                    length: Padding.p32 + Size.PlanCandidatesGallery.Card.w,
+                    offset:
+                        (Padding.p32 + Size.PlanCandidatesGallery.Card.w) *
+                        index,
+                })}
+                renderItem={({ item, index }) => (
+                    <YStack
+                        key={index}
+                        mr={index !== planCandidates.length - 1 && Padding.p32}
+                        w={Size.PlanCandidatesGallery.Card.w}
+                        h={Size.PlanCandidatesGallery.Card.h.active}
+                        onPress={() => onClickCard(index)}
+                    >
+                        {item ? (
+                            <PlanCandidateGalleryCard
+                                plan={item}
+                                isActive={index === activeIndex}
+                                onClickFirstItem={() => onClickFirstItem(index)}
+                                onClickLastItem={() => onClickLastItem(index)}
+                            />
+                        ) : (
+                            <PlanCandidateGalleryCardPlaceHolder />
+                        )}
+                    </YStack>
+                )}
+            />
+        </YStack>
+    );
+}

--- a/src/view/plancandidate/PlanCandidatesGallery.tsx
+++ b/src/view/plancandidate/PlanCandidatesGallery.tsx
@@ -1,11 +1,13 @@
-import { Box, Center, Skeleton } from "@chakra-ui/react";
+import { Center } from "@chakra-ui/react";
 import { Splide, SplideSlide } from "@splidejs/react-splide";
 import "@splidejs/splide/css";
 import { useEffect, useRef, useState } from "react";
-import { Size } from "src/constant/size";
 import { Time } from "src/constant/time";
 import { Plan } from "src/domain/models/Plan";
-import { PlanCandidateGalleryCard } from "src/view/plancandidate/PlanCandidatesGalleryCard";
+import {
+    PlanCandidateGalleryCard,
+    PlanCandidateGalleryCardPlaceHolder,
+} from "src/view/plancandidate/PlanCandidatesGalleryCard";
 import { styled } from "styled-components";
 
 export type Props = {
@@ -96,18 +98,7 @@ export function PlanCandidatesGallery({
                         />
                     </SplideSlide>
                 ))}
-                {isCreating && (
-                    <Box
-                        w={Size.PlanCandidatesGallery.Card.w + "px"}
-                        h={Size.PlanCandidatesGallery.Card.h.inactive + "px"}
-                        borderRadius={
-                            Size.PlanCandidatesGallery.Card.borderRadius
-                        }
-                        overflow="hidden"
-                    >
-                        <Skeleton w="100%" h="100%" />
-                    </Box>
-                )}
+                {isCreating && <PlanCandidateGalleryCardPlaceHolder />}
             </SlideContainer>
         </Center>
     );

--- a/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
+++ b/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
@@ -118,16 +118,18 @@ const Card = styled(YStack, {
     width: Size.PlanCandidatesGallery.Card.w,
     borderRadius: Size.PlanCandidatesGallery.Card.borderRadius,
     overflow: "hidden",
-    shadowOffset: { width: 0, height: 0 },
-    shadowColor: "black",
     backgroundColor: "$gray9",
 
     variants: {
         isActive: {
             true: {
                 filter: "none",
-                shadowOpacity: 0.25,
                 height: Size.PlanCandidatesGallery.Card.h.active,
+                shadowOffset: { width: 0, height: 0 },
+                shadowColor: "rgb(132,166,255)",
+                shadowOpacity: 0.4,
+                shadowRadius: 50,
+                elevationAndroid: 20,
             },
             false: {
                 filter: "blur(1px)",

--- a/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
+++ b/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
@@ -151,9 +151,6 @@ function PageIndicator({
             px={Padding.p16}
             w="100%"
             h={4}
-            shadowColor="black"
-            shadowOpacity={0.25}
-            shadowRadius={20}
             columnGap={Padding.p4}
         >
             {createArrayWithSize(total).map((_, i) => {

--- a/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
+++ b/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
@@ -1,11 +1,13 @@
-import { Box, Center, HStack, Text, VStack } from "@chakra-ui/react";
-import "@splidejs/splide/css";
+import { LinearGradient } from "@tamagui/linear-gradient";
 import { useState } from "react";
+import { Padding } from "src/constant/padding";
 import { Size } from "src/constant/size";
 import { Image, getDefaultPlaceImage } from "src/domain/models/Image";
 import { Plan } from "src/domain/models/Plan";
+import { createArrayWithSize } from "src/domain/util/array";
 import { PlaceCategoryIcon } from "src/view/place/PlaceCategoryIcon";
 import { StoryImagePreview } from "src/view/plancandidate/StoryImagePreview";
+import { Text, XStack, YStack, styled } from "tamagui";
 
 type Props = {
     plan: Plan;
@@ -24,30 +26,18 @@ export function PlanCandidateGalleryCard({
 }: Props) {
     const [currentPlaceIndex, setCurrentPlaceIndex] = useState<number>(0);
 
+    // TODO: Not Foundの画像がNativeでも表示されるようにする
     const images: Image[] = plan.places.map((place) =>
         place.images.length > 0 ? place.images[0] : getDefaultPlaceImage()
     );
 
     return (
-        <Center h={Size.PlanCandidatesGallery.Card.h.active + "px"}>
-            <Box
-                transition="all 0.3s ease-in-out"
-                w={Size.PlanCandidatesGallery.Card.w + "px"}
-                h={
-                    isActive
-                        ? Size.PlanCandidatesGallery.Card.h.active + "px"
-                        : Size.PlanCandidatesGallery.Card.h.inactive + "px"
-                }
-                borderRadius={
-                    Size.PlanCandidatesGallery.Card.borderRadius + "px"
-                }
-                overflow="hidden"
-                position="relative"
-                filter={isActive ? "none" : "blur(1px)"}
-                boxShadow={
-                    isActive ? "0px 0px 60px 0px rgba(0, 0, 0, 0.25)" : "none"
-                }
-            >
+        <YStack
+            alignItems="center"
+            justifyContent="center"
+            h={Size.PlanCandidatesGallery.Card.h.active}
+        >
+            <Card animation="quick" isActive={isActive} position="relative">
                 <StoryImagePreview
                     images={images}
                     slideable={isActive}
@@ -55,18 +45,25 @@ export function PlanCandidateGalleryCard({
                     onClickFirstItem={onClickFirstItem}
                     onClickLastItem={onClickLastItem}
                 />
-                <Box
+                <LinearGradient
                     position="absolute"
                     left={0}
                     right={0}
                     bottom={0}
-                    px="16px"
-                    pb="16px"
-                    pt="32px"
-                    background="linear-gradient(180deg, rgba(0, 0, 0, 0.00) 0%, rgba(0, 0, 0, 0.30) 30%, rgba(0, 0, 0, 0.50) 100%)"
+                    px={Padding.p16}
+                    pb={Padding.p16}
+                    pt={Padding.p32}
+                    colors={[
+                        "rgba(0, 0, 0, 0.00)",
+                        "rgba(0, 0, 0, 0.30)",
+                        "rgba(0, 0, 0, 0.50)",
+                    ]}
+                    locations={[0, 0.3, 1]}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 0, y: 1 }}
                 >
-                    <VStack w="100%" alignItems="flex-start">
-                        <HStack>
+                    <YStack w="100%" alignItems="flex-start" gap={Padding.p4}>
+                        <XStack gap={Padding.p8}>
                             <PlaceCategoryIcon
                                 category={
                                     plan.places[currentPlaceIndex].categories
@@ -81,18 +78,94 @@ export function PlanCandidateGalleryCard({
                             <Text color="white">
                                 {plan.places[currentPlaceIndex].name}
                             </Text>
-                        </HStack>
+                        </XStack>
                         <Text
+                            tag="h2"
                             color="white"
                             fontWeight="bold"
-                            fontSize="18px"
-                            as="h2"
+                            fontSize={18}
                         >
                             {plan.title}
                         </Text>
-                    </VStack>
-                </Box>
-            </Box>
-        </Center>
+                    </YStack>
+                </LinearGradient>
+                <XStack position="absolute" top={0} right={0} left={0}>
+                    <PageIndicator
+                        activeIndex={currentPlaceIndex}
+                        total={plan.places.length}
+                    />
+                </XStack>
+            </Card>
+        </YStack>
+    );
+}
+
+export function PlanCandidateGalleryCardPlaceHolder() {
+    return (
+        <XStack
+            w={Size.PlanCandidatesGallery.Card.w}
+            h={Size.PlanCandidatesGallery.Card.h.inactive}
+            borderRadius={Size.PlanCandidatesGallery.Card.borderRadius}
+            backgroundColor="$gray8"
+            overflow="hidden"
+        />
+    );
+}
+
+const Card = styled(YStack, {
+    width: Size.PlanCandidatesGallery.Card.w,
+    borderRadius: Size.PlanCandidatesGallery.Card.borderRadius,
+    overflow: "hidden",
+    shadowOffset: { width: 0, height: 0 },
+    shadowColor: "black",
+    backgroundColor: "$gray9",
+
+    variants: {
+        isActive: {
+            true: {
+                filter: "none",
+                shadowOpacity: 0.25,
+                height: Size.PlanCandidatesGallery.Card.h.active,
+            },
+            false: {
+                filter: "blur(1px)",
+                shadowOpacity: 0,
+                height: Size.PlanCandidatesGallery.Card.h.inactive,
+            },
+        },
+    },
+});
+
+function PageIndicator({
+    activeIndex,
+    total,
+}: {
+    activeIndex: number;
+    total: number;
+}) {
+    return (
+        <XStack
+            py={Padding.p16}
+            px={Padding.p16}
+            w="100%"
+            h={4}
+            shadowColor="black"
+            shadowOpacity={0.25}
+            shadowRadius={20}
+            columnGap={Padding.p4}
+        >
+            {createArrayWithSize(total).map((_, i) => {
+                return (
+                    <XStack
+                        key={i}
+                        flex={1}
+                        h={4}
+                        borderRadius={10}
+                        backgroundColor="white"
+                        opacity={i === activeIndex ? 0.8 : 0.5}
+                    />
+                );
+            })}
+        </XStack>
     );
 }

--- a/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
+++ b/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
@@ -39,7 +39,7 @@ export function PlanCandidateGalleryCard({
             justifyContent="center"
             h={Size.PlanCandidatesGallery.Card.h.active}
         >
-            <Card animation="quick" isActive={isActive} position="relative">
+            <Card animation="quicker" isActive={isActive} position="relative">
                 <StoryImagePreview
                     images={images}
                     slideable={isActive}

--- a/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
+++ b/src/view/plancandidate/PlanCandidatesGalleryCard.tsx
@@ -7,7 +7,7 @@ import { Plan } from "src/domain/models/Plan";
 import { createArrayWithSize } from "src/domain/util/array";
 import { PlaceCategoryIcon } from "src/view/place/PlaceCategoryIcon";
 import { StoryImagePreview } from "src/view/plancandidate/StoryImagePreview";
-import { Text, XStack, YStack, styled } from "tamagui";
+import { Text, XStack, YStack, isWeb, styled } from "tamagui";
 
 type Props = {
     plan: Plan;
@@ -28,7 +28,9 @@ export function PlanCandidateGalleryCard({
 
     // TODO: Not Foundの画像がNativeでも表示されるようにする
     const images: Image[] = plan.places.map((place) =>
-        place.images.length > 0 ? place.images[0] : getDefaultPlaceImage()
+        place.images.length > 0 && place.images[0].default !== ""
+            ? place.images[0]
+            : getDefaultPlaceImage({ isWeb })
     );
 
     return (

--- a/src/view/plancandidate/StoryImagePreview.native.tsx
+++ b/src/view/plancandidate/StoryImagePreview.native.tsx
@@ -1,0 +1,81 @@
+import { useRef, useState } from "react";
+import PagerView from "react-native-pager-view";
+import { Time } from "src/constant/time";
+import { ImageSizes, getImageSizeOf } from "src/domain/models/Image";
+import { StoryImagePreviewProps } from "src/types/props";
+import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
+import { StoryImagePreviewTapPagerOverlay } from "src/view/plancandidate/StoryImagePreviewTapPagerOverlay";
+import { XStack } from "tamagui";
+
+export function StoryImagePreview({
+    images,
+    imageSize = ImageSizes.Large,
+    tapControl = true,
+    slideable = true,
+    onActiveIndexChange,
+    onClickFirstItem,
+    onClickLastItem,
+}: StoryImagePreviewProps) {
+    const pagerViewRef = useRef<PagerView>(null);
+    const [currentPage, setCurrentPage] = useState<number>(0);
+
+    const handleOnPageSelected = (e: { position: number }) => {
+        onActiveIndexChange?.(e.position);
+        setCurrentPage(e.position);
+    };
+
+    const onClickNext = () => {
+        if (!pagerViewRef.current || !slideable) return;
+
+        const isLastPage = currentPage === images.length - 1;
+        if (isLastPage && onClickLastItem) {
+            onClickLastItem();
+            setTimeout(() => {
+                pagerViewRef.current.setPage(0);
+            }, Time.PlanCandidateGallery.lastItemTransitionDelay);
+        } else {
+            pagerViewRef.current.setPage(currentPage + 1);
+        }
+    };
+
+    const onClickPrev = () => {
+        if (!pagerViewRef.current || !slideable) return;
+
+        const isFirstPage = currentPage === 0;
+        if (isFirstPage && onClickFirstItem) {
+            onClickFirstItem();
+        } else {
+            pagerViewRef.current.setPage(currentPage - 1);
+        }
+    };
+
+    return (
+        <XStack w="100%" h="100%" position="relative" overflow="hidden">
+            <PagerView
+                ref={pagerViewRef}
+                useNext
+                initialPage={currentPage}
+                onPageSelected={(e) =>
+                    handleOnPageSelected({ position: e.nativeEvent.position })
+                }
+                style={{ flex: 1 }}
+            >
+                {images.map((image, i) => (
+                    <ImageWithSkeleton
+                        key={i}
+                        isGoogleImage={image.isGoogleImage}
+                        attributionToBottom={false}
+                        attributionPaddingY="48px"
+                        src={getImageSizeOf(imageSize, image)}
+                    />
+                ))}
+            </PagerView>
+            {tapControl && (
+                <StoryImagePreviewTapPagerOverlay
+                    onClickNext={onClickNext}
+                    onClickPrev={onClickPrev}
+                />
+            )}
+        </XStack>
+    );
+}

--- a/src/view/plancandidate/StoryImagePreview.tsx
+++ b/src/view/plancandidate/StoryImagePreview.tsx
@@ -1,26 +1,13 @@
-import { Box, HStack } from "@chakra-ui/react";
+import { Box } from "@chakra-ui/react";
 import { Splide, SplideSlide } from "@splidejs/react-splide";
 import "@splidejs/splide/css";
 import { useEffect, useRef } from "react";
 import { Time } from "src/constant/time";
-import {
-    ImageSize,
-    ImageSizes,
-    Image as ImageType,
-    getImageSizeOf,
-} from "src/domain/models/Image";
+import { ImageSizes, getImageSizeOf } from "src/domain/models/Image";
+import { StoryImagePreviewProps } from "src/types/props";
 import { ImageWithSkeleton } from "src/view/common/ImageWithSkeleton";
+import { StoryImagePreviewTapPagerOverlay } from "src/view/plancandidate/StoryImagePreviewTapPagerOverlay";
 import { styled } from "styled-components";
-
-type Props = {
-    images: ImageType[];
-    imageSize?: ImageSize;
-    tapControl?: boolean;
-    slideable?: boolean;
-    onActiveIndexChange?: (index: number) => void;
-    onClickLastItem?: () => void;
-    onClickFirstItem?: () => void;
-};
 
 export function StoryImagePreview({
     images,
@@ -30,7 +17,7 @@ export function StoryImagePreview({
     onActiveIndexChange,
     onClickFirstItem,
     onClickLastItem,
-}: Props) {
+}: StoryImagePreviewProps) {
     const refSplide = useRef<Splide | null>(null);
 
     useEffect(() => {
@@ -101,16 +88,10 @@ export function StoryImagePreview({
                 ))}
             </SlideContainer>
             {tapControl && (
-                <HStack
-                    position="absolute"
-                    top={0}
-                    right={0}
-                    bottom={0}
-                    left={0}
-                >
-                    <Box w="100%" h="100%" onClick={onClickPrev} />
-                    <Box w="100%" h="100%" onClick={onClickNext} />
-                </HStack>
+                <StoryImagePreviewTapPagerOverlay
+                    onClickNext={onClickNext}
+                    onClickPrev={onClickPrev}
+                />
             )}
         </Box>
     );

--- a/src/view/plancandidate/StoryImagePreview.tsx
+++ b/src/view/plancandidate/StoryImagePreview.tsx
@@ -118,22 +118,6 @@ const SlideContainer = styled(Splide)`
     }
 
     & > .splide__pagination {
-        top: 0.5em;
-        bottom: initial !important;
-        // :not(is-overflow) となっても表示されるようにする
-        display: flex !important;
-    }
-
-    & > .splide__pagination > li {
-        flex: 1;
-        padding: 0 1px;
-    }
-
-    & > .splide__pagination > li > .splide__pagination__page {
-        width: 100%;
-        height: 4px;
-        border-radius: 10px;
-        transform: scale(1);
-        box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.25);
+        visibility: hidden;
     }
 `;

--- a/src/view/plancandidate/StoryImagePreviewTapPagerOverlay.tsx
+++ b/src/view/plancandidate/StoryImagePreviewTapPagerOverlay.tsx
@@ -1,0 +1,16 @@
+import { XStack } from "tamagui";
+
+export function StoryImagePreviewTapPagerOverlay({
+    onClickPrev,
+    onClickNext,
+}: {
+    onClickPrev?: () => void;
+    onClickNext?: () => void;
+}) {
+    return (
+        <XStack position="absolute" top={0} right={0} bottom={0} left={0}>
+            <XStack flex={1} h="100%" onPress={onClickPrev} />
+            <XStack flex={1} h="100%" onPress={onClickNext} />
+        </XStack>
+    );
+}


### PR DESCRIPTION
### 修正の概要
<!--　
    XXの機能を作成した
    UIの修正であればスクリーンショットがあるとわかりやすい
-->
- カテゴリからプランを作成し、作成されたプラン候補一覧を表示する機能をNative対応した

|before| after |
|---|-------|
||![image](https://github.com/user-attachments/assets/b06cd0c5-3659-4486-ae2d-bb3dccf03849)|
|![image](https://github.com/user-attachments/assets/319ec6c9-78be-4d4c-a67c-df487f181828)|![image](https://github.com/user-attachments/assets/7781be96-d1b9-41fd-9a0c-1876b5ad2170)|


### 関連する Issue・PR
```
【マージ条件】関連する項目がすべてCloseされている
```
<!--
- close #0
- #0
-->

### 変更の種類
- [ ] バグの修正 (破壊的でない変更)
- [x] 新しい機能の追加
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)
- [ ] ドキュメントの追加・修正

### 修正の目的・解決したこと
<!--　YYの操作を行いやすくするため -->

### どのようにテストされているか
<!--　単体テストを作成した -->
※ Natveはカテゴリからプランを作成することができる

- [x] プランが表示されていることを確認
- [x] プランが作成できることを確認
- [x] プランが保存できることを確認(web)
- [x] スワイプで要素を切り替えられることを確認
- [x] カードの右側タップで次の画像が表示されることを確認
- [x] 最後の写真になったとき、カードの右側をタップすると次の項目に移動することを確認
- [x] 最後の項目の最後の写真になったとき、カードの右側をタップすると最初の項目に移動することを確認
- [x] カードの左側タップで前の画像が表示されることを確認
- [x] 最初の写真のときに、カードの左側をタップすると前の項目に移動することを確認
- [x] 最初の項目の最初の写真のときに、カードの左側をタップすると最後の項目に移動することを確認

```shell
# poroto
export BRANCH_POROTO=
git fetch origin $BRANCH_POROTO
git checkout $BRANCH_POROTO
git pull origin $BRANCH_POROTO
yarn install
yarn dev
```
```shell
# planner
export BRANCH_PLANNER=develop
git branch -D $BRANCH_PLANNER
git fetch origin $BRANCH_PLANNER
git checkout $BRANCH_PLANNER
go run cmd/server/main.go
````